### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/glennib/stakk/compare/v1.7.0...v1.8.0) - 2026-03-22
+
+### Added
+
+- make bookmark help line context-aware
+- add UserInput bookmark name mode with vim-like modal editing
+- add reverse cycling (b) and reverse regenerate (R) in bookmark widget
+
+### Fixed
+
+- preserve tfidf variation index when cycling through bookmark states
+- order stacks by most-recent committer timestamp
+
+### Other
+
+- use debug build instead of release in CI task
+
 ## [1.7.0](https://github.com/glennib/stakk/compare/v1.6.1...v1.7.0) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,7 +2626,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.7.0 -> 1.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.8.0](https://github.com/glennib/stakk/compare/v1.7.0...v1.8.0) - 2026-03-22

### Added

- make bookmark help line context-aware
- add UserInput bookmark name mode with vim-like modal editing
- add reverse cycling (b) and reverse regenerate (R) in bookmark widget

### Fixed

- preserve tfidf variation index when cycling through bookmark states
- order stacks by most-recent committer timestamp

### Other

- use debug build instead of release in CI task
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).