### PR TITLE
feat: add --experimental-suspend-auto-merge to guard base updates

### DIFF
--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -24,6 +24,12 @@ pub struct SubmitArgs {
     #[arg(long, default_value = "origin", env = "STAKK_REMOTE")]
     pub remote: String,
 
+    /// Temporarily disable auto-merge on PRs while updating their base
+    /// branches, then re-enable it. Prevents GitHub from auto-merging PRs
+    /// during stack reordering. Experimental.
+    #[arg(long, env = "STAKK_EXPERIMENTAL_SUSPEND_AUTO_MERGE")]
+    pub experimental_suspend_auto_merge: bool,
+
     /// Path to a custom minijinja template for stack comments.
     ///
     /// The template is rendered with minijinja and receives the following

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -4,10 +4,12 @@ use octocrab::Octocrab;
 use octocrab::models::CommentId;
 use octocrab::models::IssueState;
 
+use super::AutoMergeState;
 use super::Comment;
 use super::CreatePrParams;
 use super::Forge;
 use super::ForgeError;
+use super::MergeMethod;
 use super::PrState;
 use super::PullRequest;
 
@@ -37,6 +39,59 @@ impl GitHubForge {
             owner,
             repo,
         })
+    }
+}
+
+/// Minimal PR details fetched via the REST API.
+#[derive(serde::Deserialize)]
+struct PrDetails {
+    node_id: String,
+    auto_merge: Option<AutoMergeDetails>,
+}
+
+/// The `auto_merge` object from the GitHub REST API.
+#[derive(serde::Deserialize)]
+struct AutoMergeDetails {
+    merge_method: String,
+}
+
+/// Response shape for GraphQL mutations.
+#[derive(serde::Deserialize)]
+struct GraphQlResponse<T> {
+    #[expect(dead_code, reason = "we only need to check for errors")]
+    data: Option<T>,
+    errors: Option<Vec<GraphQlError>>,
+}
+
+#[derive(serde::Deserialize)]
+struct GraphQlError {
+    message: String,
+}
+
+#[derive(serde::Deserialize)]
+struct DisableAutoMergePayload {
+    #[expect(dead_code, reason = "needed to anchor the mutation response")]
+    #[serde(rename = "disablePullRequestAutoMerge")]
+    disable: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize)]
+struct EnableAutoMergePayload {
+    #[expect(dead_code, reason = "needed to anchor the mutation response")]
+    #[serde(rename = "enablePullRequestAutoMerge")]
+    enable: Option<serde_json::Value>,
+}
+
+impl GitHubForge {
+    /// Fetch the `node_id` and `auto_merge` state of a PR via the REST API.
+    async fn fetch_pr_details(&self, pr_number: u64) -> Result<PrDetails, ForgeError> {
+        let route = format!("/repos/{}/{}/pulls/{pr_number}", self.owner, self.repo);
+        let details: PrDetails = self
+            .client
+            .get(&route, None::<&()>)
+            .await
+            .map_err(map_octocrab_error)?;
+        Ok(details)
     }
 }
 
@@ -149,6 +204,69 @@ impl Forge for GitHubForge {
             .map_err(map_octocrab_error)?;
         Ok(())
     }
+
+    async fn get_auto_merge_state(
+        &self,
+        pr_number: u64,
+    ) -> Result<Option<AutoMergeState>, ForgeError> {
+        let details = self.fetch_pr_details(pr_number).await?;
+        Ok(details.auto_merge.map(|am| AutoMergeState {
+            merge_method: parse_merge_method(&am.merge_method),
+        }))
+    }
+
+    async fn suspend_auto_merge(&self, pr_number: u64) -> Result<(), ForgeError> {
+        let details = self.fetch_pr_details(pr_number).await?;
+        let query = format!(
+            r#"mutation {{ disablePullRequestAutoMerge(input: {{ pullRequestId: "{}" }}) {{ clientMutationId }} }}"#,
+            details.node_id,
+        );
+        let response: GraphQlResponse<DisableAutoMergePayload> = self
+            .client
+            .graphql(&serde_json::json!({ "query": query }))
+            .await
+            .map_err(map_octocrab_error)?;
+        if let Some(errors) = response.errors {
+            let message = errors
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(ForgeError::AutoMergeToggleFailed { pr_number, message });
+        }
+        Ok(())
+    }
+
+    async fn restore_auto_merge(
+        &self,
+        pr_number: u64,
+        method: MergeMethod,
+    ) -> Result<(), ForgeError> {
+        let details = self.fetch_pr_details(pr_number).await?;
+        let gql_method = match method {
+            MergeMethod::Merge => "MERGE",
+            MergeMethod::Squash => "SQUASH",
+            MergeMethod::Rebase => "REBASE",
+        };
+        let query = format!(
+            r#"mutation {{ enablePullRequestAutoMerge(input: {{ pullRequestId: "{}", mergeMethod: {gql_method} }}) {{ clientMutationId }} }}"#,
+            details.node_id,
+        );
+        let response: GraphQlResponse<EnableAutoMergePayload> = self
+            .client
+            .graphql(&serde_json::json!({ "query": query }))
+            .await
+            .map_err(map_octocrab_error)?;
+        if let Some(errors) = response.errors {
+            let message = errors
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(ForgeError::AutoMergeToggleFailed { pr_number, message });
+        }
+        Ok(())
+    }
 }
 
 fn map_octocrab_error(e: octocrab::Error) -> ForgeError {
@@ -172,6 +290,14 @@ fn map_octocrab_error(e: octocrab::Error) -> ForgeError {
     ForgeError::Api {
         message,
         source: Box::new(e),
+    }
+}
+
+fn parse_merge_method(method: &str) -> MergeMethod {
+    match method {
+        "squash" => MergeMethod::Squash,
+        "rebase" => MergeMethod::Rebase,
+        _ => MergeMethod::Merge,
     }
 }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -43,6 +43,27 @@ pub enum ForgeError {
         help("wait {retry_after_seconds}s and retry")
     )]
     RateLimited { retry_after_seconds: u64 },
+
+    #[error("failed to toggle auto-merge on PR #{pr_number}: {message}")]
+    #[diagnostic(
+        code(stakk::forge::auto_merge_toggle_failed),
+        help("you may need to re-enable auto-merge manually on the PR")
+    )]
+    AutoMergeToggleFailed { pr_number: u64, message: String },
+}
+
+/// The merge method used for a pull request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeMethod {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+/// Auto-merge state of a pull request.
+#[derive(Debug, Clone)]
+pub struct AutoMergeState {
+    pub merge_method: MergeMethod,
 }
 
 /// State of a pull request.
@@ -131,5 +152,24 @@ pub trait Forge: Send + Sync {
         &self,
         comment_id: u64,
         body: &str,
+    ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
+
+    /// Get the auto-merge state of a PR, if enabled.
+    fn get_auto_merge_state(
+        &self,
+        pr_number: u64,
+    ) -> impl std::future::Future<Output = Result<Option<AutoMergeState>, ForgeError>> + Send;
+
+    /// Disable auto-merge on a PR.
+    fn suspend_auto_merge(
+        &self,
+        pr_number: u64,
+    ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
+
+    /// Re-enable auto-merge on a PR with the given merge method.
+    fn restore_auto_merge(
+        &self,
+        pr_number: u64,
+        method: MergeMethod,
     ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,14 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
 
     // Phase 2: Plan.
     pb.set_message("Checking for existing pull requests...");
-    let plan = submit::create_submission_plan(&analysis, &forge, &remote_name, args.draft).await?;
+    let plan = submit::create_submission_plan(
+        &analysis,
+        &forge,
+        &remote_name,
+        args.draft,
+        args.experimental_suspend_auto_merge,
+    )
+    .await?;
 
     pb.finish_and_clear();
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -144,6 +144,8 @@ pub struct SubmissionPlan {
     pub draft: bool,
     /// The default branch name (e.g., "main").
     pub default_branch: String,
+    /// Whether to suspend auto-merge during base updates.
+    pub suspend_auto_merge: bool,
 }
 
 /// Phase 3 output: what was actually done.
@@ -241,6 +243,7 @@ pub async fn create_submission_plan<F: Forge>(
     forge: &F,
     remote: &str,
     draft: bool,
+    suspend_auto_merge: bool,
 ) -> Result<SubmissionPlan, SubmitError> {
     // Collect bookmark names for concurrent PR lookup.
     let bookmark_names: Vec<String> = analysis
@@ -311,6 +314,7 @@ pub async fn create_submission_plan<F: Forge>(
         remote: remote.to_string(),
         draft,
         default_branch: analysis.default_branch.clone(),
+        suspend_auto_merge,
     })
 }
 
@@ -388,8 +392,10 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     }
 
     // Step 2a: Concurrently update bases for existing PRs that need it.
-    pb.set_message("Updating PR bases...");
-    let base_update_futures: Vec<_> = plan
+    // If suspend_auto_merge is enabled, temporarily disable auto-merge on
+    // affected PRs to prevent GitHub from auto-merging during transient
+    // empty-diff states caused by base reordering.
+    let prs_needing_base_update: Vec<_> = plan
         .bookmark_plans
         .iter()
         .filter(|bp| bp.needs_base_update)
@@ -398,6 +404,40 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
                 .as_ref()
                 .map(|pr| (bp.bookmark_name.clone(), pr.number, bp.base.clone()))
         })
+        .collect();
+
+    // Suspend auto-merge on affected PRs before updating bases.
+    let mut suspended_auto_merge: Vec<(u64, crate::forge::MergeMethod)> = Vec::new();
+    if plan.suspend_auto_merge && !prs_needing_base_update.is_empty() {
+        pb.set_message("Checking auto-merge status...");
+        for &(_, pr_number, _) in &prs_needing_base_update {
+            match forge.get_auto_merge_state(pr_number).await {
+                Ok(Some(state)) => {
+                    pb.set_message(format!("Suspending auto-merge on PR #{pr_number}..."));
+                    match forge.suspend_auto_merge(pr_number).await {
+                        Ok(()) => {
+                            suspended_auto_merge.push((pr_number, state.merge_method));
+                        }
+                        Err(e) => {
+                            pb.println(format!(
+                                "  Warning: failed to suspend auto-merge on PR #{pr_number}: {e}"
+                            ));
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    pb.println(format!(
+                        "  Warning: failed to check auto-merge on PR #{pr_number}: {e}"
+                    ));
+                }
+            }
+        }
+    }
+
+    pb.set_message("Updating PR bases...");
+    let base_update_futures: Vec<_> = prs_needing_base_update
+        .into_iter()
         .map(|(name, number, base)| async move {
             forge.update_pr_base(number, &base).await.map_err(|source| {
                 SubmitError::BaseUpdateFailed {
@@ -410,6 +450,17 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     let base_results = futures::future::join_all(base_update_futures).await;
     for result in base_results {
         result?;
+    }
+
+    // Restore auto-merge on PRs that had it suspended.
+    for (pr_number, method) in &suspended_auto_merge {
+        pb.set_message(format!("Restoring auto-merge on PR #{pr_number}..."));
+        if let Err(e) = forge.restore_auto_merge(*pr_number, *method).await {
+            pb.println(format!(
+                "  Warning: failed to restore auto-merge on PR #{pr_number}: {e} — you may need \
+                 to re-enable it manually"
+            ));
+        }
     }
 
     // Step 2b: Create new PRs sequentially (base branch must exist first).
@@ -708,6 +759,25 @@ mod tests {
                 .push((comment_id, body.to_string()));
             async { Ok(()) }
         }
+
+        async fn get_auto_merge_state(
+            &self,
+            _pr_number: u64,
+        ) -> Result<Option<crate::forge::AutoMergeState>, ForgeError> {
+            Ok(None)
+        }
+
+        async fn suspend_auto_merge(&self, _pr_number: u64) -> Result<(), ForgeError> {
+            Ok(())
+        }
+
+        async fn restore_auto_merge(
+            &self,
+            _pr_number: u64,
+            _method: crate::forge::MergeMethod,
+        ) -> Result<(), ForgeError> {
+            Ok(())
+        }
     }
 
     // -- Mock JjRunner --
@@ -849,7 +919,7 @@ mod tests {
         };
 
         let forge = MockForge::new();
-        let plan = create_submission_plan(&analysis, &forge, "origin", false)
+        let plan = create_submission_plan(&analysis, &forge, "origin", false, false)
             .await
             .unwrap();
 
@@ -874,7 +944,7 @@ mod tests {
 
         let forge = MockForge::new().with_existing_pr("feat-a", make_pr(42, "feat-a", "main"));
 
-        let plan = create_submission_plan(&analysis, &forge, "origin", false)
+        let plan = create_submission_plan(&analysis, &forge, "origin", false, false)
             .await
             .unwrap();
 
@@ -901,7 +971,7 @@ mod tests {
             .with_existing_pr("feat-a", make_pr(10, "feat-a", "main"))
             .with_existing_pr("feat-b", make_pr(11, "feat-b", "main"));
 
-        let plan = create_submission_plan(&analysis, &forge, "origin", false)
+        let plan = create_submission_plan(&analysis, &forge, "origin", false, false)
             .await
             .unwrap();
 
@@ -927,7 +997,7 @@ mod tests {
 
         let forge = MockForge::new().with_existing_pr("feat-a", make_pr(10, "feat-a", "main"));
 
-        let plan = create_submission_plan(&analysis, &forge, "origin", false)
+        let plan = create_submission_plan(&analysis, &forge, "origin", false, false)
             .await
             .unwrap();
 
@@ -963,6 +1033,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let output = plan.to_string();
@@ -1005,6 +1076,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
@@ -1042,6 +1114,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
@@ -1086,6 +1159,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
@@ -1152,6 +1226,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, _push_calls) = MockJjRunner::new();
@@ -1205,6 +1280,7 @@ mod tests {
             remote: "my-remote".to_string(),
             draft: false,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, push_calls) = MockJjRunner::new();
@@ -1238,6 +1314,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: true,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let output = plan.to_string();
@@ -1263,6 +1340,7 @@ mod tests {
             remote: "origin".to_string(),
             draft: true,
             default_branch: "main".to_string(),
+            suspend_auto_merge: false,
         };
 
         let (runner, _push_calls) = MockJjRunner::new();


### PR DESCRIPTION
When reordering commits in a jj stack and re-submitting, GitHub auto-merge can trigger on transient empty-diff states during concurrent base updates, closing PRs unexpectedly. This adds an experimental flag that temporarily disables auto-merge on affected PRs while their bases are updated, then re-enables it afterward.

- Add MergeMethod, AutoMergeState types and Forge trait methods
- Implement via GitHub REST (PR details) + GraphQL (toggle mutations)
- Suspend before base updates, restore after (warnings on failure)
- CLI: --experimental-suspend-auto-merge / STAKK_EXPERIMENTAL_SUSPEND_AUTO_MERGE

Closes #35