### PR TITLE
feat(jj): warn on startup when jj is older than the minimum supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ address new features and desired changes.
 
 ## Installation
 
+### Requirements
+
+stakk shells out to the [`jj`](https://github.com/jj-vcs/jj) CLI, which must be
+installed and on your `PATH`. The minimum supported jj version is **0.39.0**.
+Older versions may work but are untested; stakk prints a warning when it detects
+one.
+
 ### mise (recommended)
 
 ```

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -7,6 +7,7 @@
 pub mod remote;
 pub mod runner;
 pub mod types;
+pub mod version;
 
 use miette::Diagnostic;
 use thiserror::Error;
@@ -17,6 +18,7 @@ use crate::jj::types::BookmarkEntryRaw;
 use crate::jj::types::GitRemote;
 use crate::jj::types::LogEntry;
 use crate::jj::types::LogEntryRaw;
+use crate::jj::version::JjVersion;
 
 /// Errors from interacting with `jj`.
 #[derive(Debug, Error, Diagnostic)]
@@ -66,6 +68,16 @@ pub struct Jj<R: JjRunner> {
 impl<R: JjRunner> Jj<R> {
     pub fn new(runner: R) -> Self {
         Self { runner }
+    }
+
+    /// Query and parse `jj --version`.
+    ///
+    /// Returns `Ok(None)` when jj ran but produced output we couldn't parse
+    /// (e.g. an unusual dev build) — callers should stay silent in that case.
+    /// Returns `Err` only when jj could not be run at all.
+    pub async fn version(&self) -> Result<Option<JjVersion>, JjError> {
+        let output = self.runner.run_jj(&["--version"]).await?;
+        Ok(version::parse(&output))
     }
 
     /// List bookmarks matching the given revset.
@@ -573,5 +585,62 @@ mod tests {
         jj.create_bookmark("stakk-abcdefghijkl", "abcdefghijklmnop")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn version_parses_plain() {
+        let runner = MockJjRunner {
+            handler: |args: &[&str]| {
+                assert_eq!(args, ["--version"]);
+                Ok("jj 0.42.0\n".to_string())
+            },
+        };
+        let jj = Jj::new(runner);
+        let version = jj.version().await.unwrap();
+        assert_eq!(
+            version,
+            Some(JjVersion {
+                major: 0,
+                minor: 42,
+                patch: 0
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn version_dev_build_parses() {
+        let runner = MockJjRunner {
+            handler: |_args: &[&str]| {
+                Ok("jj 0.42.0-b8f7c455170e3273897aaf94431f8ccfb1afa7ad\n".to_string())
+            },
+        };
+        let jj = Jj::new(runner);
+        let version = jj.version().await.unwrap();
+        assert_eq!(
+            version,
+            Some(JjVersion {
+                major: 0,
+                minor: 42,
+                patch: 0
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn version_garbage_is_none() {
+        let runner = MockJjRunner {
+            handler: |_args: &[&str]| Ok("not a version\n".to_string()),
+        };
+        let jj = Jj::new(runner);
+        assert_eq!(jj.version().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn version_runner_error_propagates() {
+        let runner = MockJjRunner {
+            handler: |_args: &[&str]| Err(JjError::NotFound(std::io::Error::other("boom"))),
+        };
+        let jj = Jj::new(runner);
+        assert!(jj.version().await.is_err());
     }
 }

--- a/src/jj/version.rs
+++ b/src/jj/version.rs
@@ -1,0 +1,158 @@
+//! jj version parsing and the minimum supported version.
+
+use std::fmt;
+
+/// A parsed jj version (`major.minor.patch`).
+///
+/// Pre-release / build suffixes (e.g. the git hash on dev builds) are tolerated
+/// by [`parse`] but not stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct JjVersion {
+    // Field order matters: the derived `Ord` compares lexicographically, so
+    // major must come before minor before patch.
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+impl fmt::Display for JjVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// The oldest jj release stakk is tested against.
+///
+/// This is the latest jj release (0.39.0, 2026-03-04) at the time stakk v1.0.0
+/// shipped (2026-03-09). Older versions may still work — for example via user
+/// config — but are untested, so we only warn rather than refuse to run.
+pub const MIN_SUPPORTED_JJ_VERSION: JjVersion = JjVersion {
+    major: 0,
+    minor: 39,
+    patch: 0,
+};
+
+/// Parse the output of `jj --version`.
+///
+/// Handles plain output (`jj 0.42.0`) and dev builds with a git-hash suffix
+/// (`jj 0.42.0-b8f7c455...`). Returns `None` on any output we can't confidently
+/// parse, so callers can stay silent rather than nag on unusual builds.
+pub fn parse(output: &str) -> Option<JjVersion> {
+    // Take the token after the leading "jj" word; tolerant of extra whitespace.
+    let token = output.split_whitespace().nth(1)?;
+    // Strip a dev-build suffix like "-b8f7c455...".
+    let core = token.split('-').next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    // Reject trailing junk like "0.42.0.1".
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(JjVersion {
+        major,
+        minor,
+        patch,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_plain() {
+        assert_eq!(
+            parse("jj 0.42.0"),
+            Some(JjVersion {
+                major: 0,
+                minor: 42,
+                patch: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_dev_suffix() {
+        assert_eq!(
+            parse("jj 0.42.0-b8f7c455170e3273897aaf94431f8ccfb1afa7ad"),
+            Some(JjVersion {
+                major: 0,
+                minor: 42,
+                patch: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_trailing_newline() {
+        assert_eq!(
+            parse("jj 0.42.0\n"),
+            Some(JjVersion {
+                major: 0,
+                minor: 42,
+                patch: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_garbage() {
+        assert_eq!(parse("not a version"), None);
+    }
+
+    #[test]
+    fn parse_empty() {
+        assert_eq!(parse(""), None);
+    }
+
+    #[test]
+    fn parse_partial() {
+        assert_eq!(parse("jj 0.42"), None);
+    }
+
+    #[test]
+    fn parse_extra_component() {
+        assert_eq!(parse("jj 0.42.0.1"), None);
+    }
+
+    #[test]
+    fn ord_compares_correctly() {
+        let v038 = JjVersion {
+            major: 0,
+            minor: 38,
+            patch: 99,
+        };
+        let v039 = JjVersion {
+            major: 0,
+            minor: 39,
+            patch: 0,
+        };
+        let v100 = JjVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
+        };
+        assert!(v038 < v039);
+        assert!(v039 < v100);
+        assert_eq!(v039.cmp(&v039), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn min_version_is_0_39_0() {
+        assert_eq!(
+            MIN_SUPPORTED_JJ_VERSION,
+            JjVersion {
+                major: 0,
+                minor: 39,
+                patch: 0
+            }
+        );
+    }
+
+    #[test]
+    fn display_roundtrip() {
+        assert_eq!(MIN_SUPPORTED_JJ_VERSION.to_string(), "0.39.0");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use crate::forge::Forge;
 use crate::jj::Jj;
 use crate::jj::remote::parse_github_url;
 use crate::jj::runner::RealJjRunner;
+use crate::jj::version::MIN_SUPPORTED_JJ_VERSION;
 
 #[tokio::main]
 async fn main() {
@@ -41,6 +42,17 @@ async fn run() -> Result<(), StakkError> {
     let config = config::Config::load(config_path)?;
     let cmd = cli::apply_config_defaults(config, Cli::command());
     let cli = Cli::from_arg_matches(&cmd.get_matches())?;
+
+    // Warn about an outdated jj for commands that shell out to it. Commands that
+    // never touch jj (completions, `auth setup`) skip the check.
+    let runs_jj = match &cli.command {
+        Some(Commands::Completions { .. }) => false,
+        Some(Commands::Auth(args)) => matches!(args.command, AuthCommands::Test),
+        _ => true, // Submit, Show, and None (= submit) all use jj.
+    };
+    if runs_jj {
+        warn_if_jj_too_old().await;
+    }
 
     match cli.command {
         Some(Commands::Submit(args)) => {
@@ -66,6 +78,24 @@ async fn run() -> Result<(), StakkError> {
     }
 
     Ok(())
+}
+
+/// Warn (to stderr) if the installed jj is older than the minimum supported
+/// version.
+///
+/// Never fails the command: if jj can't be run, or its version output can't be
+/// parsed (e.g. an unusual dev build), this stays silent. A genuine jj problem
+/// surfaces moments later with a more specific diagnostic.
+async fn warn_if_jj_too_old() {
+    let jj = Jj::new(RealJjRunner);
+    if let Ok(Some(version)) = jj.version().await
+        && version < MIN_SUPPORTED_JJ_VERSION
+    {
+        eprintln!(
+            "Warning: jj {version} is older than the minimum supported version \
+             ({MIN_SUPPORTED_JJ_VERSION}). stakk may not work correctly — consider upgrading jj."
+        );
+    }
 }
 
 async fn auth_test() -> Result<(), StakkError> {


### PR DESCRIPTION
stakk supports jj >= 0.39.0 (the latest jj release when v1.0.0 shipped). Older versions are untested and may break.

Add a `JjVersion` type, a `MIN_SUPPORTED_JJ_VERSION` constant, and a pure parser that tolerates dev-build hash suffixes and unparseable output. At startup of jj-using commands (submit, show, auth test) stakk runs `jj --version` and prints a stderr warning if it is older than the minimum. The check never fails the command: it stays silent on unparseable output and on jj being missing. Completions and `auth setup` skip the check.