### PR TITLE
fix(jj): drop removed `--allow-new` flag from `jj git push`

### DIFF
--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -174,15 +174,7 @@ impl<R: JjRunner> Jj<R> {
     /// Push a bookmark to a remote.
     pub async fn push_bookmark(&self, bookmark: &str, remote: &str) -> Result<(), JjError> {
         self.runner
-            .run_jj(&[
-                "git",
-                "push",
-                "--remote",
-                remote,
-                "--bookmark",
-                bookmark,
-                "--allow-new",
-            ])
+            .run_jj(&["git", "push", "--remote", remote, "--bookmark", bookmark])
             .await?;
         Ok(())
     }


### PR DESCRIPTION
jj 0.42 rejects `--allow-new` with "unexpected argument", breaking every push of a new bookmark. Pushing new bookmarks is now jj's default behavior — per `jj git push --help`, a bookmark that isn't tracking anything yet is pushed and tracked automatically — so the flag is simply removed.

Note: this changes behavior on old jj versions where `--allow-new` was required to push new bookmarks; those versions will refuse the push. Supporting both would require runtime version detection, which isn't worth the complexity.