### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/glennib/stakk/compare/v0.2.2...v0.2.3) - 2026-03-02
+
+### Added
+
+- *(select)* replace inquire with ratatui TUI selector
+
 ## [0.2.2](https://github.com/glennib/stakk/compare/v0.2.1...v0.2.2) - 2026-02-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/glennib/stakk/compare/v0.2.2...v0.2.3) - 2026-03-02

### Added

- *(select)* replace inquire with ratatui TUI selector
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).