### PR TITLE
chore: release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0](https://github.com/glennib/stakk/compare/v1.14.1...v1.15.0) - 2026-06-06
+
+### Added
+
+- *(jj)* echo the failing command in jj error messages
+
 ## [1.14.1](https://github.com/glennib/stakk/compare/v1.14.0...v1.14.1) - 2026-05-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.14.1"
+version = "1.15.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.14.1"
+version = "1.15.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.14.1 -> 1.15.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.15.0](https://github.com/glennib/stakk/compare/v1.14.1...v1.15.0) - 2026-06-06

### Added

- *(jj)* echo the failing command in jj error messages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).