### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/glennib/stakk/compare/v0.2.9...v1.0.0) - 2026-03-09
+
+### Highlights at 1.0
+
+- Automatic stack detection from jj change graph
+- Three-phase submission pipeline (analyze → plan → execute)
+- Interactive ratatui TUI for branch selection and bookmark assignment
+- Works without pre-existing bookmarks — creates them on-the-fly
+- Stack-awareness comments on every PR with customizable minijinja templates
+- Idempotent — re-running is always safe, existing PRs are updated
+- Dry-run mode to preview without touching GitHub
+- Draft PR support
+- PR titles and bodies from jj change descriptions
+- Environment variable configuration (`STAKK_REMOTE`, `STAKK_DRAFT`, `STAKK_TEMPLATE`)
+- Shell completions (bash, zsh, fish, elvish, powershell)
+- All VCS operations through jj — no direct git usage
+
+### Other
+
+- address clippy pedantic lints
+- add license texts (MIT, Apache-2.0)
+- add crates.io metadata (keywords, categories)
+- remove stale development documents
+
 ## [0.2.9](https://github.com/glennib/stakk/compare/v0.2.8...v0.2.9) - 2026-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "0.2.9"
+version = "1.0.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "0.2.9"
+version = "1.0.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION
## 🎉 stakk 1.0.0

First stable release.

* `stakk`: 0.2.9 → 1.0.0

### Highlights at 1.0

- Automatic stack detection from jj change graph
- Three-phase submission pipeline (analyze → plan → execute)
- Interactive ratatui TUI for branch selection and bookmark assignment
- Works without pre-existing bookmarks — creates them on-the-fly
- Stack-awareness comments on every PR with customizable minijinja templates
- Idempotent — re-running is always safe, existing PRs are updated
- Dry-run mode to preview without touching GitHub
- Draft PR support
- PR titles and bodies from jj change descriptions
- Environment variable configuration (STAKK_REMOTE, STAKK_DRAFT, STAKK_TEMPLATE)
- Shell completions (bash, zsh, fish, elvish, powershell)
- All VCS operations through jj — no direct git usage

### Changes since v0.2.9

- address clippy pedantic lints
- add license texts (MIT, Apache-2.0)
- add crates.io metadata (keywords, categories)
- remove stale development documents

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).