### PR TITLE
chore: release v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1](https://github.com/glennib/stakk/compare/v1.16.0...v1.16.1) - 2026-06-08
+
+### Fixed
+
+- standardize capitalization of diagnostic help messages
+- *(jj)* drop removed `--allow-new` flag from `jj git push`
+
 ## [1.16.0](https://github.com/glennib/stakk/compare/v1.15.0...v1.16.0) - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.16.0 -> 1.16.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.16.1](https://github.com/glennib/stakk/compare/v1.16.0...v1.16.1) - 2026-06-08

### Fixed

- standardize capitalization of diagnostic help messages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).