### PR TITLE
feat(submit): make trailer handling configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,28 @@ without a live jj repo or GitHub access.
 stakk uses its own comment metadata format (`STAKK_STACK` prefix), its own
 serde field naming (snake_case), and its own comment footer.
 
+### 8. CLI args, env vars, and config travel together
+
+Every user-facing `submit` arg has four touchpoints that must stay in sync.
+When adding, renaming, or changing the default of one, update all of them
+in the same change:
+
+1. **`src/cli/submit.rs`** — the clap field with `#[arg(long, env = "STAKK_…",
+   default_value = …)]` and a `verbatim_doc_comment` doc.
+2. **`src/config/mod.rs`** — add `Option<T>` field on `Config`, default to
+   `None`, and merge in `Config::merge`.
+3. **`src/cli/mod.rs`** — wire it into `apply_submit_defaults` (or
+   `apply_graph_defaults`) via `set_default(...)`, and add tests mirroring
+   the `sync_pr_content_*` set: `default`, `config_*`, `cli_overrides_config`.
+   Extend `toml_deserialize_full`.
+4. **`README.md`** — three places:
+   - the `stakk.toml` example block,
+   - the **Environment variables** table,
+   - the per-subcommand flag table (e.g. under `stakk submit`).
+
+A change that lands in only some of these will silently drop config-file
+support, fail to appear in `--help` defaults, or stay invisible in the docs.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ heads_revset = "heads((mine() ~ empty() ~ immutable()) & trunk()..)"
 # Options: "none", "title", "body", "all"
 sync_pr_content = "all"
 
+# How to handle git commit trailers in PR bodies (default: "keep")
+# Options: "keep", "strip"
+trailers = "strip"
+
 # Shell command for generating custom bookmark names
 bookmark_command = "my-bookmark-namer"
 
@@ -282,6 +286,7 @@ stack_placement = "comment"
 | `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default) or `body` (overridden by `--stack-placement`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
+| `STAKK_TRAILERS` | Whether to keep or strip git commit trailers in PR bodies: `keep` (default) or `strip` (overridden by `--trailers`) |
 | `STAKK_BOOKMARK_COMMAND` | Shell command for generating custom bookmark names (overridden by `--bookmark-command`) |
 | `GITHUB_TOKEN` | GitHub personal access token (see `stakk auth setup`) |
 | `GH_TOKEN` | Alternative to `GITHUB_TOKEN` |
@@ -314,6 +319,7 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default) or in the PR `body` |
 | `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
 | `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
+| `--trailers <mode>` | `STAKK_TRAILERS` | Keep or strip git commit trailers in PR bodies: `keep` (default), `strip` |
 
 PR titles come from the first line of the jj change description. PR bodies
 are populated from the full description (everything after the title line).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,6 +105,9 @@ fn apply_submit_defaults(config: &Config, mut cmd: Command) -> Command {
     if let Some(spc) = config.sync_pr_content {
         cmd = set_default(cmd, "sync_pr_content", &spc.to_string());
     }
+    if let Some(tr) = config.trailers {
+        cmd = set_default(cmd, "trailers", &tr.to_string());
+    }
     if let Some(ref ap) = config.auto_prefix {
         cmd = set_default(cmd, "auto_prefix", ap);
     }
@@ -335,6 +338,43 @@ mod tests {
         );
     }
 
+    // -- trailers tests --
+
+    #[test]
+    fn trailers_default_keep() {
+        let cli = parse_with_config(Config::default(), &["stakk", "submit", "bm"]);
+        assert_eq!(
+            submit_args(&cli).trailers,
+            crate::cli::submit::TrailerHandling::Keep,
+        );
+    }
+
+    #[test]
+    fn trailers_config_strip() {
+        let config = Config {
+            trailers: Some(crate::cli::submit::TrailerHandling::Strip),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "bm"]);
+        assert_eq!(
+            submit_args(&cli).trailers,
+            crate::cli::submit::TrailerHandling::Strip,
+        );
+    }
+
+    #[test]
+    fn trailers_cli_overrides_config() {
+        let config = Config {
+            trailers: Some(crate::cli::submit::TrailerHandling::Strip),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "--trailers=keep", "bm"]);
+        assert_eq!(
+            submit_args(&cli).trailers,
+            crate::cli::submit::TrailerHandling::Keep,
+        );
+    }
+
     // -- auto_prefix tests --
 
     #[test]
@@ -438,6 +478,7 @@ pr_mode = "draft"
 template = "/path/to/template.jinja"
 stack_placement = "body"
 sync_pr_content = "all"
+trailers = "strip"
 auto_prefix = "gb-"
 bookmark_command = "my-command"
 bookmarks_revset = "all()"
@@ -451,6 +492,10 @@ heads_revset = "heads(all())"
         assert_eq!(
             config.sync_pr_content,
             Some(crate::cli::submit::SyncPrContent::All),
+        );
+        assert_eq!(
+            config.trailers,
+            Some(crate::cli::submit::TrailerHandling::Strip),
         );
         assert_eq!(config.auto_prefix.as_deref(), Some("gb-"));
         assert_eq!(config.bookmark_command.as_deref(), Some("my-command"));

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -52,6 +52,27 @@ impl std::fmt::Display for SyncPrContent {
     }
 }
 
+/// Controls whether git commit trailers are stripped from PR bodies.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrailerHandling {
+    /// Leave trailers in the PR body verbatim.
+    #[default]
+    Keep,
+    /// Strip the trailer block (Signed-off-by, Co-authored-by, Refs, etc.)
+    /// from the PR body.
+    Strip,
+}
+
+impl std::fmt::Display for TrailerHandling {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pv = self
+            .to_possible_value()
+            .expect("all variants have possible values");
+        f.write_str(pv.get_name())
+    }
+}
+
 /// Arguments for the submit subcommand.
 #[derive(Debug, Args)]
 pub struct SubmitArgs {
@@ -154,8 +175,8 @@ pub struct SubmitArgs {
     /// When syncing is enabled, manual edits to the synced fields on
     /// GitHub will be overwritten.
     ///
-    /// Git commit trailers (Signed-off-by, Co-authored-by, Refs, etc.)
-    /// are always stripped from PR bodies, both on creation and sync.
+    /// See --trailers for control over whether git commit trailers
+    /// (Signed-off-by, Co-authored-by, Refs, etc.) are kept or stripped.
     #[arg(
         long,
         env = "STAKK_SYNC_PR_CONTENT",
@@ -164,6 +185,19 @@ pub struct SubmitArgs {
         verbatim_doc_comment
     )]
     pub sync_pr_content: SyncPrContent,
+
+    /// Whether to keep or strip git commit trailers in PR bodies.
+    ///
+    /// Trailers are key/value lines at the end of a commit message such as
+    /// Signed-off-by, Co-authored-by, or Refs.
+    #[arg(
+        long,
+        env = "STAKK_TRAILERS",
+        default_value = "keep",
+        value_enum,
+        verbatim_doc_comment
+    )]
+    pub trailers: TrailerHandling,
 
     /// Prefix for auto-generated bookmark names.
     ///

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for PrMode {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum SyncPrContent {
-    /// Do not sync (default). Title and body are only set on PR creation.
+    /// Do not sync. Title and body are only set on PR creation.
     #[default]
     None,
     /// Sync only the PR title from the first line of the commit description.
@@ -165,12 +165,6 @@ pub struct SubmitArgs {
 
     /// Controls whether existing PR titles and/or bodies are updated
     /// from jj commit descriptions on every submit.
-    ///
-    /// By default (none), stakk only sets the title and body when
-    /// creating a new PR. Other modes:
-    ///   title — sync only the PR title
-    ///   body  — sync only the PR body (description)
-    ///   all   — sync both title and body
     ///
     /// When syncing is enabled, manual edits to the synced fields on
     /// GitHub will be overwritten.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
+use crate::cli::submit::TrailerHandling;
 use crate::forge::comment::StackPlacement;
 
 /// Pre-parse the config file path from raw CLI args or environment, before clap
@@ -51,6 +52,7 @@ pub struct Config {
     pub template: Option<String>,
     pub stack_placement: Option<StackPlacement>,
     pub sync_pr_content: Option<SyncPrContent>,
+    pub trailers: Option<TrailerHandling>,
     pub auto_prefix: Option<String>,
     pub bookmark_command: Option<String>,
     pub bookmarks_revset: Option<String>,
@@ -66,6 +68,7 @@ impl Default for Config {
             template: None,
             stack_placement: None,
             sync_pr_content: None,
+            trailers: None,
             auto_prefix: None,
             bookmark_command: None,
             bookmarks_revset: None,
@@ -133,6 +136,7 @@ impl Config {
             template: self.template.or(fallback.template),
             stack_placement: self.stack_placement.or(fallback.stack_placement),
             sync_pr_content: self.sync_pr_content.or(fallback.sync_pr_content),
+            trailers: self.trailers.or(fallback.trailers),
             auto_prefix: self.auto_prefix.or(fallback.auto_prefix),
             bookmark_command: self.bookmark_command.or(fallback.bookmark_command),
             bookmarks_revset: self.bookmarks_revset.or(fallback.bookmarks_revset),

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,7 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
         &remote_name,
         args.pr_mode(),
         args.sync_pr_content,
+        args.trailers,
     )
     .await?;
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
+use crate::cli::submit::TrailerHandling;
 use crate::forge::CreatePrParams;
 use crate::forge::Forge;
 use crate::forge::ForgeError;
@@ -36,7 +37,7 @@ use crate::graph::types::SegmentCommit;
 use crate::jj::Jj;
 use crate::jj::JjError;
 use crate::jj::runner::JjRunner;
-use crate::submit::trailers::strip_trailers;
+use crate::submit::trailers::split_trailers;
 use crate::submit::unwrap::unwrap_markdown;
 
 /// Errors from the submission pipeline.
@@ -296,32 +297,47 @@ pub fn analyze_submission(
 /// - Single commit: lines after the first (the title line) become the body.
 /// - Multiple commits: concatenate all descriptions with `---` separators.
 /// - If the result is empty or whitespace-only, returns `None`.
-fn build_pr_body(commits: &[SegmentCommit]) -> Option<String> {
+///
+/// Trailer blocks (Signed-off-by, Co-authored-by, Refs, etc.) are
+/// removed from the unwrap pass and either dropped (`Strip`) or
+/// reattached verbatim after unwrapping (`Keep`), so multi-line
+/// trailer blocks survive intact.
+fn build_pr_body(commits: &[SegmentCommit], trailers: TrailerHandling) -> Option<String> {
     if commits.is_empty() {
         return None;
     }
 
-    let body = if commits.len() == 1 {
-        // Single commit: strip trailers, then strip the first line (title)
-        // and use the rest.
-        let desc = strip_trailers(commits[0].description.trim());
-        let rest = desc.lines().skip(1).collect::<Vec<_>>().join("\n");
-        rest.trim().to_string()
-    } else {
-        // Multiple commits: strip trailers from each, then concatenate.
-        let parts: Vec<&str> = commits
-            .iter()
-            .map(|c| strip_trailers(c.description.trim()))
-            .filter(|d| !d.is_empty())
-            .collect();
-        parts.join("\n\n---\n\n")
-    };
+    let parts: Vec<String> = commits
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, c)| {
+            let (body, trailer_block) = split_trailers(c.description.trim());
+            // For the single-commit case, drop the title (first) line.
+            let body_text = if commits.len() == 1 && idx == 0 {
+                body.lines().skip(1).collect::<Vec<_>>().join("\n")
+            } else {
+                body.to_string()
+            };
+            let unwrapped = unwrap_markdown(body_text.trim());
+            let kept_trailers = match trailers {
+                TrailerHandling::Keep => trailer_block,
+                TrailerHandling::Strip => None,
+            };
+            match (unwrapped.is_empty(), kept_trailers) {
+                (true, None) => None,
+                (true, Some(tb)) => Some(tb.to_string()),
+                (false, None) => Some(unwrapped),
+                (false, Some(tb)) => Some(format!("{unwrapped}\n\n{tb}")),
+            }
+        })
+        .collect();
 
-    if body.is_empty() {
-        None
-    } else {
-        Some(unwrap_markdown(&body))
+    if parts.is_empty() {
+        return None;
     }
+
+    let body = parts.join("\n\n---\n\n");
+    if body.is_empty() { None } else { Some(body) }
 }
 
 // ---------------------------------------------------------------------------
@@ -338,6 +354,7 @@ pub async fn create_submission_plan<F: Forge>(
     remote: &str,
     pr_mode: PrMode,
     sync: SyncPrContent,
+    trailers: TrailerHandling,
 ) -> Result<SubmissionPlan, SubmitError> {
     // Collect bookmark names for concurrent PR lookup.
     let bookmark_names: Vec<String> = analysis
@@ -389,7 +406,7 @@ pub async fn create_submission_plan<F: Forge>(
 
         let needs_create = existing_pr.is_none();
 
-        let body = build_pr_body(&segment.commits);
+        let body = build_pr_body(&segment.commits, trailers);
 
         let wants_title = matches!(sync, SyncPrContent::Title | SyncPrContent::All);
         let wants_body = matches!(sync, SyncPrContent::Body | SyncPrContent::All);
@@ -1282,6 +1299,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::None,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1313,6 +1331,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::None,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1346,6 +1365,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::None,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1378,6 +1398,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::None,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1402,6 +1423,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::All,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1426,6 +1448,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::All,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1455,6 +1478,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::All,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1483,6 +1507,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::All,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1505,6 +1530,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::None,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1528,6 +1554,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::All,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1554,6 +1581,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::Title,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -1580,6 +1608,7 @@ mod tests {
             "origin",
             PrMode::Regular,
             SyncPrContent::Body,
+            TrailerHandling::Keep,
         )
         .await
         .unwrap();
@@ -2184,7 +2213,7 @@ mod tests {
             short_change_id: "ch1".to_string(),
         }];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
         assert_eq!(
             body.as_deref(),
             Some("This adds feature X with foo and bar.")
@@ -2211,7 +2240,7 @@ mod tests {
             short_change_id: "ch1".to_string(),
         }];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
         assert_eq!(body, None);
     }
 
@@ -2254,7 +2283,7 @@ mod tests {
             },
         ];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
         assert_eq!(
             body.as_deref(),
             Some("First commit\n\n---\n\nSecond commit")
@@ -2263,7 +2292,7 @@ mod tests {
 
     #[test]
     fn build_pr_body_empty() {
-        let body = build_pr_body(&[]);
+        let body = build_pr_body(&[], TrailerHandling::Keep);
         assert_eq!(body, None);
     }
 
@@ -2289,7 +2318,7 @@ mod tests {
             short_change_id: "ch1".to_string(),
         }];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Strip);
         assert_eq!(body.as_deref(), Some("This adds feature X."));
     }
 
@@ -2313,7 +2342,7 @@ mod tests {
             short_change_id: "ch1".to_string(),
         }];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Strip);
         assert_eq!(body, None);
     }
 
@@ -2356,10 +2385,112 @@ mod tests {
             },
         ];
 
-        let body = build_pr_body(&commits);
+        let body = build_pr_body(&commits, TrailerHandling::Strip);
         assert_eq!(
             body.as_deref(),
             Some("First commit\n\n---\n\nSecond commit\n\nWith a body.")
+        );
+    }
+
+    #[test]
+    fn build_pr_body_single_commit_keeps_trailers() {
+        let commits = vec![SegmentCommit {
+            commit_id: "c1".to_string(),
+            change_id: "ch1".to_string(),
+            description: "Add feature X\n\nThis adds feature X.\n\nSigned-off-by: Alice \
+                          <a@b>\nRefs: DAT-123"
+                .to_string(),
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            committer: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
+            short_change_id: "ch1".to_string(),
+        }];
+
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
+        assert_eq!(
+            body.as_deref(),
+            Some("This adds feature X.\n\nSigned-off-by: Alice <a@b>\nRefs: DAT-123")
+        );
+    }
+
+    #[test]
+    fn build_pr_body_single_commit_title_plus_trailers_only_kept() {
+        let commits = vec![SegmentCommit {
+            commit_id: "c1".to_string(),
+            change_id: "ch1".to_string(),
+            description: "Add feature X\n\nSigned-off-by: Alice <a@b>".to_string(),
+            author: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            committer: crate::jj::types::Signature {
+                name: "Test".to_string(),
+                email: "test@test.com".to_string(),
+                timestamp: "T".to_string(),
+            },
+            files: vec![],
+            short_change_id: "ch1".to_string(),
+        }];
+
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
+        assert_eq!(body.as_deref(), Some("Signed-off-by: Alice <a@b>"));
+    }
+
+    #[test]
+    fn build_pr_body_multiple_commits_keeps_trailers() {
+        let commits = vec![
+            SegmentCommit {
+                commit_id: "c1".to_string(),
+                change_id: "ch1".to_string(),
+                description: "First commit\n\nSigned-off-by: Alice <a@b>".to_string(),
+                author: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                committer: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                files: vec![],
+                short_change_id: "ch1".to_string(),
+            },
+            SegmentCommit {
+                commit_id: "c2".to_string(),
+                change_id: "ch2".to_string(),
+                description: "Second commit\n\nWith a body.\n\nRefs: DAT-456".to_string(),
+                author: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                committer: crate::jj::types::Signature {
+                    name: "Test".to_string(),
+                    email: "test@test.com".to_string(),
+                    timestamp: "T".to_string(),
+                },
+                files: vec![],
+                short_change_id: "ch2".to_string(),
+            },
+        ];
+
+        let body = build_pr_body(&commits, TrailerHandling::Keep);
+        assert_eq!(
+            body.as_deref(),
+            Some(
+                "First commit\n\nSigned-off-by: Alice <a@b>\n\n---\n\nSecond commit\n\nWith a \
+                 body.\n\nRefs: DAT-456"
+            )
         );
     }
 

--- a/src/submit/trailers.rs
+++ b/src/submit/trailers.rs
@@ -1,21 +1,26 @@
-/// Strip git commit trailers from a commit description.
+/// Split a commit description into `(body, trailers)`.
 ///
-/// Returns a substring of the input with the trailing trailer block removed, if
-/// present. A trailer block is the last paragraph (separated from the rest by
-/// one or more blank lines) where every non-empty line matches the standard git
-/// trailer format: `Key: value`.
+/// A trailer block is the last paragraph (separated from the rest by one
+/// or more blank lines) where every non-empty line matches the standard
+/// git trailer format: `Key: value`.
 ///
-/// If the input has only one paragraph, it is returned unchanged — a single
-/// paragraph cannot be both content and trailers.
+/// `body` is the input with the trailer block removed. `trailers` is
+/// `Some(block)` when a trailer block was found, where `block` is the
+/// verbatim trailer substring (each trailer on its own line, no leading
+/// or trailing blank lines). When no trailer block is detected, returns
+/// `(trimmed_text, None)`.
 ///
-/// **Known limitation:** continuation lines (indented follow-up lines within a
-/// trailer value) are not recognized. If the last paragraph contains a mix of
-/// trailer lines and non-trailer lines (including continuations), the entire
-/// paragraph is conservatively kept.
-pub(crate) fn strip_trailers(text: &str) -> &str {
+/// If the input has only one paragraph, it is returned unchanged — a
+/// single paragraph cannot be both content and trailers.
+///
+/// **Known limitation:** continuation lines (indented follow-up lines
+/// within a trailer value) are not recognized. If the last paragraph
+/// contains a mix of trailer lines and non-trailer lines (including
+/// continuations), the entire paragraph is conservatively kept.
+pub(crate) fn split_trailers(text: &str) -> (&str, Option<&str>) {
     let trimmed = text.trim_end();
     if trimmed.is_empty() {
-        return trimmed;
+        return (trimmed, None);
     }
 
     // Find the boundary between the last paragraph and everything before it.
@@ -40,13 +45,13 @@ pub(crate) fn strip_trailers(text: &str) -> &str {
     // If we walked all the way to the start without finding a blank line, the
     // entire text is one paragraph — return unchanged.
     if i == 0 {
-        return trimmed;
+        return (trimmed, None);
     }
 
     let last_paragraph_start = trimmed[i..].find(|c: char| c != '\n' && c != '\r');
     let last_paragraph_start = match last_paragraph_start {
         Some(offset) => i + offset,
-        None => return trimmed,
+        None => return (trimmed, None),
     };
 
     let last_paragraph = &trimmed[last_paragraph_start..];
@@ -58,11 +63,10 @@ pub(crate) fn strip_trailers(text: &str) -> &str {
         .all(is_trailer_line);
 
     if !all_trailers {
-        return trimmed;
+        return (trimmed, None);
     }
 
-    // Strip: return everything before the blank-line boundary, trimmed.
-    trimmed[..i].trim_end()
+    (trimmed[..i].trim_end(), Some(last_paragraph))
 }
 
 /// Check if a line matches the git trailer format: `Key: value`.
@@ -84,90 +88,112 @@ fn is_trailer_line(line: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn body(text: &str) -> &str {
+        split_trailers(text).0
+    }
+
+    fn block(text: &str) -> Option<&str> {
+        split_trailers(text).1
+    }
+
     #[test]
     fn body_with_trailers() {
         let input = "feat: add caching\n\nThis adds Redis caching.\n\nSigned-off-by: Alice \
                      <a@b>\nRefs: DAT-123";
+        assert_eq!(body(input), "feat: add caching\n\nThis adds Redis caching.");
         assert_eq!(
-            strip_trailers(input),
-            "feat: add caching\n\nThis adds Redis caching."
+            block(input),
+            Some("Signed-off-by: Alice <a@b>\nRefs: DAT-123")
         );
     }
 
     #[test]
     fn no_trailers() {
         let input = "feat: add caching\n\nThis adds Redis caching.";
-        assert_eq!(strip_trailers(input), input);
+        assert_eq!(body(input), input);
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn title_plus_trailers_no_body() {
         let input = "feat: add caching\n\nSigned-off-by: Alice <a@b>";
-        assert_eq!(strip_trailers(input), "feat: add caching");
+        assert_eq!(body(input), "feat: add caching");
+        assert_eq!(block(input), Some("Signed-off-by: Alice <a@b>"));
     }
 
     #[test]
     fn title_only() {
         let input = "feat: add caching";
-        assert_eq!(strip_trailers(input), input);
+        assert_eq!(body(input), input);
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn mixed_trailer_and_non_trailer_last_paragraph() {
         let input = "title\n\nbody\n\nSigned-off-by: Alice <a@b>\nThis is not a trailer";
-        assert_eq!(strip_trailers(input), input.trim_end());
+        assert_eq!(body(input), input.trim_end());
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn multiple_paragraphs_only_last_is_trailers() {
         let input = "title\n\nbody\n\nRefs: X\n\nSigned-off-by: Alice <a@b>";
-        assert_eq!(strip_trailers(input), "title\n\nbody\n\nRefs: X");
+        assert_eq!(body(input), "title\n\nbody\n\nRefs: X");
+        assert_eq!(block(input), Some("Signed-off-by: Alice <a@b>"));
     }
 
     #[test]
     fn empty_input() {
-        assert_eq!(strip_trailers(""), "");
+        assert_eq!(body(""), "");
+        assert_eq!(block(""), None);
     }
 
     #[test]
     fn single_paragraph_no_blank_lines() {
         let input = "Signed-off-by: Alice <a@b>\nRefs: DAT-123";
-        assert_eq!(strip_trailers(input), input);
+        assert_eq!(body(input), input);
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn multiple_blank_lines_before_trailers() {
         let input = "feat: add caching\n\nBody text.\n\n\nSigned-off-by: Alice <a@b>";
-        assert_eq!(strip_trailers(input), "feat: add caching\n\nBody text.");
+        assert_eq!(body(input), "feat: add caching\n\nBody text.");
+        assert_eq!(block(input), Some("Signed-off-by: Alice <a@b>"));
     }
 
     #[test]
     fn trailing_whitespace_in_input() {
         let input = "feat: add caching\n\nBody.\n\nRefs: DAT-123\n  ";
-        assert_eq!(strip_trailers(input), "feat: add caching\n\nBody.");
+        assert_eq!(body(input), "feat: add caching\n\nBody.");
+        assert_eq!(block(input), Some("Refs: DAT-123"));
     }
 
     #[test]
     fn co_authored_by_trailer() {
         let input = "fix: resolve deadlock\n\nCo-authored-by: Bob <bob@example.com>";
-        assert_eq!(strip_trailers(input), "fix: resolve deadlock");
+        assert_eq!(body(input), "fix: resolve deadlock");
+        assert_eq!(block(input), Some("Co-authored-by: Bob <bob@example.com>"));
     }
 
     #[test]
     fn key_with_no_space_after_colon_is_not_trailer() {
         let input = "title\n\nbody\n\nNot-a-trailer:no space here";
-        assert_eq!(strip_trailers(input), input);
+        assert_eq!(body(input), input);
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn key_with_spaces_is_not_trailer() {
         let input = "title\n\nbody\n\nNot a trailer: value here";
-        assert_eq!(strip_trailers(input), input);
+        assert_eq!(body(input), input);
+        assert_eq!(block(input), None);
     }
 
     #[test]
     fn trailer_value_can_contain_colons() {
         let input = "title\n\nbody\n\nRefs: https://example.com:8080/path";
-        assert_eq!(strip_trailers(input), "title\n\nbody");
+        assert_eq!(body(input), "title\n\nbody");
+        assert_eq!(block(input), Some("Refs: https://example.com:8080/path"));
     }
 }


### PR DESCRIPTION
Adds `--trailers <keep|strip>` (env `STAKK_TRAILERS`) on `stakk submit` to control whether git commit trailers (Signed-off-by, Co-authored-by, Refs, etc.) are kept in PR bodies or stripped before posting to the forge.

The default flips from strip to **keep**, since trailers are user-authored content that downstream squash-and-merge workflows ("PR title and description" merge messages) often expect to find in the merge commit. Users who relied on the prior unconditional stripping should set `--trailers strip` or `STAKK_TRAILERS=strip`.

## Implementation notes

- `strip_trailers` is replaced by `split_trailers`, returning `(body, Option<trailer_block>)`. This lets the unwrap pass operate on the body alone and reattach the trailer block verbatim, so multi-line trailer blocks are no longer mashed into a single line by markdown reflow.
- `build_pr_body` now splits each commit description, unwraps only the body part, and reattaches kept trailers per mode.
- `TrailerHandling` enum follows the existing `SyncPrContent` pattern in `src/cli/submit.rs`, leaving room to grow into per-key control without reshaping the CLI surface.

Closes #79.