### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/glennib/stakk/compare/v0.2.3...v0.2.4) - 2026-03-02
+
+### Fixed
+
+- *(deps)* update rust crate rand to 0.10
+
+### Other
+
+- Merge pull request #23 from glennib/renovate/rand-0.x
+
 ## [0.2.3](https://github.com/glennib/stakk/compare/v0.2.2...v0.2.3) - 2026-03-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/glennib/stakk/compare/v0.2.3...v0.2.4) - 2026-03-02

### Fixed

- *(deps)* update rust crate rand to 0.10

### Other

- Merge pull request #23 from glennib/renovate/rand-0.x
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).