### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/glennib/stakk/compare/v1.1.0...v1.2.0) - 2026-03-13
+
+### Added
+
+- show short change ID prefix in TUI selection screens
+
+### Other
+
+- Merge pull request #41 from glennib/renovate/clap-4.x-lockfile
+- *(deps)* update rust crate clap_complete to v4.6.0
+- remove jack-test from claude.md
+
 ## [1.1.0](https://github.com/glennib/stakk/compare/v1.0.0...v1.1.0) - 2026-03-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.1.0 -> 1.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0](https://github.com/glennib/stakk/compare/v1.1.0...v1.2.0) - 2026-03-13

### Added

- show short change ID prefix in TUI selection screens

### Other

- Merge pull request #41 from glennib/renovate/clap-4.x-lockfile
- *(deps)* update rust crate clap_complete to v4.6.0
- remove jack-test from claude.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).