### PR TITLE
Clean up dead code and improve expect() reason messages

### DIFF
--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -20,11 +20,6 @@ pub enum ForgeError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[expect(dead_code, reason = "used in later milestones for PR lookup errors")]
-    #[error("PR not found: #{number}")]
-    #[diagnostic(code(stakk::forge::pr_not_found))]
-    PrNotFound { number: u64 },
-
     #[error("authentication failed: {message}")]
     #[diagnostic(
         code(stakk::forge::auth_failed),
@@ -35,14 +30,6 @@ pub enum ForgeError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-
-    #[expect(dead_code, reason = "used in later milestones for rate limit handling")]
-    #[error("rate limited; retry after {retry_after_seconds}s")]
-    #[diagnostic(
-        code(stakk::forge::rate_limited),
-        help("wait {retry_after_seconds}s and retry")
-    )]
-    RateLimited { retry_after_seconds: u64 },
 }
 
 /// State of a pull request.
@@ -59,10 +46,16 @@ pub struct PullRequest {
     pub number: u64,
     pub html_url: String,
     pub title: String,
-    #[expect(dead_code, reason = "populated by forge, read in future milestones")]
+    #[expect(
+        dead_code,
+        reason = "part of PR data model, not yet consumed by submission logic"
+    )]
     pub head_ref: String,
     pub base_ref: String,
-    #[expect(dead_code, reason = "populated by forge, read in future milestones")]
+    #[expect(
+        dead_code,
+        reason = "part of PR data model, not yet consumed by submission logic"
+    )]
     pub state: PrState,
     /// The PR body/description text.
     pub body: Option<String>,

--- a/src/jj/types.rs
+++ b/src/jj/types.rs
@@ -28,7 +28,10 @@ pub struct CommitRefData {
     pub name: String,
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "deserialized for completeness, used later")
+        expect(
+            dead_code,
+            reason = "deserialized for completeness, not yet read in production"
+        )
     )]
     pub target: Vec<String>,
     #[serde(default)]
@@ -38,7 +41,10 @@ pub struct CommitRefData {
     /// commit has been rewritten and the remote bookmark hasn't been updated).
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "deserialized for completeness, used later")
+        expect(
+            dead_code,
+            reason = "deserialized for completeness, not yet read in production"
+        )
     )]
     #[serde(default)]
     pub tracking_target: Option<Vec<Option<String>>>,
@@ -80,8 +86,7 @@ pub struct Bookmark {
         not(test),
         expect(
             dead_code,
-            reason = "available for push optimization (skip synced bookmarks) in a future \
-                      milestone"
+            reason = "available for push optimization (skip synced bookmarks)"
         )
     )]
     pub synced: bool,

--- a/src/select/graph_layout.rs
+++ b/src/select/graph_layout.rs
@@ -71,12 +71,6 @@ impl GraphLayout {
         self.nodes.iter().find(|n| n.row == row && n.col == col)
     }
 
-    /// Get the index of a node in the nodes vec by row/col.
-    #[expect(dead_code, reason = "available for future navigation features")]
-    pub fn node_index_at(&self, row: usize, col: usize) -> Option<usize> {
-        self.nodes.iter().position(|n| n.row == row && n.col == col)
-    }
-
     /// Return all leaf nodes (selectable branch tips), sorted left-to-right by
     /// column so that index 0 is the leftmost leaf.
     pub fn leaf_nodes(&self) -> Vec<&LayoutNode> {


### PR DESCRIPTION
## Summary
This PR removes unused code and improves the clarity of `#[expect(dead_code)]` annotations throughout the codebase. The changes focus on removing error variants and methods that were placeholders for future functionality, while also making the reasoning behind dead code expectations more precise and maintainable.

## Key Changes

- **Removed unused error variants** from `ForgeError`:
  - `PrNotFound`: Was marked for future PR lookup error handling
  - `RateLimited`: Was marked for future rate limit handling

- **Improved `#[expect(dead_code)]` messages** for clarity:
  - `PullRequest::head_ref` and `PullRequest::state`: Changed from "populated by forge, read in future milestones" to "part of PR data model, not yet consumed by submission logic"
  - `CommitRefData::target` and `CommitRefData::tracking_target`: Changed from "deserialized for completeness, used later" to "deserialized for completeness, not yet read in production"
  - `Bookmark::synced`: Simplified from "available for push optimization (skip synced bookmarks) in a future milestone" to "available for push optimization (skip synced bookmarks)"

- **Removed unused method** from `GraphLayout`:
  - `node_index_at()`: Was marked for future navigation features

## Implementation Details
The removed code was primarily placeholder implementations with `#[expect(dead_code)]` attributes indicating future use. By removing these now, we reduce maintenance burden and keep the codebase focused on current functionality. The improved expect() messages provide better context for why fields/methods exist but aren't currently used, making it easier for future developers to understand the intent.

https://claude.ai/code/session_015yiy8rTkr3HMvWAX42knsx