### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/glennib/stakk/compare/v0.2.0...v0.2.1) - 2026-02-20
+
+### Added
+
+- add shell completions subcommand and version output
+- enable vim mode (j/k navigation) and disable filtering in interactive selection
+- add help message to stage 1 of interactive bookmark selection
+- support canonical SSH URLs (ssh://git@github.com/...) in remote parsing
+
+### Other
+
+- move gif to right after Features section for better visibility
+- improve README layout — move gif to Quick Start, replace textual comment example with screenshot
+- add interactive gif and PR comment screenshot to README
+- update README to reflect submit as default command
+
 ## [0.2.0](https://github.com/glennib/stakk/compare/v0.1.1...v0.2.0) - 2026-02-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/glennib/stakk/compare/v0.2.0...v0.2.1) - 2026-02-20

### Added

- add shell completions subcommand and version output
- enable vim mode (j/k navigation) and disable filtering in interactive selection
- add help message to stage 1 of interactive bookmark selection
- support canonical SSH URLs (ssh://git@github.com/...) in remote parsing

### Other

- move gif to right after Features section for better visibility
- improve README layout — move gif to Quick Start, replace textual comment example with screenshot
- add interactive gif and PR comment screenshot to README
- update README to reflect submit as default command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).