### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/glennib/stakk/compare/v0.1.1...v0.2.0) - 2026-02-20
+
+### Added
+
+- [**breaking**] default command is now interactive submit instead of show
+- default command is now interactive submit instead of show
+- confirm before submitting when a single bookmark is auto-selected
+- two-stage inquire-based interactive bookmark selection
+- add `stakk show` subcommand
+
+### Other
+
+- research report and roadmap for interactive selector viewport
+- interactive bookmark selection for `stakk submit`
+- add features to readme
+- *(deps)* update rust crate clap to v4.5.60
+- Add renovate.json
+
 ## [0.1.1](https://github.com/glennib/stakk/compare/v0.1.0...v0.1.1) - 2026-02-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/glennib/stakk/compare/v0.1.1...v0.2.0) - 2026-02-20

### Added

- [**breaking**] default command is now interactive submit instead of show
- default command is now interactive submit instead of show
- confirm before submitting when a single bookmark is auto-selected
- two-stage inquire-based interactive bookmark selection
- add `stakk show` subcommand

### Other

- research report and roadmap for interactive selector viewport
- interactive bookmark selection for `stakk submit`
- add features to readme
- *(deps)* update rust crate clap to v4.5.60
- Add renovate.json
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).