### PR TITLE
fix: respect env vars when running without subcommand

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,9 +11,13 @@ use crate::cli::submit::SubmitArgs;
 /// stakk — bridge Jujutsu bookmarks to GitHub stacked pull requests.
 #[derive(Debug, Parser)]
 #[command(version, about)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
+    /// Default submit arguments (used when no subcommand is given).
+    #[command(flatten)]
+    pub submit_args: SubmitArgs,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -60,15 +60,3 @@ pub struct SubmitArgs {
     #[arg(long, env = "STAKK_TEMPLATE", verbatim_doc_comment)]
     pub template: Option<String>,
 }
-
-impl Default for SubmitArgs {
-    fn default() -> Self {
-        Self {
-            bookmark: None,
-            dry_run: false,
-            draft: false,
-            remote: "origin".to_string(),
-            template: None,
-        }
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn run() -> Result<(), StakkError> {
             clap_complete::generate(shell, &mut Cli::command(), "stakk", &mut std::io::stdout());
         }
         None => {
-            submit_bookmark(&SubmitArgs::default()).await?;
+            submit_bookmark(&cli.submit_args).await?;
         }
     }
 


### PR DESCRIPTION
Flatten SubmitArgs onto Cli so clap parses env vars and flags at the top level. Previously the None arm used SubmitArgs::default(), which bypassed clap entirely and ignored environment variables.

This also enables top-level flags like `stakk --draft` as an alternative to `stakk submit --draft`.

Thank you @hugobally for bringing this to my attention and suggesting a fix.