### PR TITLE
chore: release v1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.2](https://github.com/glennib/stakk/compare/v1.16.1...v1.16.2) - 2026-06-10
+
+### Fixed
+
+- *(submit)* identify the segment in the missing-bookmark error
+- *(errors)* add actionable help to auth and jj parse errors
+- *(deps)* update rust crate octocrab to 0.53.0 ([#93](https://github.com/glennib/stakk/pull/93))
+
+### Other
+
+- remove remaining future-milestone dead code
+- remove dead code and clarify expect() reasons
+- *(deps)* update dependency cargo-binstall to v1.20.0 ([#115](https://github.com/glennib/stakk/pull/115))
+
 ## [1.16.1](https://github.com/glennib/stakk/compare/v1.16.0...v1.16.1) - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,7 +2751,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.16.1"
+version = "1.16.2"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.16.1"
+version = "1.16.2"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.16.1 -> 1.16.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.16.2](https://github.com/glennib/stakk/compare/v1.16.1...v1.16.2) - 2026-06-10

### Fixed

- *(submit)* identify the segment in the missing-bookmark error
- *(errors)* add actionable help to auth and jj parse errors
- *(deps)* update rust crate octocrab to 0.53.0 ([#93](https://github.com/glennib/stakk/pull/93))

### Other

- remove remaining future-milestone dead code
- remove dead code and clarify expect() reasons
- *(deps)* update dependency cargo-binstall to v1.20.0 ([#115](https://github.com/glennib/stakk/pull/115))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).