### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1](https://github.com/glennib/stakk/compare/v1.4.0...v1.4.1) - 2026-03-16
+
+### Fixed
+
+- ignore BrokenPipe on stdin write in bookmark command
+- resolve clippy warnings from CacheEntry and CustomNameState refactor
+- *(select)* add [*]custom to bookmark help line legend when bookmark command is configured
+
+### Other
+
+- replace UseCustom(String) with CacheEntry enum and CustomNameState
+
 ## [1.4.0](https://github.com/glennib/stakk/compare/v1.3.0...v1.4.0) - 2026-03-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,7 +2626,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.4.0 -> 1.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.1](https://github.com/glennib/stakk/compare/v1.4.0...v1.4.1) - 2026-03-16

### Fixed

- ignore BrokenPipe on stdin write in bookmark command
- resolve clippy warnings from CacheEntry and CustomNameState refactor
- *(select)* add [*]custom to bookmark help line legend when bookmark command is configured

### Other

- replace UseCustom(String) with CacheEntry enum and CustomNameState
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).