### PR TITLE
feat: two-stage inquire-based interactive bookmark selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,10 @@ for milestones.
   title for single-PR stacks), stage 2 picks a bookmark within that stack
   (leaf-first, with position labels, commit summaries listed per bookmark, and
   `→ N PRs` indicating how many PRs each selection generates). Stages are
-  skipped when only one option exists. Auto-selects when only one bookmark
-  exists (showing commit title). `--dry-run` prints a prominent header.
-  `stakk show` subcommand extracted (default when no subcommand given).
-  98 total tests.
+  skipped when only one option exists. Single-bookmark case shows
+  `inquire::Confirm` prompt instead of auto-submitting. `--dry-run` prints a
+  prominent header. `stakk show` subcommand available. Default command (no
+  subcommand) is interactive submit. 97 total tests.
 
 ## Testing
 
@@ -172,6 +172,7 @@ There is intentionally no `git/` module.
 - Run `mise run fmt:nightly` (or `cargo +nightly fmt --all`) for full
   formatting locally. CI uses stable `fmt:check` which silently ignores
   nightly-only options.
+- **Always run `cargo +nightly fmt --all` before committing.**
 - If `mise` tools are missing from PATH after installation, run
   `mise install` to refresh.
 
@@ -386,3 +387,9 @@ rationale.)
 - **2026-02-20**: `inquire` with `default-features = false, features = ["console"]`
   — reuses stakk's existing `console = "0.16"` dependency (shared with
   `indicatif`). Avoids pulling in `crossterm` backend.
+- **2026-02-20**: Single-bookmark case uses `inquire::Confirm` instead of
+  auto-submitting — prevents accidental submission when running `stakk`
+  with no arguments.
+- **2026-02-20**: Default command changed from `show` to `submit` — running
+  `stakk` without a subcommand now launches interactive submit. `stakk show`
+  remains available as an explicit subcommand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,16 @@ for milestones.
 - **Sidequest (Replace anyhow)**: Complete — `SubmitError` enum with
   `Diagnostic` derives, `StakkError` aggregates all error types, `main()`
   uses `miette::Report` for rendering, zero `anyhow` usage.
+- **Interactive bookmark selection**: Complete — `stakk submit` without a
+  bookmark argument shows an interactive graph selector using `console` crate.
+  Visual graph with `○`/`│` characters, color-coded ancestors (red) and
+  focused bookmark (green/bold), keyboard navigation (arrows/jk, Enter, Esc).
+  Auto-selects when only one bookmark exists. `stakk show` subcommand
+  extracted (default when no subcommand given). 91 total tests.
 
 ## Testing
 
-- **Unit/integration tests**: `cargo nextest run --all-targets` (85 tests).
+- **Unit/integration tests**: `cargo nextest run --all-targets` (91 tests).
 - **Manual testing repo**: `../jack-testing/` (github.com/glennib/jack-testing).
   A jj repo with pre-built bookmark stacks for end-to-end verification.
   Run stakk from within that directory to test against real jj output.
@@ -119,6 +125,7 @@ src/
 │   ├── github.rs    # GitHubForge implementation
 │   └── comment.rs   # Stack comment formatting and parsing
 ├── graph/           # Change graph construction (ChangeGraph, BookmarkSegment, BranchStack)
+├── select.rs        # Interactive bookmark selection (graph renderer, keyboard nav)
 ├── submit/          # Three-phase submission (analyze → plan → execute)
 └── error.rs         # Error types (thiserror)
 ```
@@ -136,11 +143,10 @@ There is intentionally no `git/` module.
 | `base64` | Stack comment metadata encoding |
 | `http` | HTTP status codes for error mapping |
 | `thiserror` | Error type definitions |
-| `miette` | User-facing error diagnostics |
-| `inquire` | Interactive bookmark selection (later milestone) |
+| `miette` | User-facing error diagnostics (`Diagnostic` derives) |
+| `console` | Terminal I/O for interactive bookmark selection |
 | `futures` | Concurrent async operations (`join_all`) |
 | `indicatif` | Progress bars/spinners |
-| `miette` | User-facing error diagnostics (`Diagnostic` derives) |
 
 ## Conventions
 
@@ -282,6 +288,15 @@ made during implementation here.)
 - `SubmitError` uses `#[source]` on `ForgeError`/`JjError` fields — miette
   automatically treats `#[source]` fields that implement `Diagnostic` as
   diagnostic sources, walking the chain to render help from inner errors.
+- `console` crate for inline interactive TUI — `Term::read_key()` for arrow
+  keys/Enter/Esc, `Term::clear_last_lines()` for re-rendering,
+  `console::style()` for colors, `Term::is_term()` for TTY detection. No need
+  for inquire or crossterm for simple selectors.
+- Use `Term::stderr()` for interactive UI so it doesn't interfere with stdout
+  if piped. `Term::write_str()` takes `&self` (unlike `io::Write::write_all`
+  which needs `&mut self`).
+- `CursorGuard` scope guard pattern ensures `show_cursor()` is always called
+  even on error or panic during interactive selection.
 
 ## Decisions Log
 
@@ -349,3 +364,15 @@ rationale.)
   available. All references updated: crate name, binary name, error types
   (`JackError` → `StakkError`), comment metadata prefix (`JACK_STACK` →
   `STAKK_STACK`), documentation, and user-facing strings.
+- **2026-02-20**: `stakk show` extracted as subcommand — `Show` variant in
+  `Commands`, default when no subcommand given (`Some(Commands::Show) | None`).
+  Makes room for swapping the default to interactive submit later.
+- **2026-02-20**: `console` over `inquire` for interactive bookmark selection
+  — `console` is already a transitive dependency via `indicatif`, provides
+  exactly what's needed (key reading, cursor control, styling), and gives full
+  control over the graph-based rendering. No new transitive dependencies.
+- **2026-02-20**: Bookmark argument optional on `stakk submit` — `Option<String>`
+  in `SubmitArgs`. When `None`, interactive selection is triggered after
+  spinner finishes (graph is already built). Spinner is split: first spinner
+  covers auth/remote/graph, cleared before interactive prompt, second spinner
+  covers submission phases.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,6 +1801,7 @@ version = "0.1.1"
 dependencies = [
  "base64",
  "clap",
+ "console",
  "futures",
  "http",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -423,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,7 +506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -935,6 +941,19 @@ dependencies = [
  "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "inquire"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979f5ab9760427ada4fa5762b2d905e5b12704fb1fada07b6bfa66aeaa586f87"
+dependencies = [
+ "bitflags",
+ "console",
+ "dyn-clone",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1488,7 +1507,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1805,6 +1824,7 @@ dependencies = [
  "futures",
  "http",
  "indicatif",
+ "inquire",
  "miette",
  "octocrab",
  "serde",
@@ -2108,6 +2128,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 base64 = "0.22.1"
 clap = { version = "4", features = ["derive"] }
+console = "0.16"
 futures = "0.3"
 http = "1.4.0"
 indicatif = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ base64 = "0.22.1"
 clap = { version = "4", features = ["derive"] }
 console = "0.16"
 futures = "0.3"
+inquire = { version = "0.9", default-features = false, features = ["console"] }
 http = "1.4.0"
 indicatif = "0.18"
 miette = { version = "7", features = ["fancy"] }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ idempotent updates.
   updated, never duplicated.
 - **Dry-run mode** — `--dry-run` shows exactly what would happen without
   touching GitHub.
+- **Interactive selection** — running `stakk submit` without a bookmark
+  argument shows an interactive two-stage prompt: pick a stack, then pick
+  how far up the stack to submit. Shared ancestors are annotated, and each
+  option shows the resulting PR count.
 - **Draft PRs** — `--draft` creates new PRs as drafts.
 - **PR body from descriptions** — PR titles and bodies are populated from jj
   change descriptions. Manually edited PR bodies are never overwritten.
@@ -74,7 +78,10 @@ Download from the [latest release](https://github.com/glennib/stakk/releases/lat
 # See your bookmark stacks
 stakk
 
-# Submit a bookmark (and its ancestors) as stacked PRs
+# Submit interactively — pick a stack and bookmark from a menu
+stakk submit
+
+# Submit a specific bookmark (and its ancestors) as stacked PRs
 stakk submit my-feature
 
 # Preview what would happen without doing anything
@@ -145,9 +152,29 @@ Stacks (2 found):
     fix-typo (1 commit(s)): fix typo in README
 ```
 
-### `stakk submit <bookmark>`
+### `stakk submit [bookmark]`
 
 Submit a bookmark and all its ancestors as stacked PRs.
+
+When run without a bookmark argument, an interactive two-stage prompt lets
+you pick a stack and then choose how far up the stack to submit:
+
+```
+? Which stack?
+> ○ ← base ← feat-b ← feat-c  (3 PRs)
+  ○ ← standalone  (1 PR: fix login bug)
+
+? Submit up to which bookmark?
+> feat-c (leaf, 1 commit) → 3 PRs
+      add caching layer
+  feat-b (2 commits) → 2 PRs
+      refactor auth module
+  base (base, 1 commit) → 1 PR
+      add user model
+```
+
+Stages are skipped automatically when there's only one option (e.g., a
+single stack skips stage 1, a single bookmark auto-selects immediately).
 
 | Flag | Description |
 |------|-------------|

--- a/RESEARCH-interactive-selector.md
+++ b/RESEARCH-interactive-selector.md
@@ -1,0 +1,328 @@
+# Research: Interactive Selector Viewport & Graph Rendering
+
+> **Date**: 2026-02-20
+> **Context**: `stakk submit` (no args) shows an interactive bookmark picker,
+> but the current implementation renders the entire graph at once. When there
+> are many stacks/bookmarks, the output exceeds terminal height and scrolls
+> past the top. This document summarizes research into three approaches for
+> fixing this, plus analysis of how jj-stack solves it.
+
+---
+
+## Current Implementation (`src/select.rs`)
+
+- `render_graph()` writes ALL lines to the terminal at once
+- `clear_last_lines(line_count)` clears and re-renders on each keystroke
+- No terminal height awareness (no `Term::size()` call)
+- Linear display per stack (no branching/merging visualization)
+- Already has: `○`/`│` characters, green focused, red ancestors, dim commits
+- Uses `console` crate (already a direct dependency)
+
+---
+
+## How jj-stack Solves This
+
+Source: `../jj-stack/src/cli/AnalyzeCommand.res` and
+`AnalyzeCommandComponent.res`
+
+### Architecture
+
+jj-stack uses **Ink** (React for terminals) with ReScript. The rendering is
+split into two phases:
+
+1. **Pre-render** (`AnalyzeCommand.res:51-166`): Builds the full graph into
+   an array of `outputRow` objects. Each row has a `chars` array (the column
+   art) and an optional `changeId` (for selectable rows).
+
+2. **Interactive display** (`AnalyzeCommandComponent.res`): Takes the
+   pre-rendered rows and handles viewport windowing, keyboard navigation,
+   and ancestor highlighting.
+
+### Column-Based Graph Layout
+
+jj-stack uses a column tracking system for branching visualization:
+
+```
+columns = []  // tracks which changeId occupies each column
+
+for each change in topological order (leaf-to-root):
+    find column for this change (or allocate new one)
+    render "○" in that column, "│" in other active columns
+    look up parent in adjacency list
+    if parent already in a different column:
+        draw merge line "─╯", remove current column
+    else:
+        replace current column with parent
+```
+
+Characters used: `" ○"` (node), `" │"` (continuation), `" ├"` (branch),
+`"─╯"` (merge converging), `"─│"` (horizontal crossing vertical).
+
+### Viewport Windowing
+
+From `AnalyzeCommandComponent.res:39-92`:
+
+```
+terminal_height = stdout.rows
+viewport_height = terminal_height - 3  // reserve header + footer + buffer
+
+scroll_offset calculation:
+  if total_items <= viewport_height: offset = 0 (everything fits)
+  if focused < current_offset: offset = focused (scroll up)
+  if focused >= current_offset + viewport_height: scroll down to show it
+  else: keep current offset (no unnecessary jumping)
+
+// Special case: when last item selected, always show trunk()
+```
+
+Only the visible slice `output[scroll_offset..scroll_offset+viewport_height]`
+is rendered.
+
+### Ancestor Highlighting
+
+Walks the `bookmarkedChangeAdjacencyList` (child→parent map) starting from
+the selected change, collecting all ancestors into a `Set<string>`. Any row
+whose `changeId` is in the ancestor set renders in red.
+
+### Navigation
+
+Only rows with a `changeId` (bookmark rows) are selectable. Navigation
+skips connector lines automatically using a pre-computed
+`selectable_indices` array.
+
+---
+
+## Option A: Console + Viewport Windowing
+
+Enhance the current `console`-based implementation with viewport logic.
+No new dependencies.
+
+### What Changes
+
+**Pre-render phase** — new `build_graph_lines()` function produces a
+`Vec<GraphLine>` separating data from rendering:
+
+```rust
+struct GraphLine {
+    text: String,                   // unstyled text content
+    bookmark_index: Option<usize>,  // Some(i) if selectable
+    line_type: LineType,            // Bookmark, Commit, Connector, Separator, Trunk
+}
+```
+
+**Viewport rendering** — new `render_viewport()` replaces `render_graph()`:
+
+1. Get terminal height via `Term::size()` (returns `(cols, rows)`)
+2. Reserve 2 lines for header/footer
+3. Only render `lines[scroll_offset..scroll_offset+viewport_height]`
+4. Show `▲ N more` / `▼ N more` indicators when content overflows
+5. Apply styling (green/red/dim) at render time based on focused bookmark
+
+**Scroll logic** — `calculate_scroll_offset()` as a pure function:
+
+- Everything fits → offset 0
+- Focused above viewport → scroll up
+- Focused below viewport → scroll down
+- Otherwise → keep current offset
+
+**Navigation** — use pre-computed `selectable_indices: Vec<usize>` (line
+indices where `bookmark_index.is_some()`). Arrow keys jump between
+selectable lines.
+
+### Optional Enhancement: DAG Graph Rendering
+
+The `ChangeGraph` already has the data needed for jj-stack-style branching:
+
+- `adjacency_list: HashMap<String, String>` — child→parent relationships
+- `segments: HashMap<String, BookmarkSegment>` — per-change segment data
+- `stack_leaves: HashSet<String>` — leaf nodes for topological sort start
+- `stack_roots: HashSet<String>` — root nodes
+
+A column-based layout algorithm (adapted from jj-stack) could replace the
+current linear per-stack rendering. This would show stacks that share
+ancestors merging visually, matching jj-stack's output.
+
+### Console Crate Capabilities
+
+Relevant APIs (all on `Term`, all take `&self`):
+
+| Method | Purpose |
+|--------|---------|
+| `size() -> (u16, u16)` | Terminal dimensions (cols, rows) |
+| `read_key() -> Result<Key>` | Read single keypress |
+| `write_str(&str) -> Result<()>` | Write string (no `&mut self`) |
+| `clear_last_lines(n) -> Result<()>` | Clear n preceding lines |
+| `hide_cursor() / show_cursor()` | Cursor visibility |
+| `is_term() -> bool` | TTY detection |
+
+No alternate screen, no scroll regions. Viewport must be managed manually.
+
+### Assessment
+
+| Aspect | Rating |
+|--------|--------|
+| Dependency cost | None (console already a dep) |
+| Implementation effort | Medium (~200-300 lines for viewport, ~200 more for DAG) |
+| Viewport quality | Good (manual but follows proven jj-stack pattern) |
+| Graph rendering | Excellent if DAG layout is added |
+| Resize handling | Manual (re-query `Term::size()` on each render) |
+
+---
+
+## Option B: Ratatui Inline Viewport
+
+Replace the custom renderer with ratatui's `Viewport::Inline(height)`.
+
+### How It Works
+
+Ratatui provides three viewport modes:
+
+- **Fullscreen** — alternate screen buffer, replaces terminal view entirely
+- **Inline(height)** — allocates a fixed rectangular area inline with normal
+  terminal output, preserving scrollback history
+- **Fixed** — render to a specific terminal area
+
+`Viewport::Inline` is the best fit: it keeps the CLI feel (no alternate
+screen takeover) while providing a proper rendering surface.
+
+```rust
+let terminal = ratatui::init_with_options(TerminalOptions {
+    viewport: Viewport::Inline(height),
+});
+```
+
+### List Widget
+
+Ratatui has a built-in `List` + `ListState` that handles scrolling
+automatically:
+
+- `select_next()` / `select_previous()` — navigate items
+- Automatic viewport scrolling to keep selection visible
+- No manual scroll offset management needed
+- Supports custom styling per item
+
+### Backend
+
+Ratatui uses **crossterm** as its default backend. Crossterm handles raw
+mode, key events, and terminal manipulation.
+
+**Conflict note**: crossterm and `console` both manipulate terminal state.
+Using both simultaneously could cause issues (competing raw mode, event
+queues). If ratatui is adopted, the `console` dependency might need to be
+removed or isolated.
+
+### Dependency Weight
+
+Ratatui and crossterm are **not** currently in stakk's dependency tree.
+Adding them brings:
+
+- `ratatui` (modular since 0.30+, backends are feature-gated)
+- `crossterm` (default backend)
+- Various transitive deps
+
+### Known Issues
+
+- Inline viewport resizing has edge cases (ratatui issues #984, #2086)
+- Must handle `Event::Resize` and redraw
+- Some backends have rendering artifacts with inline viewports
+
+### Assessment
+
+| Aspect | Rating |
+|--------|--------|
+| Dependency cost | High (ratatui + crossterm, new dep tree) |
+| Implementation effort | Medium (rewrite select.rs, ~250 lines) |
+| Viewport quality | Excellent (built-in scrolling, resize events) |
+| Graph rendering | Custom widget needed (same effort as Option A) |
+| Resize handling | Built-in event system |
+
+---
+
+## Option C: Inquire Two-Step Selection
+
+Replace the custom graph renderer with `inquire::Select` prompts.
+
+### How It Works
+
+Two sequential prompts:
+
+1. **Stack selection** — compact single-line representation of each stack:
+   ```
+   ? Which stack to submit?
+   > feat-a -> feat-b -> feat-c (3 bookmarks)
+     standalone-fix (1 bookmark)
+     user-api -> user-model (2 bookmarks)
+   ```
+
+2. **Bookmark selection** (if stack has multiple bookmarks):
+   ```
+   ? Submit up to which bookmark in this stack?
+   > feat-c (leaf)
+     feat-b
+     feat-a (closest to trunk)
+   ```
+
+### Features for Free
+
+- **Auto-viewport**: Paginated with configurable page size (default 7)
+- **Type-to-filter**: Fuzzy search enabled by default (SkimV2 algorithm)
+- **Circular navigation**: Wraps around at list boundaries
+- **Styling**: `RenderConfig` for colors and tokens (global, not per-item)
+
+### Dependency
+
+```toml
+inquire = { version = "0.7", default-features = false, features = ["console"] }
+```
+
+The `console` backend feature reuses our existing `console` dependency,
+avoiding crossterm. Net new transitive dep: `fuzzy_matcher` only.
+
+### Limitations
+
+- **Single-line items only** — no multi-line graph art per item
+- **No graph visualization** — loses the `○`/`│` tree structure
+- **Two-step friction** — extra prompt for the common single-stack case
+  (could auto-skip step 1 when there's only one stack)
+- **Per-item coloring not supported** — `RenderConfig` applies globally
+
+### Assessment
+
+| Aspect | Rating |
+|--------|--------|
+| Dependency cost | Low (inquire with console backend, ~1 new transitive dep) |
+| Implementation effort | Low (~50-80 lines total) |
+| Viewport quality | Excellent (built-in pagination) |
+| Graph rendering | None (text-only compact representation) |
+| Resize handling | Handled by inquire |
+
+---
+
+## Comparison Summary
+
+| | Option A: Console | Option B: Ratatui | Option C: Inquire |
+|---|---|---|---|
+| **New deps** | None | ratatui + crossterm | inquire (console backend) |
+| **Viewport** | Manual (proven pattern) | Built-in | Built-in |
+| **Graph art** | Yes (current + DAG possible) | Yes (custom widget) | No |
+| **jj-stack parity** | Closest match | Close (different rendering) | Different UX |
+| **Code complexity** | ~400-500 lines | ~250 lines | ~50-80 lines |
+| **Type-to-filter** | No | No (without extra work) | Yes (free) |
+| **Risk** | Low (no new deps) | Medium (dep conflicts) | Low |
+
+---
+
+## Recommendation
+
+**Option A** for the graph rendering and viewport — it matches jj-stack's
+proven approach, adds no dependencies, and gives full control. The
+implementation splits naturally into two parts:
+
+1. **Viewport windowing** (immediate fix) — add `Term::size()`, scroll
+   offset tracking, visible-window rendering. Fixes the scrolling bug.
+2. **DAG graph layout** (follow-up) — column-based rendering adapted from
+   jj-stack. Visual enhancement showing true branching structure.
+
+Option C (inquire) remains a viable fallback or complement — it could be
+used for a `--simple` flag or as the non-TTY fallback's error message
+suggestion.

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -19,3 +19,14 @@ pub struct SubmitArgs {
     #[arg(long, default_value = "origin")]
     pub remote: String,
 }
+
+impl Default for SubmitArgs {
+    fn default() -> Self {
+        Self {
+            bookmark: None,
+            dry_run: false,
+            draft: false,
+            remote: "origin".to_string(),
+        }
+    }
+}

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -3,8 +3,9 @@ use clap::Args;
 /// Arguments for the `submit` subcommand.
 #[derive(Debug, Args)]
 pub struct SubmitArgs {
-    /// The bookmark to submit as a pull request.
-    pub bookmark: String,
+    /// The bookmark to submit as a pull request. If omitted, shows an
+    /// interactive selection.
+    pub bookmark: Option<String>,
 
     /// Show what would be done without actually doing it.
     #[arg(long)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,4 +45,17 @@ pub enum StakkError {
     #[error("no GitHub remote found")]
     #[diagnostic(help("Make sure this repository has a GitHub remote configured"))]
     NoGithubRemote,
+
+    /// A terminal I/O error.
+    #[error("terminal I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Interactive selection required but stdin is not a terminal.
+    #[error("interactive mode requires a terminal")]
+    #[diagnostic(help("Pass the bookmark name explicitly: stakk submit <BOOKMARK>"))]
+    NotInteractive,
+
+    /// User cancelled the interactive prompt.
+    #[error("interactive selection cancelled")]
+    PromptCancelled,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,11 @@ async fn run() -> Result<(), StakkError> {
                 auth_setup();
             }
         },
-        Some(Commands::Show) | None => {
+        Some(Commands::Show) => {
             show_status().await?;
+        }
+        None => {
+            submit_bookmark(&SubmitArgs::default()).await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,9 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
     pb.finish_and_clear();
 
     // Print the plan.
+    if args.dry_run {
+        println!("DRY RUN — no changes will be made.\n");
+    }
     println!("{plan}");
 
     if args.dry_run {

--- a/src/select.rs
+++ b/src/select.rs
@@ -10,7 +10,8 @@ use std::io;
 use inquire::InquireError;
 
 use crate::error::StakkError;
-use crate::graph::types::{BranchStack, ChangeGraph};
+use crate::graph::types::BranchStack;
+use crate::graph::types::ChangeGraph;
 
 /// Stage 1 item: a stack shown as a single line.
 #[derive(Debug, Clone)]
@@ -142,8 +143,7 @@ pub fn collect_stack_choices(graph: &ChangeGraph) -> Vec<StackChoice> {
                 })
                 .collect();
 
-            let commit_count: usize =
-                stack.segments.iter().map(|s| s.commits.len()).sum();
+            let commit_count: usize = stack.segments.iter().map(|s| s.commits.len()).sum();
 
             // Detect shared segments.
             let mut shared_with: Vec<(String, Vec<String>)> = Vec::new();
@@ -236,8 +236,9 @@ pub fn collect_bookmark_choices(stack: &BranchStack) -> Vec<BookmarkChoice> {
 fn map_inquire_error(err: InquireError) -> StakkError {
     match err {
         InquireError::NotTTY => StakkError::NotInteractive,
-        InquireError::OperationCanceled
-        | InquireError::OperationInterrupted => StakkError::PromptCancelled,
+        InquireError::OperationCanceled | InquireError::OperationInterrupted => {
+            StakkError::PromptCancelled
+        }
         InquireError::IO(e) => StakkError::Io(e),
         other => StakkError::Io(io::Error::other(other.to_string())),
     }
@@ -245,25 +246,18 @@ fn map_inquire_error(err: InquireError) -> StakkError {
 
 /// Show inquire stack selector, returning the chosen stack index.
 fn select_stack(choices: Vec<StackChoice>) -> Result<usize, StakkError> {
-    let result = inquire::Select::new("Which stack?", choices)
+    let result = inquire::Select::new("Which stack would you like to submit?", choices)
         .prompt()
         .map_err(map_inquire_error)?;
     Ok(result.stack_index)
 }
 
 /// Show inquire bookmark selector, returning the chosen bookmark name.
-fn select_bookmark_in_stack(
-    choices: Vec<BookmarkChoice>,
-) -> Result<String, StakkError> {
-    let result = inquire::Select::new(
-        "Submit up to which bookmark?",
-        choices,
-    )
-    .with_help_message(
-        "All bookmarks from base up to your selection will be submitted",
-    )
-    .prompt()
-    .map_err(map_inquire_error)?;
+fn select_bookmark_in_stack(choices: Vec<BookmarkChoice>) -> Result<String, StakkError> {
+    let result = inquire::Select::new("Submit up to which bookmark?", choices)
+        .with_help_message("All bookmarks from base up to your selection will be submitted")
+        .prompt()
+        .map_err(map_inquire_error)?;
     Ok(result.bookmark_name)
 }
 
@@ -277,17 +271,14 @@ fn select_bookmark_in_stack(
 ///
 /// Returns `StakkError::NotInteractive` if stdin is not a terminal.
 /// Returns `StakkError::PromptCancelled` if the user presses Escape.
-pub fn resolve_bookmark_interactively(
-    graph: &ChangeGraph,
-) -> Result<Option<String>, StakkError> {
+pub fn resolve_bookmark_interactively(graph: &ChangeGraph) -> Result<Option<String>, StakkError> {
     if graph.stacks.is_empty() {
         eprintln!("No bookmark stacks found.");
         return Ok(None);
     }
 
     // Count total bookmarks across all stacks.
-    let total_bookmarks: usize =
-        graph.stacks.iter().map(|s| s.segments.len()).sum();
+    let total_bookmarks: usize = graph.stacks.iter().map(|s| s.segments.len()).sum();
 
     if total_bookmarks == 1 {
         let segment = &graph.stacks[0].segments[0];
@@ -303,8 +294,14 @@ pub fn resolve_bookmark_interactively(
             .map(|l| l.trim())
             .filter(|l| !l.is_empty())
             .unwrap_or("(no description)");
-        eprintln!("Auto-selecting the only bookmark: {name} ({summary})");
-        return Ok(Some(name));
+        let confirmed = inquire::Confirm::new(&format!("Submit {name}? ({summary})",))
+            .with_default(true)
+            .prompt()
+            .map_err(map_inquire_error)?;
+        if confirmed {
+            return Ok(Some(name));
+        }
+        return Ok(None);
     }
 
     // Determine which stack to use.
@@ -341,11 +338,14 @@ pub fn resolve_bookmark_interactively(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
     use super::*;
-    use crate::graph::types::{
-        BookmarkSegment, BranchStack, ChangeGraph, SegmentCommit,
-    };
-    use std::collections::{HashMap, HashSet};
+    use crate::graph::types::BookmarkSegment;
+    use crate::graph::types::BranchStack;
+    use crate::graph::types::ChangeGraph;
+    use crate::graph::types::SegmentCommit;
 
     fn make_graph(stacks: Vec<BranchStack>) -> ChangeGraph {
         ChangeGraph {
@@ -359,11 +359,7 @@ mod tests {
         }
     }
 
-    fn make_segment(
-        names: &[&str],
-        change_id: &str,
-        descriptions: &[&str],
-    ) -> BookmarkSegment {
+    fn make_segment(names: &[&str], change_id: &str, descriptions: &[&str]) -> BookmarkSegment {
         BookmarkSegment {
             bookmark_names: names.iter().map(|s| s.to_string()).collect(),
             change_id: change_id.to_string(),
@@ -416,11 +412,7 @@ mod tests {
                 ],
             },
             BranchStack {
-                segments: vec![make_segment(
-                    &["gamma"],
-                    "ch_gamma",
-                    &["gamma"],
-                )],
+                segments: vec![make_segment(&["gamma"], "ch_gamma", &["gamma"])],
             },
         ]);
 
@@ -444,16 +436,8 @@ mod tests {
             },
             BranchStack {
                 segments: vec![
-                    make_segment(
-                        &["base"],
-                        "ch_shared",
-                        &["shared base"],
-                    ),
-                    make_segment(
-                        &["other-leaf"],
-                        "ch_c",
-                        &["other leaf"],
-                    ),
+                    make_segment(&["base"], "ch_shared", &["shared base"]),
+                    make_segment(&["other-leaf"], "ch_c", &["other leaf"]),
                 ],
             },
         ]);
@@ -482,17 +466,15 @@ mod tests {
                 "feat-c".to_string(),
             ],
             commit_count: 5,
-            shared_with: vec![(
-                "base".to_string(),
-                vec!["other-leaf".to_string()],
-            )],
+            shared_with: vec![("base".to_string(), vec!["other-leaf".to_string()])],
             leaf_summary: "add caching".to_string(),
         };
 
         let display = format!("{choice}");
         assert_eq!(
             display,
-            "\u{25cb} \u{2190} base \u{2190} feat-b \u{2190} feat-c  (3 PRs)  [base also in other-leaf]"
+            "\u{25cb} \u{2190} base \u{2190} feat-b \u{2190} feat-c  (3 PRs)  [base also in \
+             other-leaf]"
         );
     }
 
@@ -507,7 +489,10 @@ mod tests {
         };
 
         let display = format!("{choice}");
-        assert_eq!(display, "\u{25cb} \u{2190} standalone  (1 PR: fix login bug)");
+        assert_eq!(
+            display,
+            "\u{25cb} \u{2190} standalone  (1 PR: fix login bug)"
+        );
     }
 
     // -- BookmarkChoice tests --
@@ -515,11 +500,7 @@ mod tests {
     #[test]
     fn bookmark_choices_single_segment() {
         let stack = BranchStack {
-            segments: vec![make_segment(
-                &["only-one"],
-                "ch_a",
-                &["the commit"],
-            )],
+            segments: vec![make_segment(&["only-one"], "ch_a", &["the commit"])],
         };
 
         let choices = collect_bookmark_choices(&stack);
@@ -590,10 +571,7 @@ mod tests {
         };
 
         let choices = collect_bookmark_choices(&stack);
-        assert_eq!(
-            choices[0].commit_summaries,
-            vec!["(no description)"]
-        );
+        assert_eq!(choices[0].commit_summaries, vec!["(no description)"]);
 
         let display = format!("{}", choices[0]);
         assert!(display.contains("(no description)"));
@@ -603,18 +581,11 @@ mod tests {
     fn bookmark_choices_display_shows_commits() {
         let stack = BranchStack {
             segments: vec![
-                make_segment(
-                    &["base"],
-                    "ch_a",
-                    &["add user model"],
-                ),
+                make_segment(&["base"], "ch_a", &["add user model"]),
                 make_segment(
                     &["feat"],
                     "ch_b",
-                    &[
-                        "refactor auth module",
-                        "extract token parser",
-                    ],
+                    &["refactor auth module", "extract token parser"],
                 ),
             ],
         };
@@ -624,7 +595,8 @@ mod tests {
         let feat_display = format!("{}", choices[0]);
         assert_eq!(
             feat_display,
-            "feat (leaf, 2 commits) \u{2192} 2 PRs\n    refactor auth module\n    extract token parser"
+            "feat (leaf, 2 commits) \u{2192} 2 PRs\n    refactor auth module\n    extract token \
+             parser"
         );
 
         let base_display = format!("{}", choices[1]);
@@ -643,17 +615,8 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    #[test]
-    fn resolve_single_bookmark_auto_select() {
-        let graph = make_graph(vec![BranchStack {
-            segments: vec![make_segment(
-                &["only-bm"],
-                "ch_a",
-                &["the commit"],
-            )],
-        }]);
-
-        let result = resolve_bookmark_interactively(&graph).unwrap();
-        assert_eq!(result, Some("only-bm".to_string()));
-    }
+    // Note: the single-bookmark case now shows a confirmation prompt
+    // (inquire::Confirm), which cannot be driven from a unit test
+    // without a TTY. Interactive paths are tested manually via the
+    // jack-testing repo.
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,256 +1,336 @@
-//! Interactive bookmark selection with visual graph context.
+//! Interactive bookmark selection using inquire.
 //!
-//! Renders a graph of bookmark stacks using Unicode box-drawing characters
-//! and lets the user pick a bookmark to submit. Uses the `console` crate
-//! for terminal I/O (cursor control, key reading, styling).
+//! Two-stage selection: pick a stack, then pick a bookmark within that stack.
+//! Uses `inquire::Select` for built-in pagination and type-to-filter.
 
+use std::collections::HashMap;
+use std::fmt;
 use std::io;
 
-use console::Key;
-use console::Term;
-use console::style;
+use inquire::InquireError;
 
 use crate::error::StakkError;
-use crate::graph::types::ChangeGraph;
+use crate::graph::types::{BranchStack, ChangeGraph};
 
-/// One selectable entry in the interactive bookmark picker.
+/// Stage 1 item: a stack shown as a single line.
 #[derive(Debug, Clone)]
-pub struct SelectableBookmark {
-    /// The bookmark name (first from `segment.bookmark_names`).
-    pub bookmark_name: String,
-    /// First line of each commit description in the segment, newest-first.
-    pub commit_descriptions: Vec<String>,
-    /// Which stack this belongs to (index into `ChangeGraph::stacks`).
+pub struct StackChoice {
+    /// Index into `ChangeGraph::stacks`.
     pub stack_index: usize,
-    /// Position within the stack (0 = closest to trunk).
-    pub segment_index: usize,
-    /// Total number of segments in this stack.
+    /// Bookmark names in trunk-to-leaf order.
+    pub bookmark_names: Vec<String>,
+    /// Total number of commits across all segments.
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "used in tests to verify stack metadata")
+        expect(dead_code, reason = "used in tests to verify commit metadata")
     )]
-    pub stack_len: usize,
+    pub commit_count: usize,
+    /// Bookmarks shared with other stacks: (bookmark_name, [other stack leaf
+    /// names]).
+    pub shared_with: Vec<(String, Vec<String>)>,
+    /// First commit summary of the leaf segment.
+    pub leaf_summary: String,
 }
 
-/// Extract selectable bookmarks from a change graph.
-///
-/// Iterates all stacks and segments, producing one entry per segment using
-/// the first bookmark name. Segments are emitted in stack order (trunk-to-leaf
-/// within each stack).
-pub fn collect_selectable_bookmarks(graph: &ChangeGraph) -> Vec<SelectableBookmark> {
-    let mut result = Vec::new();
+impl fmt::Display for StackChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let chain = self.bookmark_names.join(" \u{2190} "); // ←
+        let trunk_marker = "\u{25cb} \u{2190} "; // ○ ←
+        let pr_count = self.bookmark_names.len();
+        if pr_count == 1 {
+            write!(f, "{trunk_marker}{chain}  (1 PR: {})", self.leaf_summary)?;
+        } else {
+            write!(f, "{trunk_marker}{chain}  ({pr_count} PRs)")?;
+        }
 
-    for (stack_index, stack) in graph.stacks.iter().enumerate() {
-        let stack_len = stack.segments.len();
-        for (segment_index, segment) in stack.segments.iter().enumerate() {
+        for (name, other_leaves) in &self.shared_with {
+            let others = other_leaves.join(", ");
+            write!(f, "  [{name} also in {others}]")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Stage 2 item: a bookmark within a stack.
+#[derive(Debug, Clone)]
+pub struct BookmarkChoice {
+    /// The bookmark name.
+    pub bookmark_name: String,
+    /// Position in the original stack (0 = closest to trunk).
+    pub segment_index: usize,
+    /// Total segments in the stack.
+    pub stack_len: usize,
+    /// First line of each commit description in this segment.
+    pub commit_summaries: Vec<String>,
+}
+
+impl fmt::Display for BookmarkChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let position = if self.stack_len <= 1 {
+            ""
+        } else if self.segment_index == self.stack_len - 1 {
+            "leaf, "
+        } else if self.segment_index == 0 {
+            "base, "
+        } else {
+            ""
+        };
+
+        let count = self.commit_summaries.len();
+        let commit_label = if count == 1 { "commit" } else { "commits" };
+        let pr_count = self.segment_index + 1;
+        let pr_label = if pr_count == 1 { "PR" } else { "PRs" };
+        write!(
+            f,
+            "{} ({position}{count} {commit_label}) \u{2192} {pr_count} {pr_label}",
+            self.bookmark_name,
+        )?;
+
+        for summary in &self.commit_summaries {
+            write!(f, "\n    {summary}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Build stack choices from the change graph, detecting shared segments.
+pub fn collect_stack_choices(graph: &ChangeGraph) -> Vec<StackChoice> {
+    if graph.stacks.is_empty() {
+        return Vec::new();
+    }
+
+    // Pre-pass: for each change_id, collect which stack indices contain it.
+    let mut change_to_stacks: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (stack_idx, stack) in graph.stacks.iter().enumerate() {
+        for segment in &stack.segments {
+            change_to_stacks
+                .entry(&segment.change_id)
+                .or_default()
+                .push(stack_idx);
+        }
+    }
+
+    // Build leaf name lookup: stack_index -> leaf bookmark name.
+    let leaf_names: Vec<String> = graph
+        .stacks
+        .iter()
+        .map(|stack| {
+            stack
+                .segments
+                .last()
+                .and_then(|s| s.bookmark_names.first())
+                .cloned()
+                .unwrap_or_else(|| "(unnamed)".to_string())
+        })
+        .collect();
+
+    graph
+        .stacks
+        .iter()
+        .enumerate()
+        .map(|(stack_idx, stack)| {
+            let bookmark_names: Vec<String> = stack
+                .segments
+                .iter()
+                .map(|s| {
+                    s.bookmark_names
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "(unnamed)".to_string())
+                })
+                .collect();
+
+            let commit_count: usize =
+                stack.segments.iter().map(|s| s.commits.len()).sum();
+
+            // Detect shared segments.
+            let mut shared_with: Vec<(String, Vec<String>)> = Vec::new();
+            for segment in &stack.segments {
+                let name = segment
+                    .bookmark_names
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "(unnamed)".to_string());
+
+                let other_leaves: Vec<String> = change_to_stacks
+                    .get(segment.change_id.as_str())
+                    .map(|indices| {
+                        indices
+                            .iter()
+                            .copied()
+                            .filter(|&i| i != stack_idx)
+                            .map(|i| leaf_names[i].clone())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if !other_leaves.is_empty() {
+                    shared_with.push((name, other_leaves));
+                }
+            }
+
+            let leaf_summary = stack
+                .segments
+                .last()
+                .and_then(|s| s.commits.first())
+                .and_then(|c| c.description.lines().next())
+                .map(|l| l.trim())
+                .filter(|l| !l.is_empty())
+                .unwrap_or("(no description)")
+                .to_string();
+
+            StackChoice {
+                stack_index: stack_idx,
+                bookmark_names,
+                commit_count,
+                shared_with,
+                leaf_summary,
+            }
+        })
+        .collect()
+}
+
+/// Build bookmark choices from a stack, in leaf-first order.
+pub fn collect_bookmark_choices(stack: &BranchStack) -> Vec<BookmarkChoice> {
+    let stack_len = stack.segments.len();
+
+    stack
+        .segments
+        .iter()
+        .enumerate()
+        .rev() // leaf-first
+        .map(|(segment_index, segment)| {
             let bookmark_name = segment
                 .bookmark_names
                 .first()
                 .cloned()
                 .unwrap_or_else(|| "(unnamed)".to_string());
 
-            let commit_descriptions: Vec<String> = segment
+            let commit_summaries: Vec<String> = segment
                 .commits
                 .iter()
                 .map(|c| {
-                    let first_line = c
-                        .description
+                    c.description
                         .lines()
                         .next()
                         .map(|l| l.trim())
-                        .filter(|l| !l.is_empty());
-                    first_line
+                        .filter(|l| !l.is_empty())
                         .unwrap_or("(no description)")
                         .to_string()
                 })
                 .collect();
 
-            result.push(SelectableBookmark {
+            BookmarkChoice {
                 bookmark_name,
-                commit_descriptions,
-                stack_index,
                 segment_index,
                 stack_len,
-            });
-        }
-    }
-
-    result
+                commit_summaries,
+            }
+        })
+        .collect()
 }
 
-/// Render the graph to the terminal and return the number of lines written.
-///
-/// The focused bookmark is shown in green/bold. All ancestors of the focused
-/// bookmark (same stack, lower segment_index) are highlighted in red.
-/// Non-highlighted commit lines are shown dimmed. A `trunk()` label is
-/// appended at the bottom.
-fn render_graph(
-    term: &Term,
-    bookmarks: &[SelectableBookmark],
-    focused_index: usize,
-) -> io::Result<usize> {
-    let focused = &bookmarks[focused_index];
-    let focused_stack = focused.stack_index;
-    let focused_seg = focused.segment_index;
-
-    let mut lines = 0;
-    let mut buf = String::new();
-
-    for (i, bm) in bookmarks.iter().enumerate() {
-        // Separator between entries.
-        if i > 0 {
-            let prev = &bookmarks[i - 1];
-            if bm.stack_index == prev.stack_index {
-                // Same stack: connector line.
-                buf.push_str("  \u{2502}\n"); // │
-                lines += 1;
-            } else {
-                // Different stack: blank line.
-                buf.push('\n');
-                lines += 1;
-            }
-        }
-
-        // Determine highlight for this bookmark.
-        let is_focused = i == focused_index;
-        let is_ancestor = bm.stack_index == focused_stack
-            && bm.segment_index < focused_seg;
-
-        // Bookmark line.
-        let cursor = if is_focused { "\u{25b6} " } else { "  " }; // ▶ or spaces
-        let circle = "\u{25cb}"; // ○
-        let name_display = format!("{cursor}{circle} {}", bm.bookmark_name);
-
-        if is_focused {
-            buf.push_str(&format!("{}\n", style(name_display).green().bold()));
-        } else if is_ancestor {
-            buf.push_str(&format!("{}\n", style(name_display).red()));
-        } else {
-            buf.push_str(&format!("{name_display}\n"));
-        }
-        lines += 1;
-
-        // Commit description lines.
-        for desc in &bm.commit_descriptions {
-            let commit_line = format!("  \u{2502}  {desc}"); // │
-            if is_focused {
-                buf.push_str(&format!("{}\n", style(commit_line).green()));
-            } else if is_ancestor {
-                buf.push_str(&format!("{}\n", style(commit_line).red()));
-            } else {
-                buf.push_str(&format!("{}\n", style(commit_line).dim()));
-            }
-            lines += 1;
-        }
+/// Map inquire errors to StakkError.
+fn map_inquire_error(err: InquireError) -> StakkError {
+    match err {
+        InquireError::NotTTY => StakkError::NotInteractive,
+        InquireError::OperationCanceled
+        | InquireError::OperationInterrupted => StakkError::PromptCancelled,
+        InquireError::IO(e) => StakkError::Io(e),
+        other => StakkError::Io(io::Error::other(other.to_string())),
     }
-
-    // Trunk label at the bottom, separated from the last stack.
-    if !bookmarks.is_empty() {
-        buf.push_str("  \u{2502}\n"); // │
-        lines += 1;
-        buf.push_str(&format!(
-            "  {}\n",
-            style("\u{25cb} trunk()").dim() // ○ trunk()
-        ));
-        lines += 1;
-    }
-
-    term.write_str(&buf)?;
-
-    Ok(lines)
 }
 
-/// Run the interactive bookmark selection loop.
-///
-/// Returns the index into `bookmarks` that was selected, or
-/// `StakkError::PromptCancelled` if the user presses Escape.
-fn select_bookmark(
-    term: &Term,
-    bookmarks: &[SelectableBookmark],
-) -> Result<usize, StakkError> {
-    let mut focused = bookmarks.len() - 1; // Start at the leaf of the last stack.
+/// Show inquire stack selector, returning the chosen stack index.
+fn select_stack(choices: Vec<StackChoice>) -> Result<usize, StakkError> {
+    let result = inquire::Select::new("Which stack?", choices)
+        .prompt()
+        .map_err(map_inquire_error)?;
+    Ok(result.stack_index)
+}
 
-    term.hide_cursor().ok();
-
-    // Ensure cursor is restored on any exit path.
-    struct CursorGuard<'a>(&'a Term);
-    impl Drop for CursorGuard<'_> {
-        fn drop(&mut self) {
-            self.0.show_cursor().ok();
-        }
-    }
-    let _guard = CursorGuard(term);
-
-    let mut line_count = render_graph(term, bookmarks, focused)?;
-
-    loop {
-        match term.read_key() {
-            Ok(Key::ArrowUp | Key::Char('k')) => {
-                if focused > 0 {
-                    focused -= 1;
-                } else {
-                    focused = bookmarks.len() - 1;
-                }
-            }
-            Ok(Key::ArrowDown | Key::Char('j')) => {
-                if focused < bookmarks.len() - 1 {
-                    focused += 1;
-                } else {
-                    focused = 0;
-                }
-            }
-            Ok(Key::Enter) => {
-                term.clear_last_lines(line_count)?;
-                return Ok(focused);
-            }
-            Ok(Key::Escape | Key::Char('q')) => {
-                term.clear_last_lines(line_count)?;
-                return Err(StakkError::PromptCancelled);
-            }
-            _ => continue,
-        }
-
-        term.clear_last_lines(line_count)?;
-        line_count = render_graph(term, bookmarks, focused)?;
-    }
+/// Show inquire bookmark selector, returning the chosen bookmark name.
+fn select_bookmark_in_stack(
+    choices: Vec<BookmarkChoice>,
+) -> Result<String, StakkError> {
+    let result = inquire::Select::new(
+        "Submit up to which bookmark?",
+        choices,
+    )
+    .with_help_message(
+        "All bookmarks from base up to your selection will be submitted",
+    )
+    .prompt()
+    .map_err(map_inquire_error)?;
+    Ok(result.bookmark_name)
 }
 
 /// Resolve a bookmark interactively from the change graph.
 ///
 /// - No stacks: prints a message, returns `Ok(None)`.
-/// - Single bookmark: auto-selects it, prints a message, returns `Ok(Some(name))`.
-/// - Multiple bookmarks: shows an interactive graph picker on stderr.
+/// - Single bookmark across all stacks: auto-selects it, returns
+///   `Ok(Some(name))`.
+/// - Multiple stacks: stage 1 (pick stack) then stage 2 (pick bookmark).
+/// - Single stack with multiple bookmarks: skip stage 1, show stage 2 only.
 ///
 /// Returns `StakkError::NotInteractive` if stdin is not a terminal.
 /// Returns `StakkError::PromptCancelled` if the user presses Escape.
 pub fn resolve_bookmark_interactively(
     graph: &ChangeGraph,
 ) -> Result<Option<String>, StakkError> {
-    let bookmarks = collect_selectable_bookmarks(graph);
-
-    if bookmarks.is_empty() {
+    if graph.stacks.is_empty() {
         eprintln!("No bookmark stacks found.");
         return Ok(None);
     }
 
-    if bookmarks.len() == 1 {
-        let name = bookmarks[0].bookmark_name.clone();
-        eprintln!("Auto-selecting the only bookmark: {name}");
+    // Count total bookmarks across all stacks.
+    let total_bookmarks: usize =
+        graph.stacks.iter().map(|s| s.segments.len()).sum();
+
+    if total_bookmarks == 1 {
+        let segment = &graph.stacks[0].segments[0];
+        let name = segment
+            .bookmark_names
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "(unnamed)".to_string());
+        let summary = segment
+            .commits
+            .first()
+            .and_then(|c| c.description.lines().next())
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .unwrap_or("(no description)");
+        eprintln!("Auto-selecting the only bookmark: {name} ({summary})");
         return Ok(Some(name));
     }
 
-    let term = Term::stderr();
-    if !term.is_term() {
-        return Err(StakkError::NotInteractive);
+    // Determine which stack to use.
+    let stack_index = if graph.stacks.len() == 1 {
+        // Skip stage 1.
+        0
+    } else {
+        let choices = collect_stack_choices(graph);
+        select_stack(choices)?
+    };
+
+    let stack = &graph.stacks[stack_index];
+
+    // Determine which bookmark within the stack.
+    if stack.segments.len() == 1 {
+        // Skip stage 2 -- auto-select the only bookmark in this stack.
+        let name = stack.segments[0]
+            .bookmark_names
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "(unnamed)".to_string());
+        return Ok(Some(name));
     }
 
-    eprintln!(
-        "Select a bookmark to submit ({}):\n",
-        style("arrows/jk to move, Enter to select, Esc/q to cancel").dim(),
-    );
-
-    let selected = select_bookmark(&term, &bookmarks)?;
-    let name = bookmarks[selected].bookmark_name.clone();
+    let choices = collect_bookmark_choices(stack);
+    let name = select_bookmark_in_stack(choices)?;
 
     Ok(Some(name))
 }
@@ -262,12 +342,10 @@ pub fn resolve_bookmark_interactively(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::types::BookmarkSegment;
-    use crate::graph::types::BranchStack;
-    use crate::graph::types::ChangeGraph;
-    use crate::graph::types::SegmentCommit;
-    use std::collections::HashMap;
-    use std::collections::HashSet;
+    use crate::graph::types::{
+        BookmarkSegment, BranchStack, ChangeGraph, SegmentCommit,
+    };
+    use std::collections::{HashMap, HashSet};
 
     fn make_graph(stacks: Vec<BranchStack>) -> ChangeGraph {
         ChangeGraph {
@@ -302,53 +380,34 @@ mod tests {
         }
     }
 
+    // -- StackChoice tests --
+
     #[test]
-    fn collect_empty_graph() {
+    fn stack_choices_empty_graph() {
         let graph = make_graph(vec![]);
-        let result = collect_selectable_bookmarks(&graph);
-        assert!(result.is_empty());
+        let choices = collect_stack_choices(&graph);
+        assert!(choices.is_empty());
     }
 
     #[test]
-    fn collect_single_bookmark() {
-        let graph = make_graph(vec![BranchStack {
-            segments: vec![make_segment(&["feat-a"], "ch_a", &["add feature a"])],
-        }]);
-
-        let result = collect_selectable_bookmarks(&graph);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].bookmark_name, "feat-a");
-        assert_eq!(result[0].stack_index, 0);
-        assert_eq!(result[0].segment_index, 0);
-        assert_eq!(result[0].stack_len, 1);
-    }
-
-    #[test]
-    fn collect_multi_segment_stack() {
+    fn stack_choices_single_stack() {
         let graph = make_graph(vec![BranchStack {
             segments: vec![
-                make_segment(&["feat-a"], "ch_a", &["feature a"]),
-                make_segment(&["feat-b"], "ch_b", &["feature b"]),
-                make_segment(&["feat-c"], "ch_c", &["feature c"]),
+                make_segment(&["base"], "ch_a", &["add base"]),
+                make_segment(&["leaf"], "ch_b", &["add leaf"]),
             ],
         }]);
 
-        let result = collect_selectable_bookmarks(&graph);
-        assert_eq!(result.len(), 3);
-
-        for (i, bm) in result.iter().enumerate() {
-            assert_eq!(bm.stack_index, 0);
-            assert_eq!(bm.segment_index, i);
-            assert_eq!(bm.stack_len, 3);
-        }
-
-        assert_eq!(result[0].bookmark_name, "feat-a");
-        assert_eq!(result[1].bookmark_name, "feat-b");
-        assert_eq!(result[2].bookmark_name, "feat-c");
+        let choices = collect_stack_choices(&graph);
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].stack_index, 0);
+        assert_eq!(choices[0].bookmark_names, vec!["base", "leaf"]);
+        assert_eq!(choices[0].commit_count, 2);
+        assert!(choices[0].shared_with.is_empty());
     }
 
     #[test]
-    fn collect_multiple_stacks() {
+    fn stack_choices_multiple_stacks() {
         let graph = make_graph(vec![
             BranchStack {
                 segments: vec![
@@ -365,40 +424,236 @@ mod tests {
             },
         ]);
 
-        let result = collect_selectable_bookmarks(&graph);
-        assert_eq!(result.len(), 3);
-
-        assert_eq!(result[0].stack_index, 0);
-        assert_eq!(result[1].stack_index, 0);
-        assert_eq!(result[2].stack_index, 1);
-
-        assert_eq!(result[2].segment_index, 0);
-        assert_eq!(result[2].stack_len, 1);
+        let choices = collect_stack_choices(&graph);
+        assert_eq!(choices.len(), 2);
+        assert_eq!(choices[0].bookmark_names, vec!["alpha", "beta"]);
+        assert_eq!(choices[1].bookmark_names, vec!["gamma"]);
+        assert!(choices[0].shared_with.is_empty());
+        assert!(choices[1].shared_with.is_empty());
     }
 
     #[test]
-    fn collect_commit_descriptions() {
+    fn stack_choices_shared_ancestor() {
+        // Two stacks sharing a root segment (same change_id).
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![
+                    make_segment(&["base"], "ch_shared", &["shared base"]),
+                    make_segment(&["feat-b"], "ch_b", &["feature b"]),
+                ],
+            },
+            BranchStack {
+                segments: vec![
+                    make_segment(
+                        &["base"],
+                        "ch_shared",
+                        &["shared base"],
+                    ),
+                    make_segment(
+                        &["other-leaf"],
+                        "ch_c",
+                        &["other leaf"],
+                    ),
+                ],
+            },
+        ]);
+
+        let choices = collect_stack_choices(&graph);
+        assert_eq!(choices.len(), 2);
+
+        // Stack 0: base shared with stack 1 (leaf = "other-leaf").
+        assert_eq!(choices[0].shared_with.len(), 1);
+        assert_eq!(choices[0].shared_with[0].0, "base");
+        assert_eq!(choices[0].shared_with[0].1, vec!["other-leaf"]);
+
+        // Stack 1: base shared with stack 0 (leaf = "feat-b").
+        assert_eq!(choices[1].shared_with.len(), 1);
+        assert_eq!(choices[1].shared_with[0].0, "base");
+        assert_eq!(choices[1].shared_with[0].1, vec!["feat-b"]);
+    }
+
+    #[test]
+    fn stack_choices_display_format() {
+        let choice = StackChoice {
+            stack_index: 0,
+            bookmark_names: vec![
+                "base".to_string(),
+                "feat-b".to_string(),
+                "feat-c".to_string(),
+            ],
+            commit_count: 5,
+            shared_with: vec![(
+                "base".to_string(),
+                vec!["other-leaf".to_string()],
+            )],
+            leaf_summary: "add caching".to_string(),
+        };
+
+        let display = format!("{choice}");
+        assert_eq!(
+            display,
+            "\u{25cb} \u{2190} base \u{2190} feat-b \u{2190} feat-c  (3 PRs)  [base also in other-leaf]"
+        );
+    }
+
+    #[test]
+    fn stack_choices_display_no_sharing() {
+        let choice = StackChoice {
+            stack_index: 0,
+            bookmark_names: vec!["standalone".to_string()],
+            commit_count: 1,
+            shared_with: vec![],
+            leaf_summary: "fix login bug".to_string(),
+        };
+
+        let display = format!("{choice}");
+        assert_eq!(display, "\u{25cb} \u{2190} standalone  (1 PR: fix login bug)");
+    }
+
+    // -- BookmarkChoice tests --
+
+    #[test]
+    fn bookmark_choices_single_segment() {
+        let stack = BranchStack {
+            segments: vec![make_segment(
+                &["only-one"],
+                "ch_a",
+                &["the commit"],
+            )],
+        };
+
+        let choices = collect_bookmark_choices(&stack);
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].bookmark_name, "only-one");
+        assert_eq!(choices[0].segment_index, 0);
+        assert_eq!(choices[0].stack_len, 1);
+        assert_eq!(choices[0].commit_summaries, vec!["the commit"]);
+    }
+
+    #[test]
+    fn bookmark_choices_multi_segment() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["base"], "ch_a", &["base commit"]),
+                make_segment(&["middle"], "ch_b", &["middle commit"]),
+                make_segment(&["leaf"], "ch_c", &["leaf commit"]),
+            ],
+        };
+
+        let choices = collect_bookmark_choices(&stack);
+        assert_eq!(choices.len(), 3);
+
+        // Leaf-first order.
+        assert_eq!(choices[0].bookmark_name, "leaf");
+        assert_eq!(choices[0].segment_index, 2);
+        assert_eq!(choices[1].bookmark_name, "middle");
+        assert_eq!(choices[1].segment_index, 1);
+        assert_eq!(choices[2].bookmark_name, "base");
+        assert_eq!(choices[2].segment_index, 0);
+    }
+
+    #[test]
+    fn bookmark_choices_position_labels() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["base"], "ch_a", &["base work"]),
+                make_segment(&["mid"], "ch_b", &["mid work"]),
+                make_segment(&["leaf"], "ch_c", &["leaf work"]),
+            ],
+        };
+
+        let choices = collect_bookmark_choices(&stack);
+
+        let leaf_display = format!("{}", choices[0]);
+        assert!(
+            leaf_display.starts_with("leaf (leaf, 1 commit) \u{2192} 3 PRs"),
+            "expected leaf position label and 3 PRs in '{leaf_display}'"
+        );
+
+        let mid_display = format!("{}", choices[1]);
+        assert!(
+            mid_display.starts_with("mid (1 commit) \u{2192} 2 PRs"),
+            "expected no position label and 2 PRs in '{mid_display}'"
+        );
+
+        let base_display = format!("{}", choices[2]);
+        assert!(
+            base_display.starts_with("base (base, 1 commit) \u{2192} 1 PR"),
+            "expected base position label and 1 PR in '{base_display}'"
+        );
+    }
+
+    #[test]
+    fn bookmark_choices_empty_description() {
+        let stack = BranchStack {
+            segments: vec![make_segment(&["feat"], "ch_a", &[""])],
+        };
+
+        let choices = collect_bookmark_choices(&stack);
+        assert_eq!(
+            choices[0].commit_summaries,
+            vec!["(no description)"]
+        );
+
+        let display = format!("{}", choices[0]);
+        assert!(display.contains("(no description)"));
+    }
+
+    #[test]
+    fn bookmark_choices_display_shows_commits() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(
+                    &["base"],
+                    "ch_a",
+                    &["add user model"],
+                ),
+                make_segment(
+                    &["feat"],
+                    "ch_b",
+                    &[
+                        "refactor auth module",
+                        "extract token parser",
+                    ],
+                ),
+            ],
+        };
+
+        let choices = collect_bookmark_choices(&stack);
+        // leaf-first: feat, then base
+        let feat_display = format!("{}", choices[0]);
+        assert_eq!(
+            feat_display,
+            "feat (leaf, 2 commits) \u{2192} 2 PRs\n    refactor auth module\n    extract token parser"
+        );
+
+        let base_display = format!("{}", choices[1]);
+        assert_eq!(
+            base_display,
+            "base (base, 1 commit) \u{2192} 1 PR\n    add user model"
+        );
+    }
+
+    // -- resolve_bookmark_interactively edge cases --
+
+    #[test]
+    fn resolve_no_stacks() {
+        let graph = make_graph(vec![]);
+        let result = resolve_bookmark_interactively(&graph).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn resolve_single_bookmark_auto_select() {
         let graph = make_graph(vec![BranchStack {
             segments: vec![make_segment(
-                &["feat-a"],
+                &["only-bm"],
                 "ch_a",
-                &["first line\n\nmore detail", "second commit\nwith body"],
+                &["the commit"],
             )],
         }]);
 
-        let result = collect_selectable_bookmarks(&graph);
-        assert_eq!(result[0].commit_descriptions.len(), 2);
-        assert_eq!(result[0].commit_descriptions[0], "first line");
-        assert_eq!(result[0].commit_descriptions[1], "second commit");
-    }
-
-    #[test]
-    fn collect_empty_description() {
-        let graph = make_graph(vec![BranchStack {
-            segments: vec![make_segment(&["feat-a"], "ch_a", &[""])],
-        }]);
-
-        let result = collect_selectable_bookmarks(&graph);
-        assert_eq!(result[0].commit_descriptions[0], "(no description)");
+        let result = resolve_bookmark_interactively(&graph).unwrap();
+        assert_eq!(result, Some("only-bm".to_string()));
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,404 @@
+//! Interactive bookmark selection with visual graph context.
+//!
+//! Renders a graph of bookmark stacks using Unicode box-drawing characters
+//! and lets the user pick a bookmark to submit. Uses the `console` crate
+//! for terminal I/O (cursor control, key reading, styling).
+
+use std::io;
+
+use console::Key;
+use console::Term;
+use console::style;
+
+use crate::error::StakkError;
+use crate::graph::types::ChangeGraph;
+
+/// One selectable entry in the interactive bookmark picker.
+#[derive(Debug, Clone)]
+pub struct SelectableBookmark {
+    /// The bookmark name (first from `segment.bookmark_names`).
+    pub bookmark_name: String,
+    /// First line of each commit description in the segment, newest-first.
+    pub commit_descriptions: Vec<String>,
+    /// Which stack this belongs to (index into `ChangeGraph::stacks`).
+    pub stack_index: usize,
+    /// Position within the stack (0 = closest to trunk).
+    pub segment_index: usize,
+    /// Total number of segments in this stack.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used in tests to verify stack metadata")
+    )]
+    pub stack_len: usize,
+}
+
+/// Extract selectable bookmarks from a change graph.
+///
+/// Iterates all stacks and segments, producing one entry per segment using
+/// the first bookmark name. Segments are emitted in stack order (trunk-to-leaf
+/// within each stack).
+pub fn collect_selectable_bookmarks(graph: &ChangeGraph) -> Vec<SelectableBookmark> {
+    let mut result = Vec::new();
+
+    for (stack_index, stack) in graph.stacks.iter().enumerate() {
+        let stack_len = stack.segments.len();
+        for (segment_index, segment) in stack.segments.iter().enumerate() {
+            let bookmark_name = segment
+                .bookmark_names
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "(unnamed)".to_string());
+
+            let commit_descriptions: Vec<String> = segment
+                .commits
+                .iter()
+                .map(|c| {
+                    let first_line = c
+                        .description
+                        .lines()
+                        .next()
+                        .map(|l| l.trim())
+                        .filter(|l| !l.is_empty());
+                    first_line
+                        .unwrap_or("(no description)")
+                        .to_string()
+                })
+                .collect();
+
+            result.push(SelectableBookmark {
+                bookmark_name,
+                commit_descriptions,
+                stack_index,
+                segment_index,
+                stack_len,
+            });
+        }
+    }
+
+    result
+}
+
+/// Render the graph to the terminal and return the number of lines written.
+///
+/// The focused bookmark is shown in green/bold. All ancestors of the focused
+/// bookmark (same stack, lower segment_index) are highlighted in red.
+/// Non-highlighted commit lines are shown dimmed. A `trunk()` label is
+/// appended at the bottom.
+fn render_graph(
+    term: &Term,
+    bookmarks: &[SelectableBookmark],
+    focused_index: usize,
+) -> io::Result<usize> {
+    let focused = &bookmarks[focused_index];
+    let focused_stack = focused.stack_index;
+    let focused_seg = focused.segment_index;
+
+    let mut lines = 0;
+    let mut buf = String::new();
+
+    for (i, bm) in bookmarks.iter().enumerate() {
+        // Separator between entries.
+        if i > 0 {
+            let prev = &bookmarks[i - 1];
+            if bm.stack_index == prev.stack_index {
+                // Same stack: connector line.
+                buf.push_str("  \u{2502}\n"); // │
+                lines += 1;
+            } else {
+                // Different stack: blank line.
+                buf.push('\n');
+                lines += 1;
+            }
+        }
+
+        // Determine highlight for this bookmark.
+        let is_focused = i == focused_index;
+        let is_ancestor = bm.stack_index == focused_stack
+            && bm.segment_index < focused_seg;
+
+        // Bookmark line.
+        let cursor = if is_focused { "\u{25b6} " } else { "  " }; // ▶ or spaces
+        let circle = "\u{25cb}"; // ○
+        let name_display = format!("{cursor}{circle} {}", bm.bookmark_name);
+
+        if is_focused {
+            buf.push_str(&format!("{}\n", style(name_display).green().bold()));
+        } else if is_ancestor {
+            buf.push_str(&format!("{}\n", style(name_display).red()));
+        } else {
+            buf.push_str(&format!("{name_display}\n"));
+        }
+        lines += 1;
+
+        // Commit description lines.
+        for desc in &bm.commit_descriptions {
+            let commit_line = format!("  \u{2502}  {desc}"); // │
+            if is_focused {
+                buf.push_str(&format!("{}\n", style(commit_line).green()));
+            } else if is_ancestor {
+                buf.push_str(&format!("{}\n", style(commit_line).red()));
+            } else {
+                buf.push_str(&format!("{}\n", style(commit_line).dim()));
+            }
+            lines += 1;
+        }
+    }
+
+    // Trunk label at the bottom, separated from the last stack.
+    if !bookmarks.is_empty() {
+        buf.push_str("  \u{2502}\n"); // │
+        lines += 1;
+        buf.push_str(&format!(
+            "  {}\n",
+            style("\u{25cb} trunk()").dim() // ○ trunk()
+        ));
+        lines += 1;
+    }
+
+    term.write_str(&buf)?;
+
+    Ok(lines)
+}
+
+/// Run the interactive bookmark selection loop.
+///
+/// Returns the index into `bookmarks` that was selected, or
+/// `StakkError::PromptCancelled` if the user presses Escape.
+fn select_bookmark(
+    term: &Term,
+    bookmarks: &[SelectableBookmark],
+) -> Result<usize, StakkError> {
+    let mut focused = bookmarks.len() - 1; // Start at the leaf of the last stack.
+
+    term.hide_cursor().ok();
+
+    // Ensure cursor is restored on any exit path.
+    struct CursorGuard<'a>(&'a Term);
+    impl Drop for CursorGuard<'_> {
+        fn drop(&mut self) {
+            self.0.show_cursor().ok();
+        }
+    }
+    let _guard = CursorGuard(term);
+
+    let mut line_count = render_graph(term, bookmarks, focused)?;
+
+    loop {
+        match term.read_key() {
+            Ok(Key::ArrowUp | Key::Char('k')) => {
+                if focused > 0 {
+                    focused -= 1;
+                } else {
+                    focused = bookmarks.len() - 1;
+                }
+            }
+            Ok(Key::ArrowDown | Key::Char('j')) => {
+                if focused < bookmarks.len() - 1 {
+                    focused += 1;
+                } else {
+                    focused = 0;
+                }
+            }
+            Ok(Key::Enter) => {
+                term.clear_last_lines(line_count)?;
+                return Ok(focused);
+            }
+            Ok(Key::Escape | Key::Char('q')) => {
+                term.clear_last_lines(line_count)?;
+                return Err(StakkError::PromptCancelled);
+            }
+            _ => continue,
+        }
+
+        term.clear_last_lines(line_count)?;
+        line_count = render_graph(term, bookmarks, focused)?;
+    }
+}
+
+/// Resolve a bookmark interactively from the change graph.
+///
+/// - No stacks: prints a message, returns `Ok(None)`.
+/// - Single bookmark: auto-selects it, prints a message, returns `Ok(Some(name))`.
+/// - Multiple bookmarks: shows an interactive graph picker on stderr.
+///
+/// Returns `StakkError::NotInteractive` if stdin is not a terminal.
+/// Returns `StakkError::PromptCancelled` if the user presses Escape.
+pub fn resolve_bookmark_interactively(
+    graph: &ChangeGraph,
+) -> Result<Option<String>, StakkError> {
+    let bookmarks = collect_selectable_bookmarks(graph);
+
+    if bookmarks.is_empty() {
+        eprintln!("No bookmark stacks found.");
+        return Ok(None);
+    }
+
+    if bookmarks.len() == 1 {
+        let name = bookmarks[0].bookmark_name.clone();
+        eprintln!("Auto-selecting the only bookmark: {name}");
+        return Ok(Some(name));
+    }
+
+    let term = Term::stderr();
+    if !term.is_term() {
+        return Err(StakkError::NotInteractive);
+    }
+
+    eprintln!(
+        "Select a bookmark to submit ({}):\n",
+        style("arrows/jk to move, Enter to select, Esc/q to cancel").dim(),
+    );
+
+    let selected = select_bookmark(&term, &bookmarks)?;
+    let name = bookmarks[selected].bookmark_name.clone();
+
+    Ok(Some(name))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::types::BookmarkSegment;
+    use crate::graph::types::BranchStack;
+    use crate::graph::types::ChangeGraph;
+    use crate::graph::types::SegmentCommit;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    fn make_graph(stacks: Vec<BranchStack>) -> ChangeGraph {
+        ChangeGraph {
+            adjacency_list: HashMap::new(),
+            stack_leaves: HashSet::new(),
+            stack_roots: HashSet::new(),
+            segments: HashMap::new(),
+            tainted_change_ids: HashSet::new(),
+            excluded_bookmark_count: 0,
+            stacks,
+        }
+    }
+
+    fn make_segment(
+        names: &[&str],
+        change_id: &str,
+        descriptions: &[&str],
+    ) -> BookmarkSegment {
+        BookmarkSegment {
+            bookmark_names: names.iter().map(|s| s.to_string()).collect(),
+            change_id: change_id.to_string(),
+            commits: descriptions
+                .iter()
+                .enumerate()
+                .map(|(i, desc)| SegmentCommit {
+                    commit_id: format!("c_{change_id}_{i}"),
+                    change_id: change_id.to_string(),
+                    description: desc.to_string(),
+                    author_name: "Test".to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn collect_empty_graph() {
+        let graph = make_graph(vec![]);
+        let result = collect_selectable_bookmarks(&graph);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn collect_single_bookmark() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![make_segment(&["feat-a"], "ch_a", &["add feature a"])],
+        }]);
+
+        let result = collect_selectable_bookmarks(&graph);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].bookmark_name, "feat-a");
+        assert_eq!(result[0].stack_index, 0);
+        assert_eq!(result[0].segment_index, 0);
+        assert_eq!(result[0].stack_len, 1);
+    }
+
+    #[test]
+    fn collect_multi_segment_stack() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", &["feature a"]),
+                make_segment(&["feat-b"], "ch_b", &["feature b"]),
+                make_segment(&["feat-c"], "ch_c", &["feature c"]),
+            ],
+        }]);
+
+        let result = collect_selectable_bookmarks(&graph);
+        assert_eq!(result.len(), 3);
+
+        for (i, bm) in result.iter().enumerate() {
+            assert_eq!(bm.stack_index, 0);
+            assert_eq!(bm.segment_index, i);
+            assert_eq!(bm.stack_len, 3);
+        }
+
+        assert_eq!(result[0].bookmark_name, "feat-a");
+        assert_eq!(result[1].bookmark_name, "feat-b");
+        assert_eq!(result[2].bookmark_name, "feat-c");
+    }
+
+    #[test]
+    fn collect_multiple_stacks() {
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![
+                    make_segment(&["alpha"], "ch_alpha", &["alpha"]),
+                    make_segment(&["beta"], "ch_beta", &["beta"]),
+                ],
+            },
+            BranchStack {
+                segments: vec![make_segment(
+                    &["gamma"],
+                    "ch_gamma",
+                    &["gamma"],
+                )],
+            },
+        ]);
+
+        let result = collect_selectable_bookmarks(&graph);
+        assert_eq!(result.len(), 3);
+
+        assert_eq!(result[0].stack_index, 0);
+        assert_eq!(result[1].stack_index, 0);
+        assert_eq!(result[2].stack_index, 1);
+
+        assert_eq!(result[2].segment_index, 0);
+        assert_eq!(result[2].stack_len, 1);
+    }
+
+    #[test]
+    fn collect_commit_descriptions() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![make_segment(
+                &["feat-a"],
+                "ch_a",
+                &["first line\n\nmore detail", "second commit\nwith body"],
+            )],
+        }]);
+
+        let result = collect_selectable_bookmarks(&graph);
+        assert_eq!(result[0].commit_descriptions.len(), 2);
+        assert_eq!(result[0].commit_descriptions[0], "first line");
+        assert_eq!(result[0].commit_descriptions[1], "second commit");
+    }
+
+    #[test]
+    fn collect_empty_description() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![make_segment(&["feat-a"], "ch_a", &[""])],
+        }]);
+
+        let result = collect_selectable_bookmarks(&graph);
+        assert_eq!(result[0].commit_descriptions[0], "(no description)");
+    }
+}


### PR DESCRIPTION
feat: two-stage inquire-based interactive bookmark selection

Replace custom console-based graph renderer with inquire::Select prompts.
Stage 1 picks a stack (with trunk marker, shared-ancestor annotations,
commit title for single-PR stacks). Stage 2 picks a bookmark within the
stack (leaf-first, position labels, commit summaries, PR count indicator).
Stages auto-skip when only one option exists. --dry-run prints a prominent
header. 98 total tests.

---

docs: research report and roadmap for interactive selector viewport

Add RESEARCH-interactive-selector.md documenting three approaches explored
for fixing the viewport overflow issue: console-based viewport windowing
(Option A), ratatui inline viewport (Option B), and inquire two-step
selection (Option C). Includes analysis of jj-stack's implementation.

Expand ROADMAP.md Milestone 7 into three parts: basic selection (done),
viewport windowing (next), and DAG graph rendering (follow-up). Reference
the research doc for trade-off details.

---

wip: interactive bookmark selection for `stakk submit`

Add optional bookmark argument to `stakk submit`. When omitted, shows an
interactive graph selector using the console crate. Includes viewport with
○/│ graph characters, color-coded ancestors (red) and focused bookmark
(green/bold), keyboard navigation (arrows/jk, Enter, Esc/q).

Known issue: does not handle graphs larger than terminal height (no viewport
windowing yet). Research into solutions (console viewport, ratatui, inquire)
is in progress.

91 tests, clippy clean.