### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9](https://github.com/glennib/stakk/compare/v0.2.8...v0.2.9) - 2026-03-09
+
+### Added
+
+- unwrap hard-wrapped markdown in PR bodies
+
+### Fixed
+
+- respect env vars when running without subcommand
+
+### Other
+
+- move gif
+- update gif
+
 ## [0.2.8](https://github.com/glennib/stakk/compare/v0.2.7...v0.2.8) - 2026-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,7 +2658,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 0.2.8 -> 0.2.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.9](https://github.com/glennib/stakk/compare/v0.2.8...v0.2.9) - 2026-03-09

### Added

- unwrap hard-wrapped markdown in PR bodies

### Fixed

- respect env vars when running without subcommand

### Other

- move gif
- update gif
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).