### PR TITLE
chore: release v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1](https://github.com/glennib/stakk/compare/v1.13.0...v1.13.1) - 2026-04-28
+
+### Other
+
+- *(deps)* update rust crate tokio to v1.52.1 ([#80](https://github.com/glennib/stakk/pull/80))
+- *(renovate)* enable automerge for low-risk updates
+- Merge pull request #81 from glennib/renovate/octocrab-0.x-lockfile
+- Merge pull request #82 from glennib/renovate/clap_complete-4.x-lockfile
+- *(deps)* update rust crate clap_complete to v4.6.3
+- fix clippy pedantic warnings
+
 ## [1.13.0](https://github.com/glennib/stakk/compare/v1.12.0...v1.13.0) - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.13.0 -> 1.13.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.13.1](https://github.com/glennib/stakk/compare/v1.13.0...v1.13.1) - 2026-04-28

### Other

- *(deps)* update rust crate tokio to v1.52.1 ([#80](https://github.com/glennib/stakk/pull/80))
- *(renovate)* enable automerge for low-risk updates
- Merge pull request #81 from glennib/renovate/octocrab-0.x-lockfile
- Merge pull request #82 from glennib/renovate/clap_complete-4.x-lockfile
- *(deps)* update rust crate clap_complete to v4.6.3
- fix clippy pedantic warnings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).