### PR TITLE
fix: respect env vars when running stakk without subcommand

### DIFF
--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -63,12 +63,9 @@ pub struct SubmitArgs {
 
 impl Default for SubmitArgs {
     fn default() -> Self {
-        Self {
-            bookmark: None,
-            dry_run: false,
-            draft: false,
-            remote: "origin".to_string(),
-            template: None,
-        }
+        let cmd = <Self as Args>::augment_args(clap::Command::new("submit"));
+        let matches = cmd.get_matches_from(std::iter::empty::<std::ffi::OsString>());
+        <Self as clap::FromArgMatches>::from_arg_matches(&matches)
+            .expect("default SubmitArgs should parse from empty args")
     }
 }


### PR DESCRIPTION
Hi ! Nice tool !
I'm submitting this small fix, I don't usually code in Rust but hopefully this is correct.

## Summary

Running `stakk` with no subcommand uses `SubmitArgs::default()`, which bypassed clap and hardcoded all field values. This meant `STAKK_DRAFT`, `STAKK_REMOTE`, and `STAKK_TEMPLATE` env vars were ignored unless the user explicitly ran `stakk submit`.

The fix delegates to clap in the `Default` impl via `augment_args` + `from_arg_matches`, so env vars and `default_value` attributes are processed identically to the subcommand path.

## Test plan

- Set `STAKK_DRAFT=true` and run `stakk` (no subcommand) — PR should be created as draft
- Run `stakk submit` — should behave the same as before
- Unset `STAKK_DRAFT` and run `stakk` — should default to non-draft