### PR TITLE
chore: release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0](https://github.com/glennib/stakk/compare/v1.13.1...v1.14.0) - 2026-04-28
+
+### Added
+
+- *(submit)* `--trailers <keep|strip>` flag, `STAKK_TRAILERS` env var, and
+  `trailers` config field for controlling whether git commit trailers
+  (Signed-off-by, Co-authored-by, Refs, etc.) are kept in PR bodies or
+  stripped before posting. Closes [#79](https://github.com/glennib/stakk/issues/79).
+
+### Changed
+
+- **Default trailer handling flipped from strip to keep.** v1.13.x stripped
+  trailers from PR bodies unconditionally; v1.14 keeps them by default so
+  squash-and-merge workflows that derive the merge message from the PR
+  description preserve trailers in the merge commit. Set `--trailers strip`
+  or `STAKK_TRAILERS=strip` (or `trailers = "strip"` in `stakk.toml`) to
+  restore the previous behavior.
+
+### Fixed
+
+- *(submit)* multi-line trailer blocks are no longer mashed into a single
+  line by markdown reflow when present in PR bodies.
+
 ## [1.13.1](https://github.com/glennib/stakk/compare/v1.13.0...v1.13.1) - 2026-04-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.13.1 -> 1.14.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.14.0](https://github.com/glennib/stakk/compare/v1.13.1...v1.14.0) - 2026-04-28

### Added

- *(submit)* make trailer handling configurable

### Other

- remove redundant cli help text
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).