### PR TITLE
feat(comment): minijinja-based stack comment templating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ for milestones.
   `stakk-<change_id>` bookmarks. New bookmarks are created via
   `jj bookmark create` before submission. `Jj::create_bookmark()` is the
   first write operation stakk performs on jj state. 117 total tests.
+- **Stack comment templating**: Complete — minijinja-based templating for
+  stack comments. Default template uses table layout with PR URLs, bookmark
+  names, and base branches. Custom templates via `--template` flag or
+  `STAKK_TEMPLATE` env var. `StackCommentContext`/`StackEntryContext` structs
+  provide rich template context. Metadata line always prepended
+  programmatically (not part of template). 124 total tests.
 
 ## Testing
 
@@ -126,7 +132,8 @@ src/
 ├── forge/           # Forge trait + GitHub implementation (octocrab)
 │   ├── mod.rs       # Forge trait, forge-agnostic types, ForgeError
 │   ├── github.rs    # GitHubForge implementation
-│   └── comment.rs   # Stack comment formatting and parsing
+│   ├── comment.rs   # Stack comment formatting, parsing, and template context
+│   └── default_comment.md.jinja  # Default minijinja template for stack comments
 ├── graph/           # Change graph construction (ChangeGraph, BookmarkSegment, BranchStack)
 ├── select/          # Interactive TUI selection (ratatui inline viewport)
 │   ├── mod.rs       # Public API: resolve_bookmark_interactively(), SelectionResult
@@ -153,6 +160,7 @@ There is intentionally no `git/` module.
 | `http` | HTTP status codes for error mapping |
 | `thiserror` | Error type definitions |
 | `miette` | User-facing error diagnostics (`Diagnostic` derives) |
+| `minijinja` | Jinja2 templating for stack comments |
 | `ratatui` | TUI framework for interactive graph/bookmark selection |
 | `crossterm` | Terminal events and raw mode for TUI input handling |
 | `console` | Terminal I/O (used by indicatif) |
@@ -318,6 +326,21 @@ made during implementation here.)
   calls `jj bookmark create <name> -r <revision>`. After creating new
   bookmarks, the change graph must be rebuilt to include them.
 
+- minijinja `Environment::add_template` requires `&'source str` matching
+  the environment's lifetime. For custom templates (owned `String`), use
+  `Box::leak(source.into_boxed_str())` to get a `&'static str`. This is
+  fine since the env is created once per invocation.
+- Stack comment metadata line (`<!--- STAKK_STACK: ... --->`) is always
+  prepended programmatically — it is NOT part of the minijinja template.
+  This ensures metadata survives custom templates that might omit it.
+- `StackCommentContext` / `StackEntryContext` are separate from the lean
+  `StackCommentData` / `StackEntry` types. The former are rich rendering
+  contexts (title, base, is_current, position); the latter are minimal
+  machine-readable metadata embedded as base64 JSON.
+- `format_stack_comment` returns `Result` (not infallible) because user
+  templates can fail to render. Default template is validated at compile
+  time via `include_str!` + tests.
+
 ## Decisions Log
 
 (Record significant architectural or design decisions here with date and
@@ -424,3 +447,7 @@ rationale.)
 - **2026-03-01**: `rand` added but not yet actively used — primary bookmark
   naming strategy is deterministic (`stakk-<change_id_prefix>`). `rand` is
   a fallback for name collisions.
+- **2026-03-04**: minijinja for stack comment templating — replaces
+  hardcoded numbered list with table layout. `--template` / `STAKK_TEMPLATE`
+  for custom templates. Metadata line always prepended outside the template.
+  `format_stack_comment` now returns `Result` since user templates can fail.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "2.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2669,7 @@ dependencies = [
  "http",
  "indicatif",
  "miette",
+ "minijinja",
  "octocrab",
  "rand 0.10.0",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 base64 = "0.22.1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.66"
 console = "0.16"
 crossterm = "0.29"
@@ -21,6 +21,7 @@ futures = "0.3"
 http = "1.4.0"
 indicatif = "0.18"
 miette = { version = "7", features = ["fancy"] }
+minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 octocrab = "0.49.5"
 rand = "0.10"
 ratatui = "0.30"

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -18,6 +18,10 @@ pub struct SubmitArgs {
     /// Git remote to push to.
     #[arg(long, default_value = "origin")]
     pub remote: String,
+
+    /// Path to a custom minijinja template for stack comments.
+    #[arg(long, env = "STAKK_TEMPLATE")]
+    pub template: Option<String>,
 }
 
 impl Default for SubmitArgs {
@@ -27,6 +31,7 @@ impl Default for SubmitArgs {
             dry_run: false,
             draft: false,
             remote: "origin".to_string(),
+            template: None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,10 @@ pub enum StakkError {
     #[diagnostic(help("Make sure this repository has a GitHub remote configured"))]
     NoGithubRemote,
 
+    /// Failed to load a custom template file.
+    #[error("failed to load template '{path}': {reason}")]
+    TemplateLoadFailed { path: String, reason: String },
+
     /// A terminal I/O error.
     #[error("terminal I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -5,17 +5,18 @@
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use minijinja::Environment;
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::Comment;
+use crate::submit::SubmitError;
 
 /// Prefix for the metadata HTML comment.
 const COMMENT_DATA_PREFIX: &str = "<!--- STAKK_STACK: ";
 const COMMENT_DATA_POSTFIX: &str = " --->";
-/// Unicode left arrow used to mark the current PR in the stack list.
-const STACK_COMMENT_THIS_PR: &str = "\u{2190} this PR";
-const STACK_COMMENT_FOOTER: &str = "*Created with [stakk](https://github.com/glennib/stakk)*";
+
+const DEFAULT_TEMPLATE: &str = include_str!("default_comment.md.jinja");
 
 /// Metadata embedded in stack comments as base64-encoded JSON.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -35,33 +36,67 @@ pub struct StackEntry {
     pub pr_number: u64,
 }
 
+/// Template rendering context for a full stack comment.
+#[derive(Debug, Clone, Serialize)]
+pub struct StackCommentContext {
+    pub stack: Vec<StackEntryContext>,
+    pub stack_size: usize,
+    pub default_branch: String,
+    pub current_bookmark: String,
+    pub stakk_url: String,
+}
+
+/// Template rendering context for a single entry in the stack.
+#[derive(Debug, Clone, Serialize)]
+pub struct StackEntryContext {
+    pub bookmark_name: String,
+    pub pr_url: String,
+    pub pr_number: u64,
+    pub title: String,
+    pub base: String,
+    pub is_draft: bool,
+    pub position: usize,
+    pub is_current: bool,
+}
+
+/// Build a minijinja environment with the stack comment template loaded.
+///
+/// If `custom_template` is `Some`, it is used instead of the built-in
+/// default.
+pub fn build_comment_env(
+    custom_template: Option<&str>,
+) -> Result<Environment<'static>, SubmitError> {
+    let mut env = Environment::new();
+    let source = match custom_template {
+        Some(s) => s.to_string(),
+        None => DEFAULT_TEMPLATE.to_string(),
+    };
+    env.add_template("stack_comment", Box::leak(source.into_boxed_str()))
+        .map_err(|e| SubmitError::TemplateRenderFailed {
+            message: format!("failed to compile template: {e}"),
+        })?;
+    Ok(env)
+}
+
 /// Format a stack comment body for a specific PR in the stack.
 ///
-/// `current_index` is the index into `data.stack` for the PR this comment
-/// will be posted on.
-pub fn format_stack_comment(data: &StackCommentData, current_index: usize) -> String {
+/// The metadata line (`<!--- STAKK_STACK: ... --->`) is always prepended
+/// programmatically and is NOT part of the template.
+pub fn format_stack_comment(
+    data: &StackCommentData,
+    context: &StackCommentContext,
+    template: &minijinja::Template<'_, '_>,
+) -> Result<String, SubmitError> {
     let encoded = BASE64.encode(serde_json::to_string(data).expect("serialization cannot fail"));
+    let metadata_line = format!("{COMMENT_DATA_PREFIX}{encoded}{COMMENT_DATA_POSTFIX}");
 
-    let plural = if data.stack.len() == 1 { "" } else { "s" };
-    let mut body = format!(
-        "{COMMENT_DATA_PREFIX}{encoded}{COMMENT_DATA_POSTFIX}\n### Stack ({} bookmark{plural}, \
-         base: `trunk()`)\n\n",
-        data.stack.len(),
-    );
+    let rendered = template
+        .render(context)
+        .map_err(|e| SubmitError::TemplateRenderFailed {
+            message: e.to_string(),
+        })?;
 
-    for (i, entry) in data.stack.iter().enumerate() {
-        if i == current_index {
-            body.push_str(&format!(
-                "1. **{} {STACK_COMMENT_THIS_PR}**\n",
-                entry.pr_url,
-            ));
-        } else {
-            body.push_str(&format!("1. {}\n", entry.pr_url));
-        }
-    }
-
-    body.push_str(&format!("\n---\n{STACK_COMMENT_FOOTER}"));
-    body
+    Ok(format!("{metadata_line}\n{rendered}"))
 }
 
 /// Find the existing stack comment among a list of comments.
@@ -115,10 +150,49 @@ mod tests {
         }
     }
 
+    fn sample_context(current_index: usize) -> StackCommentContext {
+        let entries = vec![
+            StackEntryContext {
+                bookmark_name: "feat-a".to_string(),
+                pr_url: "https://github.com/owner/repo/pull/1".to_string(),
+                pr_number: 1,
+                title: "feature a".to_string(),
+                base: "main".to_string(),
+                is_draft: false,
+                position: 1,
+                is_current: current_index == 0,
+            },
+            StackEntryContext {
+                bookmark_name: "feat-b".to_string(),
+                pr_url: "https://github.com/owner/repo/pull/2".to_string(),
+                pr_number: 2,
+                title: "feature b".to_string(),
+                base: "feat-a".to_string(),
+                is_draft: false,
+                position: 2,
+                is_current: current_index == 1,
+            },
+        ];
+        StackCommentContext {
+            stack_size: entries.len(),
+            current_bookmark: entries[current_index].bookmark_name.clone(),
+            stack: entries,
+            default_branch: "main".to_string(),
+            stakk_url: "https://github.com/glennib/stakk".to_string(),
+        }
+    }
+
+    fn default_env() -> Environment<'static> {
+        build_comment_env(None).unwrap()
+    }
+
     #[test]
     fn format_and_parse_roundtrip() {
         let data = sample_data();
-        let body = format_stack_comment(&data, 0);
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
         let parsed = parse_stack_comment(&body).unwrap();
         assert_eq!(parsed, data);
     }
@@ -126,21 +200,33 @@ mod tests {
     #[test]
     fn format_highlights_current_pr() {
         let data = sample_data();
-        let body = format_stack_comment(&data, 1);
-        // Second PR should be highlighted.
-        assert!(body.contains("**https://github.com/owner/repo/pull/2 \u{2190} this PR**"));
-        // First PR should not be bold.
-        assert!(!body.contains("**https://github.com/owner/repo/pull/1"));
+        let ctx = sample_context(1);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        // Second PR should be highlighted with pointing finger.
+        assert!(
+            body.contains("\u{1f448}"),
+            "expected pointing finger emoji in body: {body}"
+        );
     }
 
     #[test]
-    fn format_includes_trunk() {
-        let body = format_stack_comment(&sample_data(), 0);
-        assert!(body.contains("`trunk()`"));
+    fn format_includes_default_branch() {
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        assert!(body.contains("`main`"));
     }
 
     #[test]
     fn find_stack_comment_matches() {
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
         let comments = vec![
             Comment {
                 id: 1,
@@ -148,7 +234,7 @@ mod tests {
             },
             Comment {
                 id: 2,
-                body: format_stack_comment(&sample_data(), 0),
+                body: format_stack_comment(&data, &ctx, &tmpl).unwrap(),
             },
         ];
         let found = find_stack_comment(&comments);
@@ -189,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn format_single_bookmark_no_plural() {
+    fn format_single_entry_numbered_list() {
         let data = StackCommentData {
             version: 0,
             stack: vec![StackEntry {
@@ -198,20 +284,86 @@ mod tests {
                 pr_number: 1,
             }],
         };
-        let body = format_stack_comment(&data, 0);
-        assert!(body.contains("1 bookmark,"));
-        assert!(!body.contains("bookmarks,"));
-    }
-
-    #[test]
-    fn format_multiple_bookmarks_plural() {
-        let body = format_stack_comment(&sample_data(), 0);
-        assert!(body.contains("2 bookmarks,"));
+        let ctx = StackCommentContext {
+            stack: vec![StackEntryContext {
+                bookmark_name: "solo".to_string(),
+                pr_url: "https://github.com/o/r/pull/1".to_string(),
+                pr_number: 1,
+                title: "solo feature".to_string(),
+                base: "main".to_string(),
+                is_draft: false,
+                position: 1,
+                is_current: true,
+            }],
+            stack_size: 1,
+            default_branch: "main".to_string(),
+            current_bookmark: "solo".to_string(),
+            stakk_url: "https://github.com/glennib/stakk".to_string(),
+        };
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        assert!(
+            body.contains("1. https://github.com/o/r/pull/1"),
+            "expected numbered list entry: {body}"
+        );
     }
 
     #[test]
     fn format_includes_footer() {
-        let body = format_stack_comment(&sample_data(), 0);
-        assert!(body.contains(STACK_COMMENT_FOOTER));
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        assert!(body.contains("stakk"));
+    }
+
+    #[test]
+    fn format_header_mentions_merges_into() {
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        assert!(
+            body.contains("merges into `main`"),
+            "expected merge target in header: {body}"
+        );
+    }
+
+    #[test]
+    fn custom_template_renders() {
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let custom = "Custom: {{ stack_size }} PRs for {{ current_bookmark }}";
+        let env = build_comment_env(Some(custom)).unwrap();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        assert!(body.contains("Custom: 2 PRs for feat-a"));
+    }
+
+    #[test]
+    fn invalid_template_returns_error() {
+        let result = build_comment_env(Some("{{ unclosed"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn format_renders_numbered_entries() {
+        let data = sample_data();
+        let ctx = sample_context(0);
+        let env = default_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
+        // Should contain numbered list entries with PR URLs
+        assert!(
+            body.contains("1. https://github.com/owner/repo/pull/1"),
+            "expected entry 1: {body}"
+        );
+        assert!(
+            body.contains("2. https://github.com/owner/repo/pull/2"),
+            "expected entry 2: {body}"
+        );
     }
 }

--- a/src/forge/default_comment.md.jinja
+++ b/src/forge/default_comment.md.jinja
@@ -1,0 +1,6 @@
+This PR is part of a stack that merges into `{{ default_branch }}`:
+{% for entry in stack %}
+{{ entry.position }}. {{ entry.pr_url }}{% if entry.is_current %} 👈{% endif %}
+{%- endfor %}
+
+<sub>Created with [stakk]({{ stakk_url }})</sub>

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,8 +185,22 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
         return Ok(());
     }
 
+    // Load template.
+    let template_source = match &args.template {
+        Some(path) => {
+            Some(
+                std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
+                    path: path.clone(),
+                    reason: e.to_string(),
+                })?,
+            )
+        }
+        None => None,
+    };
+    let comment_env = forge::comment::build_comment_env(template_source.as_deref())?;
+
     // Phase 3: Execute.
-    let result = submit::execute_submission_plan(&plan, &jj, &forge).await?;
+    let result = submit::execute_submission_plan(&plan, &jj, &forge, &comment_env).await?;
 
     println!("\nSubmitted {} bookmark(s).", result.stack_entries.len());
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -12,8 +12,10 @@ use crate::forge::CreatePrParams;
 use crate::forge::Forge;
 use crate::forge::ForgeError;
 use crate::forge::PullRequest;
+use crate::forge::comment::StackCommentContext;
 use crate::forge::comment::StackCommentData;
 use crate::forge::comment::StackEntry;
+use crate::forge::comment::StackEntryContext;
 use crate::forge::comment::find_stack_comment;
 use crate::forge::comment::format_stack_comment;
 use crate::graph::types::BookmarkSegment;
@@ -76,6 +78,10 @@ pub enum SubmitError {
         #[source]
         source: ForgeError,
     },
+
+    /// Failed to render a stack comment template.
+    #[error("template rendering failed: {message} — check the template syntax (minijinja/Jinja2)")]
+    TemplateRenderFailed { message: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -122,6 +128,8 @@ pub struct SubmissionPlan {
     pub remote: String,
     /// Whether to create PRs as drafts.
     pub draft: bool,
+    /// The default branch name (e.g., "main").
+    pub default_branch: String,
 }
 
 /// Phase 3 output: what was actually done.
@@ -285,6 +293,7 @@ pub async fn create_submission_plan<F: Forge>(
         bookmark_plans,
         remote: remote.to_string(),
         draft,
+        default_branch: analysis.default_branch.clone(),
     })
 }
 
@@ -341,6 +350,7 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     plan: &SubmissionPlan,
     jj: &Jj<R>,
     forge: &F,
+    comment_env: &minijinja::Environment<'_>,
 ) -> Result<SubmissionResult, SubmitError> {
     let pb = indicatif::ProgressBar::new_spinner();
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
@@ -426,13 +436,50 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
         stack: stack_entries.clone(),
     };
 
+    let template = comment_env.get_template("stack_comment").map_err(|e| {
+        SubmitError::TemplateRenderFailed {
+            message: e.to_string(),
+        }
+    })?;
+
+    // Build the shared entry contexts from stack_entries + bookmark_plans.
+    let entry_contexts: Vec<StackEntryContext> = stack_entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let bp = &plan.bookmark_plans[i];
+            StackEntryContext {
+                bookmark_name: entry.bookmark_name.clone(),
+                pr_url: entry.pr_url.clone(),
+                pr_number: entry.pr_number,
+                title: bp.title.clone(),
+                base: bp.base.clone(),
+                is_draft: plan.draft && bp.needs_create,
+                position: i + 1,
+                is_current: false, // set per-PR below
+            }
+        })
+        .collect();
+
     let comment_futures: Vec<_> = stack_entries
         .iter()
         .enumerate()
         .map(|(i, entry)| {
-            let body = format_stack_comment(&comment_data, i);
+            // Build a context with is_current set for this PR.
+            let mut entries = entry_contexts.clone();
+            entries[i].is_current = true;
+            let ctx = StackCommentContext {
+                stack_size: entries.len(),
+                current_bookmark: entry.bookmark_name.clone(),
+                default_branch: plan.default_branch.clone(),
+                stakk_url: "https://github.com/glennib/stakk".to_string(),
+                stack: entries,
+            };
+
+            let body = format_stack_comment(&comment_data, &ctx, &template);
             let pr_number = entry.pr_number;
             async move {
+                let body = body?;
                 let existing_comments = forge
                     .list_comments(pr_number)
                     .await
@@ -477,11 +524,16 @@ mod tests {
     use crate::forge::Comment;
     use crate::forge::ForgeError;
     use crate::forge::PrState;
+    use crate::forge::comment::build_comment_env;
     use crate::graph::types::BranchStack;
     use crate::graph::types::SegmentCommit;
     use crate::jj::JjError;
 
     // -- Test helpers --
+
+    fn test_comment_env() -> minijinja::Environment<'static> {
+        build_comment_env(None).unwrap()
+    }
 
     fn make_segment(names: &[&str], change_id: &str, desc: &str) -> BookmarkSegment {
         BookmarkSegment {
@@ -893,6 +945,7 @@ mod tests {
             ],
             remote: "origin".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let output = plan.to_string();
@@ -934,13 +987,17 @@ mod tests {
             ],
             remote: "origin".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
         let jj = Jj::new(runner);
         let forge = MockForge::new();
+        let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        let result = execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         assert_eq!(result.stack_entries.len(), 2);
 
@@ -967,13 +1024,17 @@ mod tests {
             }],
             remote: "origin".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
         let jj = Jj::new(runner);
         let forge = MockForge::new();
+        let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         let updated = forge.updated_bases.lock().unwrap();
         assert_eq!(updated.len(), 1);
@@ -1007,13 +1068,17 @@ mod tests {
             ],
             remote: "origin".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
         let jj = Jj::new(runner);
         let forge = MockForge::new();
+        let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         let comments = forge.created_comments.lock().unwrap();
         // One stack comment per PR.
@@ -1025,6 +1090,8 @@ mod tests {
 
     #[tokio::test]
     async fn execute_updates_existing_stack_comments() {
+        let env = test_comment_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
         let existing_comment_body = format_stack_comment(
             &StackCommentData {
                 version: 0,
@@ -1034,8 +1101,25 @@ mod tests {
                     pr_number: 1,
                 }],
             },
-            0,
-        );
+            &StackCommentContext {
+                stack: vec![StackEntryContext {
+                    bookmark_name: "old".to_string(),
+                    pr_url: "https://example.com/1".to_string(),
+                    pr_number: 1,
+                    title: "old feature".to_string(),
+                    base: "main".to_string(),
+                    is_draft: false,
+                    position: 1,
+                    is_current: true,
+                }],
+                stack_size: 1,
+                default_branch: "main".to_string(),
+                current_bookmark: "old".to_string(),
+                stakk_url: "https://github.com/glennib/stakk".to_string(),
+            },
+            &tmpl,
+        )
+        .unwrap();
 
         let plan = SubmissionPlan {
             bookmark_plans: vec![BookmarkPlan {
@@ -1050,6 +1134,7 @@ mod tests {
             }],
             remote: "origin".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
@@ -1062,7 +1147,9 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         // Should have updated the existing comment, not created a new one.
         let created = forge.created_comments.lock().unwrap();
@@ -1100,13 +1187,17 @@ mod tests {
             ],
             remote: "my-remote".to_string(),
             draft: false,
+            default_branch: "main".to_string(),
         };
 
         let (runner, push_calls) = MockJjRunner::new();
         let jj = Jj::new(runner);
         let forge = MockForge::new();
+        let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         let calls = push_calls.lock().unwrap();
         assert_eq!(calls.len(), 2);
@@ -1129,6 +1220,7 @@ mod tests {
             }],
             remote: "origin".to_string(),
             draft: true,
+            default_branch: "main".to_string(),
         };
 
         let output = plan.to_string();
@@ -1153,13 +1245,17 @@ mod tests {
             }],
             remote: "origin".to_string(),
             draft: true,
+            default_branch: "main".to_string(),
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
         let jj = Jj::new(runner);
         let forge = MockForge::new();
+        let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge).await.unwrap();
+        execute_submission_plan(&plan, &jj, &forge, &env)
+            .await
+            .unwrap();
 
         let created = forge.created_prs.lock().unwrap();
         assert_eq!(created.len(), 1);


### PR DESCRIPTION
Replace hardcoded numbered-list stack comments with minijinja templates. Default template uses a clean list layout where raw PR URLs get GitHub's rich reference rendering (title, status badges). Custom templates supported via --template flag or STAKK_TEMPLATE env var.

- Add StackCommentContext/StackEntryContext for rich template context
- format_stack_comment now returns Result (user templates can fail)
- Metadata line always prepended programmatically, not in template
- Add TemplateRenderFailed (SubmitError) and TemplateLoadFailed (StakkError)
- Thread default_branch into SubmissionPlan for template rendering
- Add clap 'env' feature for STAKK_TEMPLATE env var support