### PR TITLE
chore(renovate): enable automerge for low-risk updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":automergeMinor",
+    ":automergeLinters",
+    ":automergeTesters"
   ],
   "ignorePaths": [
     ".github/workflows/release.yml"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Opts patch, pin, digest, minor, and lockfile-maintenance updates into Renovate's automerge flow. Major updates still require manual review. CI gating is enforced by the repo ruleset's required `ci` status check.