### PR TITLE
feat(jj): echo the failing command in jj error messages

### DIFF
--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -22,9 +22,9 @@ use crate::jj::types::LogEntryRaw;
 #[derive(Debug, Error, Diagnostic)]
 pub enum JjError {
     /// The `jj` command exited with a non-zero status.
-    #[error("jj command failed: {stderr}")]
+    #[error("jj command failed: {command}\n{stderr}")]
     #[diagnostic(code(stakk::jj::command_failed))]
-    CommandFailed { stderr: String },
+    CommandFailed { command: String, stderr: String },
 
     /// Failed to parse `jj` output.
     #[error("failed to parse jj output ({context}): {source}")]

--- a/src/jj/runner.rs
+++ b/src/jj/runner.rs
@@ -25,9 +25,52 @@ impl JjRunner for RealJjRunner {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(JjError::CommandFailed { stderr });
+            return Err(JjError::CommandFailed {
+                command: render_command(args),
+                stderr,
+            });
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}
+
+/// Render the full jj invocation (including the always-passed `--config`
+/// prefix) as a copy-pasteable shell-style string for error messages.
+fn render_command(args: &[&str]) -> String {
+    std::iter::once("jj")
+        .chain(["--config", "ui.paginate=never"])
+        .chain(args.iter().copied())
+        .map(|arg| {
+            if arg.is_empty() || arg.contains(char::is_whitespace) {
+                format!("'{}'", arg.replace('\'', r"'\''"))
+            } else {
+                arg.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_command_includes_config_prefix() {
+        let rendered = render_command(&["git", "push", "--remote", "origin"]);
+        assert_eq!(
+            rendered,
+            "jj --config ui.paginate=never git push --remote origin"
+        );
+    }
+
+    #[test]
+    fn render_command_quotes_args_with_whitespace() {
+        let rendered = render_command(&["log", "-T", r#"json(self) ++ "\n""#]);
+        assert_eq!(
+            rendered,
+            r#"jj --config ui.paginate=never log -T 'json(self) ++ "\n"'"#
+        );
     }
 }


### PR DESCRIPTION
`JjError::CommandFailed` now carries the full `jj` invocation (including the always-passed `--config ui.paginate=never` prefix) and renders it on the first line of the error message, before the captured stderr. Arguments containing whitespace are single-quoted so the line is copy-pasteable into a shell.