### PR TITLE
chore: release v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.3](https://github.com/glennib/stakk/compare/v1.10.2...v1.10.3) - 2026-03-22
+
+### Other
+
+- show repository URL in --help output
+
 ## [1.10.2](https://github.com/glennib/stakk/compare/v1.10.1...v1.10.2) - 2026-03-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.10.2 -> 1.10.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.10.3](https://github.com/glennib/stakk/compare/v1.10.2...v1.10.3) - 2026-03-22

### Other

- show repository URL in --help output
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).