### PR TITLE
chore: release v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1](https://github.com/glennib/stakk/compare/v1.14.0...v1.14.1) - 2026-05-25
+
+### Other
+
+- *(deps)* update rust crate http to v1.4.1 ([#104](https://github.com/glennib/stakk/pull/104))
+- *(deps)* lock file maintenance ([#103](https://github.com/glennib/stakk/pull/103))
+- *(deps)* update dependency cargo:cargo-dist to 0.32.0 ([#102](https://github.com/glennib/stakk/pull/102))
+- *(deps)* update rust crate serde_json to v1.0.150 ([#101](https://github.com/glennib/stakk/pull/101))
+- *(deps)* update rust crate minijinja to v2.20.0 ([#100](https://github.com/glennib/stakk/pull/100))
+- *(deps)* lock file maintenance ([#99](https://github.com/glennib/stakk/pull/99))
+- *(deps)* update rust crate clap_complete to v4.6.5 ([#98](https://github.com/glennib/stakk/pull/98))
+- *(deps)* lock file maintenance ([#97](https://github.com/glennib/stakk/pull/97))
+- *(deps)* update rust crate clap_complete to v4.6.4 ([#96](https://github.com/glennib/stakk/pull/96))
+- *(deps)* update rust crate tokio to v1.52.3 ([#95](https://github.com/glennib/stakk/pull/95))
+- *(deps)* update dependency cargo-binstall to v1.19.1 ([#94](https://github.com/glennib/stakk/pull/94))
+- *(deps)* update rust crate tokio to v1.52.2 ([#92](https://github.com/glennib/stakk/pull/92))
+- *(deps)* lock file maintenance ([#91](https://github.com/glennib/stakk/pull/91))
+- *(deps)* update dependency cargo-binstall to v1.19.0 ([#90](https://github.com/glennib/stakk/pull/90))
+- *(deps)* update dependency cargo-binstall to v1.18.1 ([#87](https://github.com/glennib/stakk/pull/87))
+
 ## [1.14.0](https://github.com/glennib/stakk/compare/v1.13.1...v1.14.0) - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,7 +2680,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.14.0"
+version = "1.14.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.14.0 -> 1.14.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.14.1](https://github.com/glennib/stakk/compare/v1.14.0...v1.14.1) - 2026-05-25

### Other

- *(deps)* update rust crate http to v1.4.1 ([#104](https://github.com/glennib/stakk/pull/104))
- *(deps)* lock file maintenance ([#103](https://github.com/glennib/stakk/pull/103))
- *(deps)* update dependency cargo:cargo-dist to 0.32.0 ([#102](https://github.com/glennib/stakk/pull/102))
- *(deps)* update rust crate serde_json to v1.0.150 ([#101](https://github.com/glennib/stakk/pull/101))
- *(deps)* update rust crate minijinja to v2.20.0 ([#100](https://github.com/glennib/stakk/pull/100))
- *(deps)* lock file maintenance ([#99](https://github.com/glennib/stakk/pull/99))
- *(deps)* update rust crate clap_complete to v4.6.5 ([#98](https://github.com/glennib/stakk/pull/98))
- *(deps)* lock file maintenance ([#97](https://github.com/glennib/stakk/pull/97))
- *(deps)* update rust crate clap_complete to v4.6.4 ([#96](https://github.com/glennib/stakk/pull/96))
- *(deps)* update rust crate tokio to v1.52.3 ([#95](https://github.com/glennib/stakk/pull/95))
- *(deps)* update dependency cargo-binstall to v1.19.1 ([#94](https://github.com/glennib/stakk/pull/94))
- *(deps)* update rust crate tokio to v1.52.2 ([#92](https://github.com/glennib/stakk/pull/92))
- *(deps)* lock file maintenance ([#91](https://github.com/glennib/stakk/pull/91))
- *(deps)* update dependency cargo-binstall to v1.19.0 ([#90](https://github.com/glennib/stakk/pull/90))
- *(deps)* update dependency cargo-binstall to v1.18.1 ([#87](https://github.com/glennib/stakk/pull/87))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).