### PR TITLE
chore: release v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.4](https://github.com/glennib/stakk/compare/v1.10.3...v1.10.4) - 2026-03-22
+
+### Other
+
+- upgrade windows-sys
+- cargo update incompatible
+- cargo update
+- pin mise tools
+- upgrade dist
+- *(deps)* update actions/checkout action to v6
+- ignore auto-generated release workflow in renovate config
+
 ## [1.10.3](https://github.com/glennib/stakk/compare/v1.10.2...v1.10.3) - 2026-03-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.10.3"
+version = "1.10.4"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.10.3 -> 1.10.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.10.4](https://github.com/glennib/stakk/compare/v1.10.3...v1.10.4) - 2026-03-22

### Other

- upgrade windows-sys
- cargo update incompatible
- cargo update
- pin mise tools
- upgrade dist
- *(deps)* update actions/checkout action to v6
- ignore auto-generated release workflow in renovate config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).