### PR TITLE
refactor: remove dead code and clarify expect() reasons

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -42,12 +42,15 @@ pub enum AuthError {
     #[error("no GitHub authentication found")]
     #[diagnostic(
         code(stakk::auth::no_token),
-        help("Run `gh auth login` or set GITHUB_TOKEN/GH_TOKEN")
+        help("run `gh auth login` or set GITHUB_TOKEN/GH_TOKEN")
     )]
     NoAuthFound,
 
     #[error("failed to run `gh auth token`: {0}")]
-    #[diagnostic(code(stakk::auth::gh_cli_error))]
+    #[diagnostic(
+        code(stakk::auth::gh_cli_error),
+        help("install the `gh` CLI, or set GITHUB_TOKEN/GH_TOKEN to skip it")
+    )]
     GhCliError(std::io::Error),
 }
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -20,11 +20,6 @@ pub enum ForgeError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[expect(dead_code, reason = "used in later milestones for PR lookup errors")]
-    #[error("PR not found: #{number}")]
-    #[diagnostic(code(stakk::forge::pr_not_found))]
-    PrNotFound { number: u64 },
-
     #[error("authentication failed: {message}")]
     #[diagnostic(
         code(stakk::forge::auth_failed),
@@ -45,14 +40,6 @@ pub enum ForgeError {
         )
     )]
     MalformedResponse { field: &'static str },
-
-    #[expect(dead_code, reason = "used in later milestones for rate limit handling")]
-    #[error("rate limited; retry after {retry_after_seconds}s")]
-    #[diagnostic(
-        code(stakk::forge::rate_limited),
-        help("wait {retry_after_seconds}s and retry")
-    )]
-    RateLimited { retry_after_seconds: u64 },
 }
 
 /// State of a pull request.
@@ -69,10 +56,16 @@ pub struct PullRequest {
     pub number: u64,
     pub html_url: String,
     pub title: String,
-    #[expect(dead_code, reason = "populated by forge, read in future milestones")]
+    #[expect(
+        dead_code,
+        reason = "part of PR data model, not yet consumed by submission logic"
+    )]
     pub head_ref: String,
     pub base_ref: String,
-    #[expect(dead_code, reason = "populated by forge, read in future milestones")]
+    #[expect(
+        dead_code,
+        reason = "part of PR data model, not yet consumed by submission logic"
+    )]
     pub state: PrState,
     /// The PR body/description text.
     pub body: Option<String>,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -7,7 +7,6 @@ pub mod types;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::collections::VecDeque;
 
 use self::types::BookmarkSegment;
 use self::types::BranchStack;
@@ -398,46 +397,6 @@ fn collect_timestamps_desc(stack: &BranchStack) -> Vec<&str> {
         .collect();
     timestamps.sort_unstable_by(|a, b| b.cmp(a));
     timestamps
-}
-
-/// Topological sort using Kahn's algorithm.
-///
-/// Returns change IDs ordered leaves-first, roots-last. This is the order
-/// suitable for display (the user sees their leaf work at the top).
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "used in later milestones for display ordering")
-)]
-pub fn topological_sort(graph: &ChangeGraph) -> Vec<String> {
-    // Calculate in-degrees: how many children point to each parent.
-    let mut in_degrees: HashMap<&String, usize> = HashMap::new();
-    for parent_id in graph.adjacency_list.values() {
-        *in_degrees.entry(parent_id).or_insert(0) += 1;
-    }
-
-    // Start from leaves, sorted for deterministic output.
-    let mut leaves: Vec<String> = graph.stack_leaves.iter().cloned().collect();
-    leaves.sort();
-    let mut queue: VecDeque<String> = leaves.into();
-
-    let mut result = Vec::new();
-
-    while let Some(change_id) = queue.pop_front() {
-        result.push(change_id.clone());
-
-        if let Some(parent_id) = graph.adjacency_list.get(&change_id)
-            && let Some(degree) = in_degrees.get_mut(parent_id)
-        {
-            *degree -= 1;
-            if *degree == 0 {
-                // Parent is now ready — push to front to keep stacks
-                // visually grouped (DFS-like).
-                queue.push_front(parent_id.clone());
-            }
-        }
-    }
-
-    result
 }
 
 #[cfg(test)]
@@ -992,117 +951,6 @@ mod tests {
         // Adjacency: ch_b -> ch_a, ch_c -> ch_a
         assert_eq!(graph.adjacency_list.get("ch_b").unwrap(), "ch_a");
         assert_eq!(graph.adjacency_list.get("ch_c").unwrap(), "ch_a");
-    }
-
-    /// Topological sort: leaves first, roots last.
-    ///
-    /// Graph: `ch_c` -> `ch_b` -> `ch_a` (linear)
-    /// Expected sort: [`ch_c`, `ch_b`, `ch_a`]
-    #[tokio::test]
-    async fn topological_sort_linear() {
-        let runner = MockJjRunner {
-            handler: |args: &[&str]| {
-                if args[0] == "diff" {
-                    return Ok(String::new());
-                }
-                if args[0] == "bookmark" {
-                    let lines = [
-                        bookmark_json("bm_c", "c_c", "ch_c"),
-                        bookmark_json("bm_b", "c_b", "ch_b"),
-                        bookmark_json("bm_a", "c_a", "ch_a"),
-                    ];
-                    return Ok(lines.join("\n"));
-                }
-
-                let revset = args[2];
-                if revset.contains("c_c") {
-                    let lines = [
-                        log_entry_json("c_c", "ch_c", &["c_b"], &["bm_c"]),
-                        log_entry_json("c_b", "ch_b", &["c_a"], &["bm_b"]),
-                        log_entry_json("c_a", "ch_a", &["trunk_c"], &["bm_a"]),
-                    ];
-                    return Ok(lines.join("\n"));
-                }
-
-                Ok(String::new())
-            },
-        };
-
-        let jj = Jj::new(runner);
-        let graph = build_change_graph(
-            &jj,
-            "mine() ~ trunk() ~ immutable()",
-            "heads((mine() ~ empty() ~ immutable()) & trunk()..)",
-        )
-        .await
-        .unwrap();
-        let sorted = topological_sort(&graph);
-
-        assert_eq!(sorted, vec!["ch_c", "ch_b", "ch_a"]);
-    }
-
-    /// Topological sort with branching: leaves processed first, then shared
-    /// root.
-    ///
-    /// Graph: `ch_b` -> `ch_a`, `ch_c` -> `ch_a`
-    /// Expected: [`ch_b`, `ch_c`, `ch_a`] or [`ch_c`, `ch_b`, `ch_a`] depending
-    /// on sort. With alphabetical leaf ordering: `ch_b` before `ch_c`.
-    #[tokio::test]
-    async fn topological_sort_branching() {
-        let runner = MockJjRunner {
-            handler: |args: &[&str]| {
-                if args[0] == "diff" {
-                    return Ok(String::new());
-                }
-                if args[0] == "bookmark" {
-                    let lines = [
-                        bookmark_json("bm_b", "c_b", "ch_b"),
-                        bookmark_json("bm_c", "c_c", "ch_c"),
-                        bookmark_json("bm_a", "c_a", "ch_a"),
-                    ];
-                    return Ok(lines.join("\n"));
-                }
-
-                let revset = args[2];
-                if revset.contains("c_b") {
-                    let lines = [
-                        log_entry_json("c_b", "ch_b", &["c_a"], &["bm_b"]),
-                        log_entry_json("c_a", "ch_a", &["trunk_c"], &["bm_a"]),
-                    ];
-                    return Ok(lines.join("\n"));
-                }
-                if revset.contains("c_c") {
-                    let lines = [
-                        log_entry_json("c_c", "ch_c", &["c_a"], &["bm_c"]),
-                        log_entry_json("c_a", "ch_a", &["trunk_c"], &["bm_a"]),
-                    ];
-                    return Ok(lines.join("\n"));
-                }
-
-                Ok(String::new())
-            },
-        };
-
-        let jj = Jj::new(runner);
-        let graph = build_change_graph(
-            &jj,
-            "mine() ~ trunk() ~ immutable()",
-            "heads((mine() ~ empty() ~ immutable()) & trunk()..)",
-        )
-        .await
-        .unwrap();
-        let sorted = topological_sort(&graph);
-
-        // ch_b is processed first (alphabetical), its parent ch_a becomes
-        // ready but ch_c hasn't been processed yet. Since we push_front the
-        // parent, ch_a goes to front, then ch_c is next in queue.
-        // Actually with push_front: queue starts [ch_b, ch_c].
-        // Pop ch_b -> result [ch_b]. Parent ch_a has in-degree 2, decrement
-        // to 1 — not ready yet. Queue: [ch_c].
-        // Pop ch_c -> result [ch_b, ch_c]. Parent ch_a decremented to 0,
-        // push_front. Queue: [ch_a].
-        // Pop ch_a -> result [ch_b, ch_c, ch_a].
-        assert_eq!(sorted, vec!["ch_b", "ch_c", "ch_a"]);
     }
 
     /// Single bookmark, single commit — simplest possible case.

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -50,10 +50,24 @@ pub struct BranchStack {
 pub struct ChangeGraph {
     /// Child `change_id` → parent `change_id` (toward trunk). Each entry
     /// represents a stacking relationship between two bookmarked changes.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "populated during graph construction; exposed for diagnostics"
+        )
+    )]
     pub adjacency_list: HashMap<String, String>,
 
     /// Change IDs that are leaf nodes (no children point to them as parent).
     /// Each leaf defines one stack.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "populated during graph construction; exposed for diagnostics"
+        )
+    )]
     pub stack_leaves: HashSet<String>,
 
     /// Change IDs closest to trunk with no parent in the adjacency list.
@@ -77,7 +91,10 @@ pub struct ChangeGraph {
     /// stacking.
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "used in later milestones for diagnostics")
+        expect(
+            dead_code,
+            reason = "populated during graph construction; exposed for diagnostics"
+        )
     )]
     pub tainted_change_ids: HashSet<String>,
 

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -222,18 +222,6 @@ impl<R: JjRunner> Jj<R> {
             .map(String::from)
             .collect())
     }
-
-    /// Fetch from all remotes.
-    #[expect(
-        dead_code,
-        reason = "available for pre-submission fetch in a future milestone"
-    )]
-    pub async fn git_fetch(&self) -> Result<(), JjError> {
-        self.runner
-            .run_jj(&["git", "fetch", "--all-remotes"])
-            .await?;
-        Ok(())
-    }
 }
 
 fn parse_bookmarks(output: &str) -> Result<Vec<Bookmark>, JjError> {

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -30,7 +30,13 @@ pub enum JjError {
 
     /// Failed to parse `jj` output.
     #[error("failed to parse jj output ({context}): {source}")]
-    #[diagnostic(code(stakk::jj::parse_error))]
+    #[diagnostic(
+        code(stakk::jj::parse_error),
+        help(
+            "jj's output may have changed shape — this can indicate a jj/stakk version \
+             incompatibility; check `jj --version`"
+        )
+    )]
     ParseError {
         context: String,
         source: serde_json::Error,

--- a/src/jj/types.rs
+++ b/src/jj/types.rs
@@ -28,7 +28,10 @@ pub struct CommitRefData {
     pub name: String,
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "deserialized for completeness, used later")
+        expect(
+            dead_code,
+            reason = "deserialized for completeness, not yet read in production"
+        )
     )]
     pub target: Vec<String>,
     #[serde(default)]
@@ -38,7 +41,10 @@ pub struct CommitRefData {
     /// commit has been rewritten and the remote bookmark hasn't been updated).
     #[cfg_attr(
         not(test),
-        expect(dead_code, reason = "deserialized for completeness, used later")
+        expect(
+            dead_code,
+            reason = "deserialized for completeness, not yet read in production"
+        )
     )]
     #[serde(default)]
     pub tracking_target: Option<Vec<Option<String>>>,
@@ -80,8 +86,7 @@ pub struct Bookmark {
         not(test),
         expect(
             dead_code,
-            reason = "available for push optimization (skip synced bookmarks) in a future \
-                      milestone"
+            reason = "available for push optimization (skip synced bookmarks)"
         )
     )]
     pub synced: bool,

--- a/src/select/graph_layout.rs
+++ b/src/select/graph_layout.rs
@@ -71,12 +71,6 @@ impl GraphLayout {
         self.nodes.iter().find(|n| n.row == row && n.col == col)
     }
 
-    /// Get the index of a node in the nodes vec by row/col.
-    #[expect(dead_code, reason = "available for future navigation features")]
-    pub fn node_index_at(&self, row: usize, col: usize) -> Option<usize> {
-        self.nodes.iter().position(|n| n.row == row && n.col == col)
-    }
-
     /// Return all leaf nodes (selectable branch tips), sorted left-to-right by
     /// column so that index 0 is the leftmost leaf.
     pub fn leaf_nodes(&self) -> Vec<&LayoutNode> {

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -52,9 +52,12 @@ pub enum SubmitError {
     BookmarkNotFound { bookmark: String },
 
     /// A segment in the change graph has no bookmark name.
-    #[error("segment has no bookmark name")]
-    #[diagnostic(code(stakk::submit::segment_missing_bookmark))]
-    SegmentMissingBookmark,
+    #[error("segment for change {change_id} has no bookmark name")]
+    #[diagnostic(
+        code(stakk::submit::segment_missing_bookmark),
+        help("this is likely a bug in stakk — please report it")
+    )]
+    SegmentMissingBookmark { change_id: String },
 
     /// Failed to look up an existing PR for a bookmark.
     #[error("failed to check for existing PR for '{bookmark}'")]
@@ -364,7 +367,9 @@ pub async fn create_submission_plan<F: Forge>(
             seg.bookmark_names
                 .first()
                 .cloned()
-                .ok_or(SubmitError::SegmentMissingBookmark)
+                .ok_or_else(|| SubmitError::SegmentMissingBookmark {
+                    change_id: seg.change_id.clone(),
+                })
         })
         .collect::<Result<_, _>>()?;
 


### PR DESCRIPTION
## Summary

Re-implements the intentions of #74 on top of current `main`, then extends the same sweep to the rest of the codebase and adds some error-message UX polish. One concern per commit.

## Commits

**refactor: remove dead code and clarify expect() reasons** (the original #74 scope)
- Remove the unused `ForgeError::PrNotFound` and `ForgeError::RateLimited` variants.
- Remove the unused `GraphLayout::node_index_at()` method.
- Reword stale `#[expect(dead_code)]` reasons on `PullRequest::head_ref`/`state`, `CommitRefData::target`/`tracking_target`, and `Bookmark::synced` to describe why the items exist rather than promising future milestones.

**refactor: remove remaining future-milestone dead code**
- Remove the unused `Jj::git_fetch()` method (zero call sites).
- Remove `topological_sort()` and its two tests — only exercised by its own tests.
- Mark `ChangeGraph::adjacency_list`/`stack_leaves` with the same `cfg_attr(not(test), expect(dead_code))` pattern as their sibling fields, and de-milestone the `tainted_change_ids` reason.

**fix(errors): add actionable help to auth and jj parse errors**
- `AuthError::GhCliError`: suggest installing `gh` or setting `GITHUB_TOKEN`/`GH_TOKEN`.
- `JjError::ParseError`: point at jj/stakk version incompatibility.
- Lowercase the `NoAuthFound` help text for consistency.

**fix(submit): identify the segment in the missing-bookmark error**
- `SegmentMissingBookmark` now carries and renders the segment's change ID, with a "likely a bug — please report it" help text.

Supersedes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)