### PR TITLE
feat(select): experimental custom bookmark name generation via external command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities", "development-tools"]
 pedantic = { level = "warn", priority = -1 }
 too_many_lines = "allow"
 doc_markdown = "allow"
+doc_link_with_quotes = "allow"
 
 [[bin]]
 name = "stakk"
@@ -35,7 +36,7 @@ ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "process"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "io-util"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -58,4 +58,84 @@ pub struct SubmitArgs {
     )]
     #[arg(long, env = "STAKK_TEMPLATE", verbatim_doc_comment)]
     pub template: Option<String>,
+
+    /// [EXPERIMENTAL] Shell command for generating custom bookmark names.
+    ///
+    /// This feature is experimental and may change or be removed in future
+    /// releases.
+    ///
+    /// The command is invoked via `sh -c <command>` (Unix) or `cmd /C
+    /// <command>` (Windows). It receives a JSON object on stdin describing
+    /// a single segment of commits and must print exactly one bookmark name
+    /// to stdout (plain text, leading/trailing whitespace is trimmed).
+    ///
+    /// The custom name appears as an additional [*] toggle option in the
+    /// TUI, after the existing bookmarks [x] and generated name [+].
+    ///
+    /// JSON input schema:
+    ///
+    ///   rules               — object with validation constraints
+    ///     .max_length       — integer, max name length in bytes (255)
+    ///     .disallowed_chars — string of forbidden characters
+    ///   commits             — array of commit objects, ordered
+    ///                         trunk-to-tip (oldest first); the last
+    ///                         element is the tip being bookmarked
+    ///
+    /// Each commit object:
+    ///
+    ///   commit_id           — full hex commit hash (string)
+    ///   change_id           — full jj change ID (string)
+    ///   short_change_id     — shortest unique change ID prefix (string)
+    ///   description         — full commit message incl. body (string)
+    ///   author              — object with name, email, timestamp
+    ///     .name             — author name (string)
+    ///     .email            — author email (string)
+    ///     .timestamp        — commit timestamp (string, ISO 8601)
+    ///   files               — array of file paths changed by this commit
+    ///                         (array of strings, e.g. ["src/main.rs"])
+    ///
+    /// Minimal example (two commits):
+    ///
+    ///   {
+    ///     "rules": {
+    ///       "max_length": 255,
+    ///       "disallowed_chars": " ~^:?*[\\"
+    ///     },
+    ///     "commits": [
+    ///       {
+    ///         "commit_id": "aaa111",
+    ///         "change_id": "abc123",
+    ///         "short_change_id": "abc",
+    ///         "description": "add login page",
+    ///         "author": {
+    ///           "name": "Jo",
+    ///           "email": "jo@example.com",
+    ///           "timestamp": "2026-03-01T12:00:00+01:00"
+    ///         },
+    ///         "files": ["src/login.rs"]
+    ///       },
+    ///       {
+    ///         "commit_id": "bbb222",
+    ///         "change_id": "def456",
+    ///         "short_change_id": "def",
+    ///         "description": "style login form",
+    ///         "author": {
+    ///           "name": "Jo",
+    ///           "email": "jo@example.com",
+    ///           "timestamp": "2026-03-01T13:00:00+01:00"
+    ///         },
+    ///         "files": ["src/login.rs", "styles/login.css"]
+    ///       }
+    ///     ]
+    ///   }
+    ///
+    /// Expected stdout (one line, trimmed):
+    ///
+    ///   login-page
+    #[arg(
+        long = "experimental-bookmark-command",
+        env = "STAKK_EXPERIMENTAL_BOOKMARK_COMMAND",
+        verbatim_doc_comment
+    )]
+    pub bookmark_command: Option<String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use crate::auth::AuthError;
 use crate::forge::ForgeError;
 use crate::jj::JjError;
+use crate::select::bookmark_gen::BookmarkGenError;
 use crate::submit::SubmitError;
 
 /// Errors that can occur in stakk.
@@ -28,6 +29,11 @@ pub enum StakkError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Submit(#[from] SubmitError),
+
+    /// An error from the bookmark name generation command.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    BookmarkGen(#[from] BookmarkGenError),
 
     /// The specified remote is not a GitHub URL.
     #[error("remote '{name}' is not a GitHub URL: {url}")]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -125,7 +125,18 @@ pub async fn build_change_graph<R: JjRunner>(
         .cloned()
         .collect();
 
-    let stacks = group_segments_into_stacks(&stack_leaves, &adjacency_list, &segments);
+    let mut stacks = group_segments_into_stacks(&stack_leaves, &adjacency_list, &segments);
+
+    // Pre-fetch file lists for all commits concurrently.
+    fetch_file_lists(jj, &mut stacks).await?;
+    // Also update the segments map so it stays in sync.
+    for stack in &stacks {
+        for segment in &stack.segments {
+            if let Some(seg) = segments.get_mut(&segment.change_id) {
+                *seg = segment.clone();
+            }
+        }
+    }
 
     Ok(ChangeGraph {
         adjacency_list,
@@ -273,8 +284,9 @@ async fn traverse_and_discover_segments<R: JjRunner>(
                     commit_id: change.commit_id.clone(),
                     change_id: change.change_id.clone(),
                     description: change.description.clone(),
-                    author_name: change.author.name.clone(),
+                    author: change.author.clone(),
                     short_change_id: change.short_change_id.clone(),
+                    files: vec![],
                 });
             }
         }
@@ -296,6 +308,37 @@ async fn traverse_and_discover_segments<R: JjRunner>(
         already_seen_change_id,
         excluded: false,
     })
+}
+
+/// Pre-fetch file lists for all commits in all stacks concurrently.
+async fn fetch_file_lists<R: JjRunner>(
+    jj: &Jj<R>,
+    stacks: &mut [BranchStack],
+) -> Result<(), StakkError> {
+    // Collect all (stack_idx, seg_idx, commit_idx, commit_id) tuples.
+    let mut tasks: Vec<(usize, usize, usize, String)> = Vec::new();
+    for (si, stack) in stacks.iter().enumerate() {
+        for (sgi, segment) in stack.segments.iter().enumerate() {
+            for (ci, commit) in segment.commits.iter().enumerate() {
+                if commit.files.is_empty() {
+                    tasks.push((si, sgi, ci, commit.commit_id.clone()));
+                }
+            }
+        }
+    }
+
+    let futures: Vec<_> = tasks
+        .iter()
+        .map(|(_, _, _, commit_id)| jj.get_diff_files(commit_id))
+        .collect();
+
+    let results = futures::future::join_all(futures).await;
+
+    for ((si, sgi, ci, _), result) in tasks.iter().zip(results) {
+        stacks[*si].segments[*sgi].commits[*ci].files = result?;
+    }
+
+    Ok(())
 }
 
 /// Walk from each leaf to root via the adjacency list, producing one
@@ -440,6 +483,9 @@ mod tests {
     async fn linear_stack() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     // Return two bookmarks.
                     let lines = [
@@ -497,6 +543,9 @@ mod tests {
     async fn branching_shared_root() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_b", "c_b", "ch_b"),
@@ -563,6 +612,9 @@ mod tests {
     async fn merge_commit_excluded() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_merge", "c_merge", "ch_merge"));
                 }
@@ -605,6 +657,9 @@ mod tests {
     async fn merge_taint_propagation() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_b", "c_b", "ch_b"),
@@ -652,6 +707,9 @@ mod tests {
     async fn taint_from_previous_traversal() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         // bm_merge will be processed first, tainting ch_merge.
@@ -704,6 +762,9 @@ mod tests {
     async fn multiple_bookmarks_same_change() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_a", "c_x", "ch_x"),
@@ -750,6 +811,9 @@ mod tests {
     async fn no_bookmarks() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(String::new());
                 }
@@ -784,6 +848,9 @@ mod tests {
     async fn multi_commit_segment() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_b", "c4", "ch_b"),
@@ -849,6 +916,9 @@ mod tests {
     async fn already_collected_early_stop() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_b", "c_b", "ch_b"),
@@ -911,6 +981,9 @@ mod tests {
     async fn topological_sort_linear() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_c", "c_c", "ch_c"),
@@ -957,6 +1030,9 @@ mod tests {
     async fn topological_sort_branching() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     let lines = [
                         bookmark_json("bm_b", "c_b", "ch_b"),
@@ -1013,6 +1089,9 @@ mod tests {
     async fn single_bookmark_single_commit() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_x", "c_x", "ch_x"));
                 }
@@ -1053,6 +1132,9 @@ mod tests {
     async fn segment_commit_metadata() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("feat", "c1", "ch1"));
                 }
@@ -1079,7 +1161,7 @@ mod tests {
         assert_eq!(seg.commits[0].commit_id, "c1");
         assert_eq!(seg.commits[0].change_id, "ch1");
         assert_eq!(seg.commits[0].description, "desc c1");
-        assert_eq!(seg.commits[0].author_name, "T");
+        assert_eq!(seg.commits[0].author.name, "T");
     }
 
     /// `group_segments_into_stacks` is deterministic (sorted by leaf
@@ -1121,6 +1203,9 @@ mod tests {
     async fn non_user_bookmarks_filtered_from_segment() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     // Only bm_user belongs to the user.
                     return Ok(bookmark_json("bm_user", "c_x", "ch_x"));
@@ -1167,6 +1252,9 @@ mod tests {
     async fn only_non_user_bookmarks_no_segment_boundary() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_user", "c_user", "ch_user"));
                 }
@@ -1221,6 +1309,9 @@ mod tests {
     async fn unbookmarked_head_discovered() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_a", "c_a", "ch_a"));
                 }
@@ -1284,6 +1375,9 @@ mod tests {
     async fn unbookmarked_head_at_bookmarked_commit_skipped() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_a", "c_a", "ch_a"));
                 }
@@ -1325,6 +1419,9 @@ mod tests {
     async fn multiple_unbookmarked_heads() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_a", "c_a", "ch_a"));
                 }
@@ -1406,6 +1503,9 @@ mod tests {
     async fn unbookmarked_head_with_bookmarked_ancestor() {
         let runner = MockJjRunner {
             handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
                 if args[0] == "bookmark" {
                     return Ok(bookmark_json("bm_mid", "c_mid", "ch_mid"));
                 }

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+use crate::jj::types::Signature;
+
 /// A commit within a bookmark segment, carrying metadata needed for display
 /// and later PR creation.
 #[derive(Debug, Clone)]
@@ -10,13 +12,11 @@ pub struct SegmentCommit {
     pub commit_id: String,
     pub change_id: String,
     pub description: String,
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used in later milestones for PR creation")
-    )]
-    pub author_name: String,
+    pub author: Signature,
     /// Shortest unique change ID prefix (from jj).
     pub short_change_id: String,
+    /// Files changed by this commit.
+    pub files: Vec<String>,
 }
 
 /// A group of consecutive commits belonging to one or more bookmarks.

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -204,6 +204,21 @@ impl<R: JjRunner> Jj<R> {
         parse_log_entries(&output)
     }
 
+    /// Get the list of files changed by a specific commit.
+    pub async fn get_diff_files(&self, commit_id: &str) -> Result<Vec<String>, JjError> {
+        let output = self
+            .runner
+            .run_jj(&["diff", "-r", commit_id, "--name-only"])
+            .await?;
+
+        Ok(output
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect())
+    }
+
     /// Fetch from all remotes.
     #[expect(
         dead_code,

--- a/src/jj/types.rs
+++ b/src/jj/types.rs
@@ -15,12 +15,10 @@ pub struct CommitData {
 }
 
 /// Author/committer signature.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Signature {
     pub name: String,
-    #[expect(dead_code, reason = "deserialized for completeness, used later")]
     pub email: String,
-    #[expect(dead_code, reason = "deserialized for completeness, used later")]
     pub timestamp: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,10 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
 
     let (bookmark, change_graph) = match &args.bookmark {
         Some(name) => (name.clone(), change_graph),
-        None => match select::resolve_bookmark_interactively(&change_graph)? {
+        None => match select::resolve_bookmark_interactively(
+            &change_graph,
+            args.bookmark_command.as_deref(),
+        )? {
             Some(result) => {
                 // Create any new bookmarks that were assigned.
                 let has_new = result.assignments.iter().any(|a| a.is_new);

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -4,6 +4,9 @@
 //! bookmarks). Uses ratatui's inline viewport (not fullscreen).
 
 use std::io;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
 
 use crossterm::event;
 use ratatui::Terminal;
@@ -19,8 +22,13 @@ use ratatui::text::Span;
 use ratatui::widgets::Widget;
 
 use super::SelectionResult;
+use super::bookmark_gen;
+use super::bookmark_gen::BookmarkGenError;
+use super::bookmark_gen::BookmarkNameCache;
 use super::bookmark_widget::BookmarkAssignmentState;
 use super::bookmark_widget::BookmarkWidget;
+use super::bookmark_widget::RowState;
+use super::bookmark_widget::SelectionError;
 use super::bookmark_widget::bookmark_help_line;
 use super::event::Action;
 use super::event::map_event;
@@ -43,12 +51,23 @@ enum Screen {
     BookmarkAssignment,
 }
 
+/// A pending bookmark command: row index + oneshot receiver for the result.
+struct PendingCommand {
+    row_idx: usize,
+    rx: tokio::sync::oneshot::Receiver<Result<String, BookmarkGenError>>,
+}
+
 /// Run the TUI selection flow.
 ///
 /// Returns `Ok(Some(result))` on successful selection, `Ok(None)` if the user
 /// cancels from the graph view.
-pub fn run_tui(graph: &ChangeGraph) -> Result<Option<SelectionResult>, StakkError> {
+pub fn run_tui(
+    graph: &ChangeGraph,
+    bookmark_command: Option<&str>,
+) -> Result<Option<SelectionResult>, StakkError> {
     let layout = build_layout(graph);
+    let has_bookmark_command = bookmark_command.is_some();
+    let bookmark_cache = Arc::new(Mutex::new(BookmarkNameCache::new()));
 
     if layout.leaf_nodes().is_empty() {
         eprintln!("No selectable branches found.");
@@ -80,6 +99,9 @@ pub fn run_tui(graph: &ChangeGraph) -> Result<Option<SelectionResult>, StakkErro
         &mut graph_state,
         &mut bookmark_state,
         &mut screen,
+        has_bookmark_command,
+        bookmark_command,
+        &bookmark_cache,
     );
 
     // Clear the inline viewport so subsequent output doesn't interleave with TUI
@@ -96,14 +118,35 @@ pub fn run_tui(graph: &ChangeGraph) -> Result<Option<SelectionResult>, StakkErro
     result
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "TUI event loop needs all context threaded through"
+)]
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stderr>>,
     layout: &GraphLayout,
     graph_state: &mut GraphViewState,
     bookmark_state: &mut Option<BookmarkAssignmentState>,
     screen: &mut Screen,
+    has_bookmark_command: bool,
+    bookmark_command: Option<&str>,
+    bookmark_cache: &Arc<Mutex<BookmarkNameCache>>,
 ) -> Result<Option<SelectionResult>, StakkError> {
+    let mut pending: Vec<PendingCommand> = Vec::new();
+    let mut spinner_tick: usize = 0;
+    let mut error_message: Option<String> = None;
+
     loop {
+        // Check for completed background commands before drawing.
+        drain_completed(&mut pending, bookmark_state);
+
+        let has_pending = !pending.is_empty();
+
+        // Update spinner state for loading indicators.
+        if has_pending {
+            spinner_tick = spinner_tick.wrapping_add(1);
+        }
+
         // Draw.
         terminal.draw(|frame| {
             let area = frame.area();
@@ -132,21 +175,39 @@ fn run_event_loop(
                 Screen::BookmarkAssignment => {
                     if let Some(bm_state) = bookmark_state.as_ref() {
                         render_bookmark_screen(
-                            frame, chunks[0], chunks[1], chunks[2], chunks[3], bm_state,
+                            frame,
+                            chunks[0],
+                            chunks[1],
+                            chunks[2],
+                            chunks[3],
+                            bm_state,
+                            spinner_tick,
+                            bookmark_command,
+                            error_message.as_deref(),
                         );
                     }
                 }
             }
         })?;
 
-        // Handle input.
+        // Poll for input with a short timeout so we can re-render spinner
+        // frames while commands are in-flight.
+        let poll_timeout = if has_pending {
+            Duration::from_millis(80)
+        } else {
+            Duration::from_secs(60)
+        };
+
+        if !event::poll(poll_timeout)? {
+            continue; // No input — re-render (updates spinner).
+        }
+
         let ev = event::read()?;
         let action = map_event(&ev);
 
         match screen {
             Screen::GraphView => match action {
                 Action::Left => {
-                    // ←/h: move selection to a lower column (lower index).
                     let leaves = layout.leaf_nodes();
                     if graph_state.selected_leaf > 0 {
                         graph_state.selected_leaf -= 1;
@@ -155,7 +216,6 @@ fn run_event_loop(
                     }
                 }
                 Action::Right => {
-                    // →/l: move selection to a higher column (higher index).
                     let leaves = layout.leaf_nodes();
                     if graph_state.selected_leaf < leaves.len().saturating_sub(1) {
                         graph_state.selected_leaf += 1;
@@ -167,7 +227,10 @@ fn run_event_loop(
                     let leaves = layout.leaf_nodes();
                     if let Some(leaf) = leaves.get(graph_state.selected_leaf) {
                         let path = path_to_leaf(layout, leaf.row, leaf.col);
-                        *bookmark_state = Some(BookmarkAssignmentState::from_path(&path));
+                        *bookmark_state = Some(BookmarkAssignmentState::from_path(
+                            &path,
+                            has_bookmark_command,
+                        ));
                         *screen = Screen::BookmarkAssignment;
                     }
                 }
@@ -191,21 +254,34 @@ fn run_event_loop(
                     }
                 }
                 Action::Toggle => {
+                    error_message = None;
                     if let Some(state) = bookmark_state {
                         state.toggle_current();
+
+                        if let Some(cmd) = bookmark_command {
+                            fire_pending_commands(state, cmd, bookmark_cache, &mut pending);
+                        }
                     }
                 }
                 Action::Select => {
                     if let Some(state) = bookmark_state.as_ref() {
-                        let assignments = state.build_result();
-                        if assignments.is_empty() {
-                            // Nothing selected — don't proceed.
-                            continue;
+                        match state.build_result() {
+                            Ok(assignments) if assignments.is_empty() => {}
+                            Ok(assignments) => {
+                                return Ok(Some(SelectionResult { assignments }));
+                            }
+                            Err(SelectionError::DuplicateName(name)) => {
+                                error_message = Some(format!("Duplicate bookmark name: {name}"));
+                            }
+                            Err(SelectionError::StillLoading) => {
+                                error_message =
+                                    Some("A bookmark name is still loading…".to_string());
+                            }
                         }
-                        return Ok(Some(SelectionResult { assignments }));
                     }
                 }
                 Action::Cancel => {
+                    pending.clear();
                     *screen = Screen::GraphView;
                     *bookmark_state = None;
                 }
@@ -214,6 +290,146 @@ fn run_event_loop(
                 }
                 Action::Left | Action::Right | Action::None => {}
             },
+        }
+    }
+}
+
+/// Spawn background tasks for any `UseCustom("")` sentinel rows. Also detects
+/// invalidated `UseCustom` rows whose dynamic segment changed.
+fn fire_pending_commands(
+    state: &mut BookmarkAssignmentState,
+    command: &str,
+    cache: &Arc<Mutex<BookmarkNameCache>>,
+    pending: &mut Vec<PendingCommand>,
+) {
+    let cache_guard = cache.lock().expect("cache mutex poisoned");
+
+    let needs_fire: Vec<usize> = state
+        .rows
+        .iter()
+        .enumerate()
+        .filter_map(|(i, row)| match &row.state {
+            RowState::UseCustom(name) if name.is_empty() => Some(i),
+            RowState::UseCustom(_) => {
+                // Check if the dynamic segment changed.
+                let segment = bookmark_gen::dynamic_segment_commits(&state.rows, i);
+                let key = bookmark_gen::cache_key(&segment);
+                if let Some(cached_name) = cache_guard.get(&key)
+                    && row.custom_name.as_ref() == Some(cached_name)
+                {
+                    return None;
+                }
+                Some(i)
+            }
+            _ => None,
+        })
+        .collect();
+
+    if needs_fire.is_empty() {
+        return;
+    }
+
+    let handle = tokio::runtime::Handle::current();
+
+    for idx in &needs_fire {
+        let idx = *idx;
+
+        // Remove any existing pending command for this row.
+        pending.retain(|p| p.row_idx != idx);
+
+        // Check cache first (synchronous hit — e.g. from an orphaned task).
+        let segment = bookmark_gen::dynamic_segment_commits(&state.rows, idx);
+        let key = bookmark_gen::cache_key(&segment);
+        if let Some(cached_name) = cache_guard.get(&key) {
+            state.rows[idx].custom_name = Some(cached_name.clone());
+            state.rows[idx].state = RowState::UseCustom(cached_name.clone());
+            continue;
+        }
+
+        // Build the input before spawning (we need to read from state).
+        let input = bookmark_gen::build_segment_input(&segment);
+        let json = serde_json::to_string(&input).expect("SegmentInput is always serializable");
+        let cmd = command.to_string();
+        let task_cache = Arc::clone(cache);
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        handle.spawn(async move {
+            let result = bookmark_gen::run_command(&cmd, &json).await;
+
+            // On success, validate and cache — even if the receiver is gone
+            // (orphaned task), the result is preserved for later lookups.
+            if let Ok(ref name) = result
+                && bookmark_gen::validate_bookmark_name(name).is_ok()
+                && let Ok(mut guard) = task_cache.lock()
+            {
+                guard.insert(key, name.clone());
+            }
+
+            let _ = tx.send(result);
+        });
+
+        // Set loading sentinel.
+        state.rows[idx].state = RowState::UseCustom(String::new());
+
+        pending.push(PendingCommand { row_idx: idx, rx });
+    }
+}
+
+/// Drain completed background commands and update row state.
+///
+/// The spawned tasks already validate and cache on success, so this function
+/// only updates the TUI row state from the result.
+fn drain_completed(
+    pending: &mut Vec<PendingCommand>,
+    bookmark_state: &mut Option<BookmarkAssignmentState>,
+) {
+    let Some(state) = bookmark_state.as_mut() else {
+        pending.clear();
+        return;
+    };
+
+    let mut completed = Vec::new();
+    for (i, cmd) in pending.iter_mut().enumerate() {
+        match cmd.rx.try_recv() {
+            Ok(result) => completed.push((i, cmd.row_idx, result)),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {} // Still running.
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                // Sender dropped without sending — treat as error.
+                completed.push((
+                    i,
+                    cmd.row_idx,
+                    Err(BookmarkGenError::EmptyOutput {
+                        command: "(dropped)".to_string(),
+                    }),
+                ));
+            }
+        }
+    }
+
+    // Process in reverse index order so removal doesn't shift indices.
+    completed.sort_by(|a, b| b.0.cmp(&a.0));
+    for (pending_idx, row_idx, result) in completed {
+        pending.remove(pending_idx);
+
+        if row_idx >= state.rows.len() {
+            continue;
+        }
+
+        match result {
+            Ok(name) => {
+                if bookmark_gen::validate_bookmark_name(&name).is_ok() {
+                    state.rows[row_idx].custom_name = Some(name.clone());
+                    state.rows[row_idx].state = RowState::UseCustom(name);
+                } else {
+                    state.rows[row_idx].custom_name = None;
+                    state.rows[row_idx].state = RowState::Unchecked;
+                }
+            }
+            Err(_e) => {
+                state.rows[row_idx].custom_name = None;
+                state.rows[row_idx].state = RowState::Unchecked;
+            }
         }
     }
 }
@@ -247,6 +463,10 @@ fn render_graph_screen(
     frame.render_widget(graph_help_line(), help_area);
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "render function needs all layout areas plus state"
+)]
 fn render_bookmark_screen(
     frame: &mut ratatui::Frame,
     title_area: Rect,
@@ -254,6 +474,9 @@ fn render_bookmark_screen(
     content_area: Rect,
     help_area: Rect,
     state: &BookmarkAssignmentState,
+    spinner_tick: usize,
+    bookmark_command: Option<&str>,
+    error_message: Option<&str>,
 ) {
     let title = Line::from(vec![Span::styled(
         " Assign bookmarks to commits",
@@ -263,13 +486,20 @@ fn render_bookmark_screen(
     )]);
     frame.render_widget(title, title_area);
 
-    let subtitle = Line::from(vec![Span::styled(
-        " Checked commits ([x]/[+]) will be pushed and have PRs created or updated.",
-        Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
-    )]);
+    let subtitle = if let Some(err) = error_message {
+        Line::from(vec![Span::styled(
+            format!(" {err}"),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )])
+    } else {
+        Line::from(vec![Span::styled(
+            " Checked commits ([x]/[+]/[*]) will be pushed and have PRs created or updated.",
+            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+        )])
+    };
     frame.render_widget(subtitle, subtitle_area);
 
-    let widget = BookmarkWidget::new(state);
+    let widget = BookmarkWidget::new(state, spinner_tick, bookmark_command);
     widget.render(content_area, frame.buffer_mut());
 
     frame.render_widget(bookmark_help_line(), help_area);

--- a/src/select/bookmark_gen.rs
+++ b/src/select/bookmark_gen.rs
@@ -1,0 +1,568 @@
+//! Custom bookmark name generation via external shell command.
+//!
+//! Provides validation, caching, and async command invocation for custom
+//! bookmark names. The command receives a JSON segment description on stdin
+//! and returns a single bookmark name on stdout.
+
+use std::collections::HashMap;
+
+use miette::Diagnostic;
+use serde::Serialize;
+use thiserror::Error;
+
+use super::bookmark_widget::BookmarkRow;
+
+/// Errors from the bookmark name generation command.
+#[derive(Debug, Error, Diagnostic)]
+pub enum BookmarkGenError {
+    /// The command exited with a non-zero status.
+    #[error("bookmark command failed (exit code {exit_code}): {stderr}")]
+    #[diagnostic(
+        code(stakk::bookmark_command::failed),
+        help("check your bookmark command for errors")
+    )]
+    CommandFailed { exit_code: i32, stderr: String },
+
+    /// The command was not found.
+    #[error("bookmark command not found: {command}")]
+    #[diagnostic(
+        code(stakk::bookmark_command::not_found),
+        help("check that the command exists and is on your PATH")
+    )]
+    NotFound {
+        command: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The command produced no output.
+    #[error("bookmark command produced empty output: {command}")]
+    #[diagnostic(
+        code(stakk::bookmark_command::empty_output),
+        help("the command must print a single bookmark name to stdout")
+    )]
+    EmptyOutput { command: String },
+
+    /// The generated name is invalid.
+    #[error("invalid bookmark name {name:?}: {reason}")]
+    #[diagnostic(
+        code(stakk::bookmark_command::invalid_name),
+        help("bookmark names must be valid git refs")
+    )]
+    InvalidName { name: String, reason: String },
+
+    /// An I/O error.
+    #[error("bookmark command I/O error: {0}")]
+    #[diagnostic(code(stakk::bookmark_command::io))]
+    Io(#[from] std::io::Error),
+}
+
+/// JSON protocol: top-level object sent to the command on stdin.
+#[derive(Debug, Serialize)]
+pub(super) struct SegmentInput {
+    rules: RulesInput,
+    commits: Vec<CommitInput>,
+}
+
+/// Validation rules sent to the command.
+#[derive(Debug, Serialize)]
+struct RulesInput {
+    max_length: usize,
+    disallowed_chars: String,
+}
+
+/// A commit in the segment, sent to the command on stdin.
+#[derive(Debug, Serialize)]
+struct CommitInput {
+    commit_id: String,
+    change_id: String,
+    short_change_id: String,
+    description: String,
+    author: AuthorInput,
+    files: Vec<String>,
+}
+
+/// Author info for a commit.
+#[derive(Debug, Serialize)]
+struct AuthorInput {
+    name: String,
+    email: String,
+    timestamp: String,
+}
+
+/// Maximum bookmark name length in bytes.
+const MAX_BOOKMARK_LENGTH: usize = 255;
+
+/// Characters disallowed in bookmark names.
+const DISALLOWED_CHARS: &str = " ~^:?*[\\";
+
+/// Cache for custom bookmark names, keyed by ordered commit IDs.
+pub type BookmarkNameCache = HashMap<Vec<String>, String>;
+
+/// Generate the default `stakk-<change_id[:12]>` bookmark name.
+pub fn default_bookmark_name(change_id: &str) -> String {
+    let prefix = if change_id.len() >= 12 {
+        &change_id[..12]
+    } else {
+        change_id
+    };
+    format!("stakk-{prefix}")
+}
+
+/// Validate a bookmark name against git ref rules.
+pub fn validate_bookmark_name(name: &str) -> Result<(), BookmarkGenError> {
+    if name.is_empty() {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: "name is empty".to_string(),
+        });
+    }
+    if name.len() > MAX_BOOKMARK_LENGTH {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: format!("exceeds maximum length of {MAX_BOOKMARK_LENGTH} bytes"),
+        });
+    }
+    if name.starts_with('-') || name.starts_with('.') {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: format!("cannot start with {:?}", &name[..1]),
+        });
+    }
+    if name.ends_with('.') {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: "cannot end with '.'".to_string(),
+        });
+    }
+    #[expect(
+        clippy::case_sensitive_file_extension_comparisons,
+        reason = "git ref rule, not a file extension"
+    )]
+    if name.ends_with(".lock") {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: "cannot end with '.lock'".to_string(),
+        });
+    }
+    if name.contains("..") {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: "cannot contain '..'".to_string(),
+        });
+    }
+    if name.contains("@{") {
+        return Err(BookmarkGenError::InvalidName {
+            name: name.to_string(),
+            reason: "cannot contain '@{'".to_string(),
+        });
+    }
+    for ch in name.chars() {
+        if ch.is_ascii_control() || DISALLOWED_CHARS.contains(ch) {
+            return Err(BookmarkGenError::InvalidName {
+                name: name.to_string(),
+                reason: format!("contains disallowed character {ch:?}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Build the cache key from a set of bookmark rows (ordered commit IDs).
+pub fn cache_key(rows: &[&BookmarkRow]) -> Vec<String> {
+    rows.iter().map(|r| r.commit_id.clone()).collect()
+}
+
+/// Generate a custom bookmark name by invoking the external command.
+///
+/// Results are cached by the ordered commit IDs of the segment.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "app.rs calls build_segment_input + run_command directly for async spawning"
+    )
+)]
+pub async fn generate_custom_name(
+    command: &str,
+    rows: &[&BookmarkRow],
+    cache: &mut BookmarkNameCache,
+) -> Result<String, BookmarkGenError> {
+    let key = cache_key(rows);
+    if let Some(cached) = cache.get(&key) {
+        return Ok(cached.clone());
+    }
+
+    let input = build_segment_input(rows);
+    let json = serde_json::to_string(&input).expect("SegmentInput is always serializable");
+
+    let name = run_command(command, &json).await?;
+    validate_bookmark_name(&name)?;
+
+    cache.insert(key, name.clone());
+    Ok(name)
+}
+
+/// Build the JSON input struct from bookmark rows. Exposed for `app.rs` to
+/// serialize before spawning a background task.
+pub(super) fn build_segment_input(rows: &[&BookmarkRow]) -> SegmentInput {
+    SegmentInput {
+        rules: RulesInput {
+            max_length: MAX_BOOKMARK_LENGTH,
+            disallowed_chars: DISALLOWED_CHARS.to_string(),
+        },
+        commits: rows
+            .iter()
+            .map(|row| CommitInput {
+                commit_id: row.commit_id.clone(),
+                change_id: row.change_id.clone(),
+                short_change_id: row.short_change_id.clone(),
+                description: row.description.clone(),
+                author: AuthorInput {
+                    name: row.author.name.clone(),
+                    email: row.author.email.clone(),
+                    timestamp: row.author.timestamp.clone(),
+                },
+                files: row.files.clone(),
+            })
+            .collect(),
+    }
+}
+
+/// Run the shell command with the given JSON on stdin. Exposed for `app.rs`
+/// to spawn as a background task.
+pub(super) async fn run_command(
+    command: &str,
+    stdin_data: &str,
+) -> Result<String, BookmarkGenError> {
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    let mut child = if cfg!(windows) {
+        Command::new("cmd")
+            .args(["/C", command])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+    } else {
+        Command::new("sh")
+            .args(["-c", command])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+    }
+    .map_err(|e| BookmarkGenError::NotFound {
+        command: command.to_string(),
+        source: e,
+    })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(stdin_data.as_bytes()).await?;
+        // Drop to close stdin so the child can finish.
+    }
+
+    let output = child.wait_with_output().await?;
+
+    if !output.status.success() {
+        return Err(BookmarkGenError::CommandFailed {
+            exit_code: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        return Err(BookmarkGenError::EmptyOutput {
+            command: command.to_string(),
+        });
+    }
+
+    Ok(name)
+}
+
+/// Collect rows forming the dynamic segment starting at `row_idx`.
+///
+/// A dynamic segment runs from the given row downward (toward trunk) until
+/// hitting another checked (non-`Unchecked`) row or reaching the trunk row.
+/// The returned rows are in trunk-to-tip order (oldest first).
+pub fn dynamic_segment_commits(rows: &[BookmarkRow], row_idx: usize) -> Vec<&BookmarkRow> {
+    use super::bookmark_widget::RowState;
+
+    let mut segment = vec![&rows[row_idx]];
+
+    // Walk downward (toward trunk).
+    for i in (0..row_idx).rev() {
+        let row = &rows[i];
+        if row.is_trunk {
+            break;
+        }
+        if row.state != RowState::Unchecked {
+            break;
+        }
+        segment.push(row);
+    }
+
+    // Reverse to get trunk-to-tip order.
+    segment.reverse();
+    segment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jj::types::Signature;
+    use crate::select::bookmark_widget::RowState;
+
+    #[test]
+    fn default_name_long_id() {
+        assert_eq!(
+            default_bookmark_name("abcdefghijklmnop"),
+            "stakk-abcdefghijkl"
+        );
+    }
+
+    #[test]
+    fn default_name_short_id() {
+        assert_eq!(default_bookmark_name("short"), "stakk-short");
+    }
+
+    #[test]
+    fn valid_names_pass() {
+        for name in ["feature", "my-branch", "fix/thing", "a.b", "CAPS"] {
+            validate_bookmark_name(name).unwrap();
+        }
+    }
+
+    #[test]
+    fn invalid_names_rejected() {
+        let cases = [
+            ("", "empty"),
+            ("-leading", "start with"),
+            (".leading", "start with"),
+            ("trailing.", "end with '.'"),
+            ("foo.lock", "end with '.lock'"),
+            ("has..dots", "contain '..'"),
+            ("has@{ref", "contain '@{'"),
+            ("has space", "disallowed character"),
+            ("has~tilde", "disallowed character"),
+            ("has^caret", "disallowed character"),
+            ("has:colon", "disallowed character"),
+            ("has?question", "disallowed character"),
+            ("has*star", "disallowed character"),
+            ("has[bracket", "disallowed character"),
+            ("has\\backslash", "disallowed character"),
+        ];
+        for (name, expected_reason) in cases {
+            let err = validate_bookmark_name(name).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected_reason),
+                "name={name:?}: expected reason containing {expected_reason:?}, got {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn too_long_name_rejected() {
+        let name = "a".repeat(256);
+        let err = validate_bookmark_name(&name).unwrap_err();
+        assert!(err.to_string().contains("maximum length"));
+    }
+
+    #[test]
+    fn cache_hit_and_miss() {
+        let mut cache = BookmarkNameCache::new();
+        let key = vec!["c1".to_string(), "c2".to_string()];
+        cache.insert(key.clone(), "cached-name".to_string());
+        assert_eq!(cache.get(&key), Some(&"cached-name".to_string()));
+
+        let miss_key = vec!["c3".to_string()];
+        assert_eq!(cache.get(&miss_key), None);
+    }
+
+    fn make_row(commit_id: &str, change_id: &str, state: RowState, is_trunk: bool) -> BookmarkRow {
+        BookmarkRow {
+            change_id: change_id.to_string(),
+            short_change_id: change_id[..4.min(change_id.len())].to_string(),
+            commit_id: commit_id.to_string(),
+            summary: "test".to_string(),
+            description: "test".to_string(),
+            existing_bookmarks: vec![],
+            state,
+            generated_name: Some(default_bookmark_name(change_id)),
+            is_trunk,
+            author: Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
+            custom_name: None,
+            has_bookmark_command: false,
+        }
+    }
+
+    #[test]
+    fn dynamic_segment_single_checked_row() {
+        let rows = vec![
+            make_row("c0", "ch0", RowState::Unchecked, true),
+            make_row("c1", "ch1", RowState::Unchecked, false),
+            make_row("c2", "ch2", RowState::UseGenerated, false),
+        ];
+        let segment = dynamic_segment_commits(&rows, 2);
+        assert_eq!(segment.len(), 2);
+        assert_eq!(segment[0].commit_id, "c1");
+        assert_eq!(segment[1].commit_id, "c2");
+    }
+
+    #[test]
+    fn dynamic_segment_stops_at_checked_neighbor() {
+        let rows = vec![
+            make_row("c0", "ch0", RowState::Unchecked, true),
+            make_row("c1", "ch1", RowState::UseExisting(0), false),
+            make_row("c2", "ch2", RowState::Unchecked, false),
+            make_row("c3", "ch3", RowState::UseGenerated, false),
+        ];
+        let segment = dynamic_segment_commits(&rows, 3);
+        assert_eq!(segment.len(), 2);
+        assert_eq!(segment[0].commit_id, "c2");
+        assert_eq!(segment[1].commit_id, "c3");
+    }
+
+    #[test]
+    fn dynamic_segment_stops_at_trunk() {
+        let rows = vec![
+            make_row("c0", "ch0", RowState::Unchecked, true),
+            make_row("c1", "ch1", RowState::UseGenerated, false),
+        ];
+        let segment = dynamic_segment_commits(&rows, 1);
+        assert_eq!(segment.len(), 1);
+        assert_eq!(segment[0].commit_id, "c1");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_returns_expected_output() {
+        let mut cache = BookmarkNameCache::new();
+        let row = make_row("c1", "ch1", RowState::UseGenerated, false);
+        let rows: Vec<&BookmarkRow> = vec![&row];
+        let name = generate_custom_name("echo my-branch", &rows, &mut cache)
+            .await
+            .unwrap();
+        assert_eq!(name, "my-branch");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_failure_returns_error() {
+        let mut cache = BookmarkNameCache::new();
+        let row = make_row("c1", "ch1", RowState::UseGenerated, false);
+        let rows: Vec<&BookmarkRow> = vec![&row];
+        let err = generate_custom_name("false", &rows, &mut cache)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BookmarkGenError::CommandFailed { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn missing_command_returns_not_found() {
+        let mut cache = BookmarkNameCache::new();
+        let row = make_row("c1", "ch1", RowState::UseGenerated, false);
+        let rows: Vec<&BookmarkRow> = vec![&row];
+        // sh -c with a non-existent command returns exit 127, not NotFound.
+        // NotFound only fires if sh itself is missing, which we can't easily
+        // test. Instead verify the CommandFailed path for missing programs.
+        let err = generate_custom_name("nonexistent_command_xyz_12345", &rows, &mut cache)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BookmarkGenError::CommandFailed { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn empty_output_returns_error() {
+        let mut cache = BookmarkNameCache::new();
+        let row = make_row("c1", "ch1", RowState::UseGenerated, false);
+        let rows: Vec<&BookmarkRow> = vec![&row];
+        let err = generate_custom_name("echo -n ''", &rows, &mut cache)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BookmarkGenError::EmptyOutput { .. }));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cached_result_reused() {
+        let mut cache = BookmarkNameCache::new();
+        let row = make_row("c1", "ch1", RowState::UseGenerated, false);
+        let rows: Vec<&BookmarkRow> = vec![&row];
+
+        // First call populates cache.
+        let name1 = generate_custom_name("echo cached-name", &rows, &mut cache)
+            .await
+            .unwrap();
+        assert_eq!(name1, "cached-name");
+
+        // Second call with a different command still returns cached value.
+        let name2 = generate_custom_name("echo different-name", &rows, &mut cache)
+            .await
+            .unwrap();
+        assert_eq!(name2, "cached-name");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_receives_json_stdin() {
+        use std::io::Write;
+
+        let mut cache = BookmarkNameCache::new();
+        let mut row = make_row("c1", "ch1_full_change_id", RowState::UseGenerated, false);
+        row.description = "add login page".to_string();
+        row.files = vec!["src/login.rs".to_string()];
+        let rows: Vec<&BookmarkRow> = vec![&row];
+
+        // Use a command that reads stdin and outputs a fixed name.
+        let tmpdir = std::env::temp_dir();
+        let script_path = tmpdir.join("stakk_test_stdin.sh");
+        {
+            let mut f = std::fs::File::create(&script_path).unwrap();
+            writeln!(f, "#!/bin/sh").unwrap();
+            // Save stdin to a file for inspection, output a valid name.
+            let capture_path = tmpdir.join("stakk_test_stdin_capture.json");
+            writeln!(f, "cat > {}", capture_path.display()).unwrap();
+            writeln!(f, "echo valid-name").unwrap();
+        }
+        std::fs::set_permissions(
+            &script_path,
+            std::os::unix::fs::PermissionsExt::from_mode(0o755),
+        )
+        .unwrap();
+
+        let name =
+            generate_custom_name(&format!("sh {}", script_path.display()), &rows, &mut cache)
+                .await
+                .unwrap();
+        assert_eq!(name, "valid-name");
+
+        // Verify the JSON that was sent.
+        let capture_path = tmpdir.join("stakk_test_stdin_capture.json");
+        let captured = std::fs::read_to_string(&capture_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&captured).unwrap();
+        assert_eq!(parsed["rules"]["max_length"], 255);
+        assert!(
+            parsed["rules"]["disallowed_chars"]
+                .as_str()
+                .unwrap()
+                .contains('~')
+        );
+        assert_eq!(parsed["commits"][0]["description"], "add login page");
+        assert_eq!(parsed["commits"][0]["files"][0], "src/login.rs");
+
+        // Clean up.
+        let _ = std::fs::remove_file(&script_path);
+        let _ = std::fs::remove_file(&capture_path);
+    }
+}

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -15,16 +15,20 @@ use ratatui::text::Span;
 use ratatui::widgets::Widget;
 
 use super::BookmarkAssignment;
+use super::bookmark_gen;
 use super::graph_layout::LayoutNode;
+use crate::jj::types::Signature;
 
 /// The inclusion state of a bookmark row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RowState {
     /// Included in submission using the existing bookmark at the given index
     /// into `BookmarkRow::existing_bookmarks`.
     UseExisting(usize),
     /// Included in submission; a new stakk-xxx bookmark will be created.
     UseGenerated,
+    /// Included in submission; a custom name from the bookmark command.
+    UseCustom(String),
     /// Excluded from submission.
     Unchecked,
 }
@@ -36,16 +40,28 @@ pub struct BookmarkRow {
     pub change_id: String,
     /// Shortest unique change ID prefix (from jj).
     pub short_change_id: String,
-    /// The commit summary.
+    /// The jj commit ID.
+    pub commit_id: String,
+    /// The commit summary (first line of description).
     pub summary: String,
+    /// Full commit description.
+    pub description: String,
     /// Existing bookmark names on this change (may be empty).
     pub existing_bookmarks: Vec<String>,
     /// Whether and how this row is included in the submission.
     pub state: RowState,
     /// Generated bookmark name (`stakk-<change_id_prefix>`).
     pub generated_name: Option<String>,
+    /// Custom name from the bookmark command (populated lazily).
+    pub custom_name: Option<String>,
     /// Whether this is the trunk row (not toggleable).
     pub is_trunk: bool,
+    /// Author signature.
+    pub author: Signature,
+    /// Files changed by this commit.
+    pub files: Vec<String>,
+    /// Whether a bookmark command is configured.
+    pub has_bookmark_command: bool,
 }
 
 impl BookmarkRow {
@@ -55,10 +71,32 @@ impl BookmarkRow {
         if self.is_trunk {
             return None;
         }
-        match self.state {
-            RowState::UseExisting(idx) => self.existing_bookmarks.get(idx).map(String::as_str),
+        match &self.state {
+            RowState::UseExisting(idx) => self.existing_bookmarks.get(*idx).map(String::as_str),
             RowState::UseGenerated => self.generated_name.as_deref(),
+            RowState::UseCustom(name) => Some(name.as_str()),
             RowState::Unchecked => None,
+        }
+    }
+}
+
+/// Reasons why the selection cannot be confirmed.
+#[derive(Debug)]
+pub enum SelectionError {
+    /// Two included rows resolved to the same bookmark name.
+    DuplicateName(String),
+    /// A custom name is still being computed.
+    StillLoading,
+}
+
+/// Helper to construct `UseCustom` state, using cached name or an empty
+/// sentinel that signals the caller to invoke the command.
+struct UseCustomSentinel;
+impl UseCustomSentinel {
+    fn make(row: &BookmarkRow) -> RowState {
+        match &row.custom_name {
+            Some(name) => RowState::UseCustom(name.clone()),
+            None => RowState::UseCustom(String::new()),
         }
     }
 }
@@ -74,7 +112,7 @@ pub struct BookmarkAssignmentState {
 
 impl BookmarkAssignmentState {
     /// Build state from a path of layout nodes (trunk-to-leaf order).
-    pub fn from_path(path: &[&LayoutNode]) -> Self {
+    pub fn from_path(path: &[&LayoutNode], has_bookmark_command: bool) -> Self {
         let rows: Vec<BookmarkRow> = path
             .iter()
             .map(|node| {
@@ -82,7 +120,7 @@ impl BookmarkAssignmentState {
                 let generated_name = if node.is_trunk {
                     None
                 } else {
-                    Some(generate_bookmark_name(&node.change_id))
+                    Some(bookmark_gen::default_bookmark_name(&node.change_id))
                 };
                 let state = if existing_bookmarks.is_empty() {
                     RowState::Unchecked
@@ -93,11 +131,17 @@ impl BookmarkAssignmentState {
                 BookmarkRow {
                     change_id: node.change_id.clone(),
                     short_change_id: node.short_change_id.clone(),
+                    commit_id: node.commit_id.clone(),
                     summary: node.summary.clone(),
+                    description: node.description.clone(),
                     existing_bookmarks,
                     state,
                     generated_name,
+                    custom_name: None,
                     is_trunk: node.is_trunk,
+                    author: node.author.clone(),
+                    files: node.files.clone(),
+                    has_bookmark_command,
                 }
             })
             .collect();
@@ -110,13 +154,15 @@ impl BookmarkAssignmentState {
 
     /// Toggle the state of the current row through the cycle.
     ///
-    /// - **Multiple existing, generated distinct**: `UseExisting(0) → … →
-    ///   UseExisting(N-1) → UseGenerated → Unchecked → UseExisting(0) → …`
-    /// - **Single existing ≠ generated**: `UseExisting(0) → UseGenerated →
-    ///   Unchecked → UseExisting(0) → …`
-    /// - **Existing == generated** (or generated matches any existing):
-    ///   generated is skipped in the cycle.
-    /// - **No existing**: `Unchecked → UseGenerated → Unchecked → …`
+    /// The cycle is: `UseExisting(0..N-1)` → `UseGenerated` → `UseCustom`
+    /// → `Unchecked` → back to start. `UseGenerated` is skipped when it
+    /// matches an existing bookmark. `UseCustom` is skipped when no
+    /// bookmark command is configured, or if the custom name matches the
+    /// generated or any existing name.
+    ///
+    /// When toggling to `UseCustom`, the state is set to
+    /// `UseCustom(String::new())` as a sentinel — the caller (`app.rs`)
+    /// is responsible for firing the command and filling in the real name.
     pub fn toggle_current(&mut self) {
         let Some(row) = self.rows.get_mut(self.cursor) else {
             return;
@@ -130,23 +176,44 @@ impl BookmarkAssignmentState {
             None => false,
         };
 
-        row.state = match row.state {
+        let has_distinct_custom = row.has_bookmark_command
+            && match &row.custom_name {
+                Some(custom) => {
+                    let matches_generated = row.generated_name.as_ref() == Some(custom);
+                    let matches_existing = row.existing_bookmarks.iter().any(|e| e == custom);
+                    !matches_generated && !matches_existing
+                }
+                // No cached custom name yet — include UseCustom so it can be
+                // resolved lazily.
+                None => true,
+            };
+
+        row.state = match &row.state {
             RowState::UseExisting(idx) => {
                 let next_idx = idx + 1;
                 if next_idx < row.existing_bookmarks.len() {
                     RowState::UseExisting(next_idx)
                 } else if has_distinct_generated {
                     RowState::UseGenerated
+                } else if has_distinct_custom {
+                    UseCustomSentinel::make(row)
                 } else {
                     RowState::Unchecked
                 }
             }
-            RowState::UseGenerated => RowState::Unchecked,
-            RowState::Unchecked => {
-                if !row.existing_bookmarks.is_empty() {
-                    RowState::UseExisting(0)
+            RowState::UseGenerated => {
+                if has_distinct_custom {
+                    UseCustomSentinel::make(row)
                 } else {
+                    RowState::Unchecked
+                }
+            }
+            RowState::UseCustom(_) => RowState::Unchecked,
+            RowState::Unchecked => {
+                if row.existing_bookmarks.is_empty() {
                     RowState::UseGenerated
+                } else {
+                    RowState::UseExisting(0)
                 }
             }
         };
@@ -172,58 +239,96 @@ impl BookmarkAssignmentState {
     }
 
     /// Build the selection result from included rows.
-    pub fn build_result(&self) -> Vec<BookmarkAssignment> {
-        self.rows
-            .iter()
-            .filter(|r| !r.is_trunk && r.state != RowState::Unchecked)
-            .map(|r| {
-                let (bookmark_name, is_new) = match r.state {
-                    RowState::UseExisting(idx) => (
-                        r.existing_bookmarks
-                            .get(idx)
-                            .cloned()
-                            .expect("UseExisting index in bounds"),
-                        false,
-                    ),
-                    RowState::UseGenerated => (
-                        r.generated_name
-                            .clone()
-                            .expect("UseGenerated requires name"),
-                        true,
-                    ),
-                    RowState::Unchecked => unreachable!("filtered above"),
-                };
-                BookmarkAssignment {
-                    change_id: r.change_id.clone(),
-                    bookmark_name,
-                    is_new,
+    ///
+    /// Returns `Err` with the duplicate bookmark name if any two included rows
+    /// resolve to the same name, or if any row is still loading (`UseCustom`
+    /// with empty sentinel).
+    pub fn build_result(&self) -> Result<Vec<BookmarkAssignment>, SelectionError> {
+        let mut assignments = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for r in &self.rows {
+            if r.is_trunk || r.state == RowState::Unchecked {
+                continue;
+            }
+
+            let (bookmark_name, is_new) = match &r.state {
+                RowState::UseExisting(idx) => (
+                    r.existing_bookmarks
+                        .get(*idx)
+                        .cloned()
+                        .expect("UseExisting index in bounds"),
+                    false,
+                ),
+                RowState::UseGenerated => (
+                    r.generated_name
+                        .clone()
+                        .expect("UseGenerated requires name"),
+                    true,
+                ),
+                RowState::UseCustom(name) if name.is_empty() => {
+                    return Err(SelectionError::StillLoading);
                 }
-            })
-            .collect()
+                RowState::UseCustom(name) => (name.clone(), true),
+                RowState::Unchecked => unreachable!("filtered above"),
+            };
+
+            if !seen.insert(bookmark_name.clone()) {
+                return Err(SelectionError::DuplicateName(bookmark_name));
+            }
+
+            assignments.push(BookmarkAssignment {
+                change_id: r.change_id.clone(),
+                bookmark_name,
+                is_new,
+            });
+        }
+
+        Ok(assignments)
     }
 }
 
-/// Generate a bookmark name from a change ID.
+/// Shorten a string to `max` chars by keeping the start and end, joined by `…`.
 ///
-/// Uses `stakk-<first 12 chars of change_id>`, matching jj's `push-<change_id>`
-/// convention.
-fn generate_bookmark_name(change_id: &str) -> String {
-    let prefix = if change_id.len() >= 12 {
-        &change_id[..12]
-    } else {
-        change_id
-    };
-    format!("stakk-{prefix}")
+/// `"jq -r '.commits' | tr ' ' '-' | tr '[:upper:]' '[:lower:]'"` with max=14
+/// becomes `"jq -r…lower']"`.
+fn shorten_middle(s: &str, max: usize) -> String {
+    let len = s.chars().count();
+    if len <= max {
+        return s.to_string();
+    }
+    // 1 char for `…`, split the rest ~evenly favoring the start.
+    let budget = max.saturating_sub(1);
+    let head = budget.div_ceil(2);
+    let tail = budget / 2;
+    let start: String = s.chars().take(head).collect();
+    let end: String = s.chars().skip(len - tail).collect();
+    format!("{start}\u{2026}{end}")
 }
 
 /// Renders the bookmark assignment screen.
 pub struct BookmarkWidget<'a> {
     state: &'a BookmarkAssignmentState,
+    spinner_tick: usize,
+    bookmark_command: Option<&'a str>,
 }
 
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Max display width for the command label between spinners.
+const COMMAND_LABEL_MAX: usize = 16;
+
 impl<'a> BookmarkWidget<'a> {
-    pub fn new(state: &'a BookmarkAssignmentState) -> Self {
-        Self { state }
+    pub fn new(
+        state: &'a BookmarkAssignmentState,
+        spinner_tick: usize,
+        bookmark_command: Option<&'a str>,
+    ) -> Self {
+        Self {
+            state,
+            spinner_tick,
+            bookmark_command,
+        }
     }
 
     fn build_lines(&self) -> Vec<Line<'a>> {
@@ -247,21 +352,36 @@ impl<'a> BookmarkWidget<'a> {
             let cursor_indicator = if is_selected { "> " } else { "  " };
 
             // Per-state checkbox symbol and color.
-            let (checkbox, state_color, state_bold) = match row.state {
+            let (checkbox, state_color, state_bold) = match &row.state {
                 RowState::UseExisting(_) => ("[x]", Color::Green, true),
                 RowState::UseGenerated => ("[+]", Color::Yellow, true),
+                RowState::UseCustom(_) => ("[*]", Color::Cyan, true),
                 RowState::Unchecked => ("[ ]", Color::DarkGray, false),
             };
 
-            let name_str = match row.state {
-                RowState::UseExisting(idx) => {
-                    row.existing_bookmarks.get(idx).cloned().unwrap_or_default()
-                }
+            let name_str = match &row.state {
+                RowState::UseExisting(idx) => row
+                    .existing_bookmarks
+                    .get(*idx)
+                    .cloned()
+                    .unwrap_or_default(),
                 RowState::UseGenerated => row
                     .generated_name
                     .as_ref()
                     .map(|n| format!("{n} (new)"))
                     .unwrap_or_default(),
+                RowState::UseCustom(name) => {
+                    if name.is_empty() {
+                        let frame = SPINNER_FRAMES[self.spinner_tick % SPINNER_FRAMES.len()];
+                        let label = self
+                            .bookmark_command
+                            .map(|cmd| shorten_middle(cmd, COMMAND_LABEL_MAX))
+                            .unwrap_or_default();
+                        format!("{frame}{label}{frame}")
+                    } else {
+                        format!("{name} (custom)")
+                    }
+                }
                 RowState::Unchecked => {
                     if let Some(first) = row.existing_bookmarks.first() {
                         first.clone()
@@ -394,21 +514,28 @@ mod tests {
             change_id: change_id.to_string(),
             commit_id: format!("commit_{change_id}"),
             summary: summary.to_string(),
+            description: summary.to_string(),
             bookmark_names: bookmarks.iter().map(ToString::to_string).collect(),
             is_trunk,
             is_leaf,
             stack_index: 0,
             short_change_id: change_id[..4.min(change_id.len())].to_string(),
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
         }
     }
 
     #[test]
     fn generate_name_from_change_id() {
         assert_eq!(
-            generate_bookmark_name("abcdefghijklmnop"),
+            bookmark_gen::default_bookmark_name("abcdefghijklmnop"),
             "stakk-abcdefghijkl"
         );
-        assert_eq!(generate_bookmark_name("short"), "stakk-short");
+        assert_eq!(bookmark_gen::default_bookmark_name("short"), "stakk-short");
     }
 
     #[test]
@@ -419,7 +546,7 @@ mod tests {
             make_node("ch_b", "add feature", &[], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let state = BookmarkAssignmentState::from_path(&refs);
+        let state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows.len(), 3);
 
@@ -445,7 +572,7 @@ mod tests {
             make_node("ch_a", "work", &["feat"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         // Cursor should start on the non-trunk row; starts UseExisting.
         assert_eq!(state.cursor, 1);
@@ -466,9 +593,9 @@ mod tests {
     fn toggle_trunk_is_noop() {
         let nodes = [make_node("", "trunk", &[], true, false)];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
         state.cursor = 0;
-        let state_before = state.rows[0].state;
+        let state_before = state.rows[0].state.clone();
         state.toggle_current();
         assert_eq!(state.rows[0].state, state_before);
     }
@@ -482,7 +609,7 @@ mod tests {
             make_node("abcdefghijkl", "work", &["stakk-abcdefghijkl"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows[1].state, RowState::UseExisting(0));
 
@@ -501,7 +628,7 @@ mod tests {
             make_node("ch_x", "feature", &[], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows[1].state, RowState::Unchecked);
 
@@ -521,13 +648,13 @@ mod tests {
             make_node("ch_c", "leaf", &["leaf"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         // Toggle the middle (unmarked) commit: Unchecked → UseGenerated.
         state.cursor = 2;
         state.toggle_current();
 
-        let result = state.build_result();
+        let result = state.build_result().unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].bookmark_name, "base");
         assert!(!result[0].is_new);
@@ -544,51 +671,54 @@ mod tests {
             make_node("ch_a", "work", &["feat"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         // Toggle twice: UseExisting → UseGenerated → Unchecked.
         state.cursor = 1;
         state.toggle_current();
         state.toggle_current();
 
-        let result = state.build_result();
+        let result = state.build_result().unwrap();
         assert!(result.is_empty());
+    }
+
+    fn make_bare_row(state: RowState) -> BookmarkRow {
+        BookmarkRow {
+            change_id: "a".to_string(),
+            short_change_id: "a".to_string(),
+            commit_id: "commit_a".to_string(),
+            summary: "work".to_string(),
+            description: "work".to_string(),
+            existing_bookmarks: vec!["feat".to_string()],
+            state,
+            generated_name: Some("stakk-aaaaaaaaaaaa".to_string()),
+            custom_name: None,
+            is_trunk: false,
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
+            has_bookmark_command: false,
+        }
     }
 
     #[test]
     fn effective_name_returns_correct_values() {
-        let row_existing = BookmarkRow {
-            change_id: "a".to_string(),
-            short_change_id: "a".to_string(),
-            summary: "work".to_string(),
-            existing_bookmarks: vec!["feat".to_string()],
-            state: RowState::UseExisting(0),
-            generated_name: None,
-            is_trunk: false,
-        };
+        let row_existing = make_bare_row(RowState::UseExisting(0));
         assert_eq!(row_existing.effective_name(), Some("feat"));
 
-        let row_generated = BookmarkRow {
-            change_id: "b".to_string(),
-            short_change_id: "b".to_string(),
-            summary: "work".to_string(),
-            existing_bookmarks: vec![],
-            state: RowState::UseGenerated,
-            generated_name: Some("stakk-bbbbbbbbb".to_string()),
-            is_trunk: false,
-        };
+        let mut row_generated = make_bare_row(RowState::UseGenerated);
+        row_generated.existing_bookmarks = vec![];
+        row_generated.generated_name = Some("stakk-bbbbbbbbb".to_string());
         assert_eq!(row_generated.effective_name(), Some("stakk-bbbbbbbbb"));
 
-        let row_unchecked = BookmarkRow {
-            change_id: "c".to_string(),
-            short_change_id: "c".to_string(),
-            summary: "work".to_string(),
-            existing_bookmarks: vec!["feat".to_string()],
-            state: RowState::Unchecked,
-            generated_name: None,
-            is_trunk: false,
-        };
+        let row_unchecked = make_bare_row(RowState::Unchecked);
         assert_eq!(row_unchecked.effective_name(), None);
+
+        let row_custom = make_bare_row(RowState::UseCustom("my-branch".to_string()));
+        assert_eq!(row_custom.effective_name(), Some("my-branch"));
     }
 
     #[test]
@@ -598,8 +728,8 @@ mod tests {
             make_node("ch_a", "add feature", &["feat"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let state = BookmarkAssignmentState::from_path(&refs);
-        let widget = BookmarkWidget::new(&state);
+        let state = BookmarkAssignmentState::from_path(&refs, false);
+        let widget = BookmarkWidget::new(&state, 0, None);
 
         let area = Rect::new(0, 0, 60, 10);
         let mut buf = Buffer::empty(area);
@@ -631,7 +761,7 @@ mod tests {
             ),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows[1].state, RowState::UseExisting(0));
 
@@ -667,7 +797,7 @@ mod tests {
             ),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows[1].state, RowState::UseExisting(0));
 
@@ -689,12 +819,12 @@ mod tests {
             make_node("ch_a", "work", &["alpha", "beta"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let mut state = BookmarkAssignmentState::from_path(&refs);
+        let mut state = BookmarkAssignmentState::from_path(&refs, false);
 
         // Toggle once: UseExisting(0) → UseExisting(1).
         state.toggle_current();
 
-        let result = state.build_result();
+        let result = state.build_result().unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].bookmark_name, "beta");
         assert!(!result[0].is_new);
@@ -707,7 +837,7 @@ mod tests {
             make_node("ch_a", "work", &["alpha", "beta", "gamma"], false, true),
         ];
         let refs: Vec<&LayoutNode> = nodes.iter().collect();
-        let state = BookmarkAssignmentState::from_path(&refs);
+        let state = BookmarkAssignmentState::from_path(&refs, false);
 
         assert_eq!(state.rows[1].existing_bookmarks.len(), 3);
         assert_eq!(state.rows[1].existing_bookmarks[0], "alpha");

--- a/src/select/graph_layout.rs
+++ b/src/select/graph_layout.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::graph::types::ChangeGraph;
+use crate::jj::types::Signature;
 
 /// A positioned node in the 2D graph layout.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +21,8 @@ pub struct LayoutNode {
     pub commit_id: String,
     /// First line of the commit description.
     pub summary: String,
+    /// Full commit description.
+    pub description: String,
     /// Bookmark names on this commit (may be empty).
     pub bookmark_names: Vec<String>,
     /// Whether this node is the trunk node.
@@ -30,6 +33,10 @@ pub struct LayoutNode {
     pub stack_index: usize,
     /// Shortest unique change ID prefix (from jj).
     pub short_change_id: String,
+    /// Author signature.
+    pub author: Signature,
+    /// Files changed by this commit.
+    pub files: Vec<String>,
 }
 
 /// An edge connecting two nodes in the layout.
@@ -109,11 +116,18 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
         change_id: String::new(),
         commit_id: String::new(),
         summary: "trunk".to_string(),
+        description: String::new(),
         bookmark_names: vec![],
         is_trunk: true,
         is_leaf: false,
         stack_index: 0,
         short_change_id: String::new(),
+        author: Signature {
+            name: String::new(),
+            email: String::new(),
+            timestamp: String::new(),
+        },
+        files: vec![],
     });
 
     let num_stacks = graph.stacks.len();
@@ -172,11 +186,14 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
                     change_id: commit.change_id.clone(),
                     commit_id: commit.commit_id.clone(),
                     summary,
+                    description: commit.description.clone(),
                     bookmark_names,
                     is_trunk: false,
                     is_leaf,
                     stack_index: stack_idx,
                     short_change_id: commit.short_change_id.clone(),
+                    author: commit.author.clone(),
+                    files: commit.files.clone(),
                 });
 
                 edges.push(LayoutEdge {
@@ -279,7 +296,12 @@ mod tests {
                     commit_id: format!("c_{change_id}_{i}"),
                     change_id: change_id.to_string(),
                     description: desc.to_string(),
-                    author_name: "Test".to_string(),
+                    author: crate::jj::types::Signature {
+                        name: "Test".to_string(),
+                        email: "test@test.com".to_string(),
+                        timestamp: "T".to_string(),
+                    },
+                    files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
                 })
                 .collect(),

--- a/src/select/graph_widget.rs
+++ b/src/select/graph_widget.rs
@@ -393,7 +393,12 @@ mod tests {
                     commit_id: format!("c_{change_id}_{i}"),
                     change_id: change_id.to_string(),
                     description: desc.to_string(),
-                    author_name: "Test".to_string(),
+                    author: crate::jj::types::Signature {
+                        name: "Test".to_string(),
+                        email: "test@test.com".to_string(),
+                        timestamp: "T".to_string(),
+                    },
+                    files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
                 })
                 .collect(),

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -4,6 +4,7 @@
 //! assignment view for toggling which commits get bookmarks.
 
 mod app;
+pub(crate) mod bookmark_gen;
 mod bookmark_widget;
 mod event;
 mod graph_layout;
@@ -41,6 +42,7 @@ pub struct SelectionResult {
 /// Returns `StakkError::PromptCancelled` if the user presses Escape/q.
 pub fn resolve_bookmark_interactively(
     graph: &ChangeGraph,
+    bookmark_command: Option<&str>,
 ) -> Result<Option<SelectionResult>, StakkError> {
     if graph.stacks.is_empty() {
         eprintln!("No bookmark stacks found.");
@@ -51,7 +53,7 @@ pub fn resolve_bookmark_interactively(
         return Err(StakkError::NotInteractive);
     }
 
-    app::run_tui(graph)
+    app::run_tui(graph, bookmark_command)
 }
 
 // ---------------------------------------------------------------------------
@@ -81,7 +83,7 @@ mod tests {
     #[test]
     fn resolve_no_stacks() {
         let graph = make_graph_empty();
-        let result = resolve_bookmark_interactively(&graph).unwrap();
+        let result = resolve_bookmark_interactively(&graph, None).unwrap();
         assert_eq!(result, None);
     }
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -560,7 +560,12 @@ mod tests {
                 commit_id: format!("c_{change_id}"),
                 change_id: change_id.to_string(),
                 description: desc.to_string(),
-                author_name: "Test".to_string(),
+                author: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                files: vec![],
                 short_change_id: change_id[..4.min(change_id.len())].to_string(),
             }],
         }
@@ -1290,7 +1295,12 @@ mod tests {
             commit_id: "c1".to_string(),
             change_id: "ch1".to_string(),
             description: "Add feature X\n\nThis adds feature X with foo and bar.".to_string(),
-            author_name: "Test".to_string(),
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -1307,7 +1317,12 @@ mod tests {
             commit_id: "c1".to_string(),
             change_id: "ch1".to_string(),
             description: "Add feature X".to_string(),
-            author_name: "Test".to_string(),
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -1322,14 +1337,24 @@ mod tests {
                 commit_id: "c1".to_string(),
                 change_id: "ch1".to_string(),
                 description: "First commit".to_string(),
-                author_name: "Test".to_string(),
+                author: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                files: vec![],
                 short_change_id: "ch1".to_string(),
             },
             SegmentCommit {
                 commit_id: "c2".to_string(),
                 change_id: "ch2".to_string(),
                 description: "Second commit".to_string(),
-                author_name: "Test".to_string(),
+                author: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                files: vec![],
                 short_change_id: "ch2".to_string(),
             },
         ];


### PR DESCRIPTION
Add --experimental-bookmark-command / STAKK_EXPERIMENTAL_BOOKMARK_COMMAND that lets users provide a shell command for generating bookmark names. The command receives segment data (commits, files, author info) as JSON on stdin and returns a single bookmark name on stdout.

Key design decisions:
- Appears as [*] toggle option in TUI cycle after [x] existing and [+] generated
- Commands run asynchronously with braille spinner animation
- Results cached by commit ID sequence (Arc<Mutex> shared with background tasks)
- Orphaned task results (from invalidation) still populate the cache
- Bookmark names validated against git ref rules before acceptance
- Duplicate name detection blocks confirmation with inline error message
- File lists pre-fetched during graph construction for the JSON protocol
- SegmentCommit.author_name replaced with full Signature (name, email, timestamp)