### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0](https://github.com/glennib/stakk/compare/v1.11.0...v1.12.0) - 2026-04-02
+
+### Added
+
+- add --sync-pr-content CLI flag, env var, and config field
+- add update_pr_title to Forge trait and implementations
+
+### Other
+
+- add missing diagnostic help messages and sync display test
+
 ## [1.11.0](https://github.com/glennib/stakk/compare/v1.10.4...v1.11.0) - 2026-03-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.11.0 -> 1.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.12.0](https://github.com/glennib/stakk/compare/v1.11.0...v1.12.0) - 2026-04-02

### Added

- implement content sync in execution phase
- thread sync_pr_content through planning phase
- add --sync-pr-content CLI flag, env var, and config field
- add update_pr_title to Forge trait and implementations

### Other

- add missing diagnostic help messages and sync display test
- replace --sync-pr-content bool with enum, add change detection
- add --sync-pr-content to README
- suppress struct_excessive_bools clippy warning on BookmarkPlan
- add execution tests for content sync
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).