### PR TITLE
fix: stop silently dropping selected bookmarks on jj-immutable revs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,24 @@ States are **skipped** when they would produce no name or a duplicate of
 another state's name (e.g., UseTfidf skipped if it matches an existing
 bookmark; UseGenerated skipped if it matches an existing one).
 
+### Locked Rows (immutable commits)
+
+A row is **locked** when `is_immutable && existing_bookmarks.is_empty()`
+(`BookmarkRow::is_locked()`): its commit is jj-immutable and carries no
+bookmark known to the graph, so any name assigned there would be filtered out
+by the bookmarks revset on the post-creation graph rebuild. Locked rows are
+permanently `[ ]` Unchecked (dark gray) and render a hint —
+`(immutable — bookmark <names> excluded by --bookmarks-revset)` when the
+commit carries filtered-out bookmarks (`excluded_bookmarks`), else
+`(immutable)`. All mutating keys (Space, `b`, `r`, `R`, `i`) no-op; the row
+stays focusable so the hint is discoverable, and the help line shows
+`immutable — locked` instead of the cycle keys. Immutable rows that *are*
+segment boundaries (possible under custom revsets without `~ immutable()`)
+are not locked. Accepted limitation: locking keys on commit immutability, not
+revset semantics — under a custom revset that includes immutable commits, a
+bare immutable row stays locked; create the bookmark outside the TUI and the
+row unlocks as a boundary.
+
 ### Variation (`r`/`R`)
 
 `r`/`R` cycles *within* the current state type:
@@ -259,6 +277,18 @@ are in-flight to animate the spinner (10-frame animation).
 - ratatui inline viewport: `enable_raw_mode()` before, `disable_raw_mode()` after.
 - Graph layout deduplicates shared segments by `commit_id` (not `change_id`).
 - Auto-generated bookmark names: `stakk-<first 12 chars of change_id>`.
+- `LOG_TEMPLATE` emits an `immutable` field; `LogEntryRaw` is deliberately
+  *not* serde-defaulted so a template/parser mismatch fails loudly as a
+  `ParseError` instead of silently parsing `immutable: false`.
+- `SegmentCommit::local_bookmark_names` carries the *unfiltered* local
+  bookmark names from jj log — unlike `BookmarkSegment::bookmark_names`,
+  it includes bookmarks the bookmarks revset excluded (e.g. on immutable
+  commits). Used to diagnose excluded selections and label locked TUI rows.
+- `analyze_submission` errors (`stakk::submit::selected_bookmarks_excluded`)
+  when a selected bookmark is a boundary in no segment of the target stack,
+  instead of silently folding it away. The intentional fold for
+  deliberately-unchecked rows is unaffected (unchecked names are never in
+  `selected_bookmarks`).
 - Stack reorder safety: bookmarks must be pushed one-at-a-time with immediate
   base/PR updates. If all bookmarks are pushed before bases are updated, a PR
   whose head moved down the stack will have an empty diff (head is ancestor of

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ stack_placement = "body"
 auto_prefix = "gb-"
 
 # Revset for discovering bookmarks (default: "mine() ~ trunk() ~ immutable()")
+# Note: the default excludes bookmarks on immutable commits. Stale untracked
+# remote bookmarks can pin commits immutable — clean them up with
+# `jj bookmark forget --include-remotes 'glob:<pattern>'`, or drop the
+# `~ immutable()` term for one run to include them.
 bookmarks_revset = "mine() ~ trunk() ~ immutable()"
 
 # Revset for discovering unbookmarked heads

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -287,6 +287,8 @@ async fn traverse_and_discover_segments<R: JjRunner>(
                     committer: change.committer.clone(),
                     short_change_id: change.short_change_id.clone(),
                     files: vec![],
+                    is_immutable: change.immutable,
+                    local_bookmark_names: change.local_bookmark_names.clone(),
                 });
             }
         }
@@ -436,6 +438,17 @@ mod tests {
         parents: &[&str],
         local_bookmarks: &[&str],
     ) -> String {
+        log_entry_json_full(commit_id, change_id, parents, local_bookmarks, false)
+    }
+
+    /// Build a log entry NDJSON line with an explicit `immutable` flag.
+    fn log_entry_json_full(
+        commit_id: &str,
+        change_id: &str,
+        parents: &[&str],
+        local_bookmarks: &[&str],
+        immutable: bool,
+    ) -> String {
         let parents_json: Vec<String> = parents.iter().map(|p| format!("\"{p}\"")).collect();
         let parents_str = parents_json.join(",");
 
@@ -447,7 +460,7 @@ mod tests {
 
         let short = &change_id[..4.min(change_id.len())];
         format!(
-            r#"{{"commit":{{"commit_id":"{commit_id}","parents":[{parents_str}],"change_id":"{change_id}","description":"desc {commit_id}","author":{{"name":"T","email":"t@t.t","timestamp":"T"}},"committer":{{"name":"T","email":"t@t.t","timestamp":"T"}}}},"local_bookmarks":[{bookmarks_str}],"remote_bookmarks":[],"short_change_id":"{short}"}}"#,
+            r#"{{"commit":{{"commit_id":"{commit_id}","parents":[{parents_str}],"change_id":"{change_id}","description":"desc {commit_id}","author":{{"name":"T","email":"t@t.t","timestamp":"T"}},"committer":{{"name":"T","email":"t@t.t","timestamp":"T"}}}},"local_bookmarks":[{bookmarks_str}],"remote_bookmarks":[],"immutable":{immutable},"short_change_id":"{short}"}}"#,
         )
     }
 
@@ -1069,6 +1082,8 @@ mod tests {
                         committer: test_sig(ts),
                         short_change_id: id[..4].to_string(),
                         files: vec![],
+                        is_immutable: false,
+                        local_bookmark_names: vec![],
                     }],
                 },
             );
@@ -1129,6 +1144,61 @@ mod tests {
         assert_eq!(graph.segments.len(), 1);
         let seg = graph.segments.get("ch_x").unwrap();
         assert_eq!(seg.bookmark_names, vec!["bm_user"]);
+    }
+
+    /// The immutable flag and unfiltered local bookmark names are threaded
+    /// into `SegmentCommit`, even for bookmarks excluded from the graph.
+    ///
+    /// Commit c_mid is immutable and carries bookmark bm_pinned, which the
+    /// bookmarks revset filtered out (not in `get_my_bookmarks` output). It
+    /// must not become a segment boundary, but its commit must record the
+    /// flag and the bookmark name so later phases can diagnose the exclusion.
+    #[tokio::test]
+    async fn immutable_flag_and_local_bookmarks_threaded() {
+        let runner = MockJjRunner {
+            handler: |args: &[&str]| {
+                if args[0] == "diff" {
+                    return Ok(String::new());
+                }
+                if args[0] == "bookmark" {
+                    return Ok(bookmark_json("bm_leaf", "c_leaf", "ch_leaf"));
+                }
+
+                let revset = args[2];
+                if revset.contains("c_leaf") {
+                    let lines = [
+                        log_entry_json("c_leaf", "ch_leaf", &["c_mid"], &["bm_leaf"]),
+                        log_entry_json_full("c_mid", "ch_mid", &["trunk_c"], &["bm_pinned"], true),
+                    ];
+                    return Ok(lines.join("\n"));
+                }
+
+                Ok(String::new())
+            },
+        };
+
+        let jj = Jj::new(runner);
+        let graph = build_change_graph(
+            &jj,
+            "mine() ~ trunk() ~ immutable()",
+            "heads((mine() ~ empty() ~ immutable()) & trunk()..)",
+        )
+        .await
+        .unwrap();
+
+        // bm_pinned is not a boundary: one segment, named after bm_leaf only.
+        assert_eq!(graph.segments.len(), 1);
+        let seg = graph.segments.get("ch_leaf").unwrap();
+        assert_eq!(seg.bookmark_names, vec!["bm_leaf"]);
+        assert_eq!(seg.commits.len(), 2);
+
+        let leaf_commit = &seg.commits[0];
+        assert!(!leaf_commit.is_immutable);
+        assert_eq!(leaf_commit.local_bookmark_names, vec!["bm_leaf"]);
+
+        let mid_commit = &seg.commits[1];
+        assert!(mid_commit.is_immutable);
+        assert_eq!(mid_commit.local_bookmark_names, vec!["bm_pinned"]);
     }
 
     /// A commit with only non-user bookmarks is treated as unbookmarked

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -18,6 +18,12 @@ pub struct SegmentCommit {
     pub short_change_id: String,
     /// Files changed by this commit.
     pub files: Vec<String>,
+    /// Whether jj considers the commit immutable.
+    pub is_immutable: bool,
+    /// All local bookmark names on this commit, unfiltered — unlike
+    /// `BookmarkSegment::bookmark_names`, this includes bookmarks excluded
+    /// from the graph by the bookmarks revset (e.g. on immutable commits).
+    pub local_bookmark_names: Vec<String>,
 }
 
 /// A group of consecutive commits belonging to one or more bookmarks.

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -64,7 +64,7 @@ const BOOKMARK_TEMPLATE: &str = r#""{\"name\":" ++ json(self.name()) ++ ",\"sync
 
 // Template for `jj log`: produces one JSON object per line with commit +
 // bookmarks + shortest unique change ID prefix.
-const LOG_TEMPLATE: &str = r#""{\"commit\":" ++ json(self) ++ ",\"local_bookmarks\":" ++ json(local_bookmarks) ++ ",\"remote_bookmarks\":" ++ json(remote_bookmarks) ++ ",\"short_change_id\":\"" ++ change_id.shortest() ++ "\"}\n""#;
+const LOG_TEMPLATE: &str = r#""{\"commit\":" ++ json(self) ++ ",\"local_bookmarks\":" ++ json(local_bookmarks) ++ ",\"remote_bookmarks\":" ++ json(remote_bookmarks) ++ ",\"immutable\":" ++ immutable ++ ",\"short_change_id\":\"" ++ change_id.shortest() ++ "\"}\n""#;
 
 /// Main interface for interacting with `jj`.
 pub struct Jj<R: JjRunner> {
@@ -288,6 +288,7 @@ fn parse_log_entries(output: &str) -> Result<Vec<LogEntry>, JjError> {
                     None => b.name.clone(),
                 })
                 .collect(),
+            immutable: raw.immutable,
             short_change_id: raw.short_change_id,
         });
     }
@@ -372,7 +373,7 @@ mod tests {
 
     #[test]
     fn parse_log_entries_single() {
-        let input = r#"{"commit":{"commit_id":"abc","parents":["def"],"change_id":"xyz","description":"desc\n","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[{"name":"feat","target":["abc"]}],"remote_bookmarks":[{"name":"feat","remote":"origin","target":["abc"],"tracking_target":["abc"]}],"short_change_id":"xyz"}"#;
+        let input = r#"{"commit":{"commit_id":"abc","parents":["def"],"change_id":"xyz","description":"desc\n","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[{"name":"feat","target":["abc"]}],"remote_bookmarks":[{"name":"feat","remote":"origin","target":["abc"],"tracking_target":["abc"]}],"immutable":false,"short_change_id":"xyz"}"#;
         let entries = parse_log_entries(input).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].commit_id, "abc");
@@ -382,7 +383,7 @@ mod tests {
 
     #[test]
     fn parse_log_entries_no_bookmarks() {
-        let input = r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"xyz"}"#;
+        let input = r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"xyz"}"#;
         let entries = parse_log_entries(input).unwrap();
         assert_eq!(entries.len(), 1);
         assert!(entries[0].local_bookmark_names.is_empty());
@@ -391,13 +392,31 @@ mod tests {
 
     #[test]
     fn parse_log_entries_multiple() {
-        let line1 = r#"{"commit":{"commit_id":"aaa","parents":[],"change_id":"x1","description":"first","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"x1"}"#;
-        let line2 = r#"{"commit":{"commit_id":"bbb","parents":["aaa"],"change_id":"x2","description":"second","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"x2"}"#;
+        let line1 = r#"{"commit":{"commit_id":"aaa","parents":[],"change_id":"x1","description":"first","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"x1"}"#;
+        let line2 = r#"{"commit":{"commit_id":"bbb","parents":["aaa"],"change_id":"x2","description":"second","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"x2"}"#;
         let input = format!("{line1}\n{line2}");
         let entries = parse_log_entries(&input).unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].commit_id, "aaa");
         assert_eq!(entries[1].commit_id, "bbb");
+    }
+
+    #[test]
+    fn parse_log_entries_immutable_true() {
+        let input = r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[{"name":"pinned","target":["abc"]}],"remote_bookmarks":[],"immutable":true,"short_change_id":"xyz"}"#;
+        let entries = parse_log_entries(input).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].immutable);
+        assert_eq!(entries[0].local_bookmark_names, vec!["pinned"]);
+    }
+
+    /// The `immutable` field is deliberately not serde-defaulted: output from
+    /// a template that doesn't emit it must fail loudly, not parse as false.
+    #[test]
+    fn parse_log_entries_missing_immutable_is_error() {
+        let input = r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"xyz"}"#;
+        let result = parse_log_entries(input);
+        assert!(matches!(result, Err(JjError::ParseError { .. })));
     }
 
     // -- parse_git_remote_list tests --
@@ -478,7 +497,7 @@ mod tests {
     async fn get_default_branch_integration() {
         let runner = MockJjRunner {
             handler: |_args: &[&str]| {
-                Ok(r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[{"name":"main","target":["abc"]}],"remote_bookmarks":[{"name":"main","remote":"git","target":["abc"],"tracking_target":["abc"]},{"name":"main","remote":"origin","target":["abc"],"tracking_target":["abc"]}],"short_change_id":"xyz"}"#.to_string())
+                Ok(r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[{"name":"main","target":["abc"]}],"remote_bookmarks":[{"name":"main","remote":"git","target":["abc"],"tracking_target":["abc"]},{"name":"main","remote":"origin","target":["abc"],"tracking_target":["abc"]}],"immutable":false,"short_change_id":"xyz"}"#.to_string())
             },
         };
         let jj = Jj::new(runner);
@@ -490,7 +509,7 @@ mod tests {
     async fn get_default_branch_no_remote_bookmarks() {
         let runner = MockJjRunner {
             handler: |_args: &[&str]| {
-                Ok(r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"xyz"}"#.to_string())
+                Ok(r#"{"commit":{"commit_id":"abc","parents":[],"change_id":"xyz","description":"","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"xyz"}"#.to_string())
             },
         };
         let jj = Jj::new(runner);
@@ -506,7 +525,7 @@ mod tests {
                 // Check the revset is constructed correctly
                 let revset = args[2];
                 assert!(revset.contains(".."));
-                Ok(r#"{"commit":{"commit_id":"c1","parents":["c0"],"change_id":"ch1","description":"change 1","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"ch1"}"#.to_string())
+                Ok(r#"{"commit":{"commit_id":"c1","parents":["c0"],"change_id":"ch1","description":"change 1","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"ch1"}"#.to_string())
             },
         };
         let jj = Jj::new(runner);
@@ -544,7 +563,7 @@ mod tests {
             handler: |args: &[&str]| {
                 assert_eq!(args[0], "log");
                 assert_eq!(args[2], "custom-heads-revset");
-                Ok(r#"{"commit":{"commit_id":"h1","parents":["c_a"],"change_id":"ch_h1","description":"unbookmarked head","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"short_change_id":"ch_h"}"#.to_string())
+                Ok(r#"{"commit":{"commit_id":"h1","parents":["c_a"],"change_id":"ch_h1","description":"unbookmarked head","author":{"name":"A","email":"a@b.c","timestamp":"T"},"committer":{"name":"A","email":"a@b.c","timestamp":"T"}},"local_bookmarks":[],"remote_bookmarks":[],"immutable":false,"short_change_id":"ch_h"}"#.to_string())
             },
         };
         let jj = Jj::new(runner);

--- a/src/jj/types.rs
+++ b/src/jj/types.rs
@@ -56,6 +56,9 @@ pub struct LogEntryRaw {
     pub commit: CommitData,
     pub local_bookmarks: Vec<CommitRefData>,
     pub remote_bookmarks: Vec<CommitRefData>,
+    /// Whether jj considers the commit immutable. Deliberately not
+    /// serde-defaulted: a template/parser mismatch must fail loudly.
+    pub immutable: bool,
     /// Shortest unique change ID prefix (from `change_id.shortest(4)`).
     pub short_change_id: String,
 }
@@ -103,6 +106,8 @@ pub struct LogEntry {
     pub committer: Signature,
     pub local_bookmark_names: Vec<String>,
     pub remote_bookmark_names: Vec<String>,
+    /// Whether jj considers the commit immutable.
+    pub immutable: bool,
     /// Shortest unique change ID prefix (from jj).
     pub short_change_id: String,
 }
@@ -187,10 +192,12 @@ mod tests {
             "remote_bookmarks": [
                 {"name":"feature","remote":"origin","target":["abc123"],"tracking_target":["abc123"]}
             ],
+            "immutable": false,
             "short_change_id": "xyz7"
         }"#;
         let entry: LogEntryRaw = serde_json::from_str(json).unwrap();
         assert_eq!(entry.commit.commit_id, "abc123");
+        assert!(!entry.immutable);
         assert_eq!(entry.local_bookmarks.len(), 1);
         assert_eq!(entry.local_bookmarks[0].name, "feature");
         assert_eq!(entry.remote_bookmarks.len(), 1);

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -27,6 +27,7 @@ use super::bookmark_gen::BookmarkGenError;
 use super::bookmark_gen::BookmarkNameCache;
 use super::bookmark_gen::CacheEntry;
 use super::bookmark_widget::BookmarkAssignmentState;
+use super::bookmark_widget::BookmarkRow;
 use super::bookmark_widget::BookmarkWidget;
 use super::bookmark_widget::CustomNameState;
 use super::bookmark_widget::InputMode;
@@ -744,6 +745,10 @@ fn render_bookmark_screen(
                 .rows
                 .get(state.cursor)
                 .map_or(0, |r| r.existing_bookmarks.len()),
+            state
+                .rows
+                .get(state.cursor)
+                .is_some_and(BookmarkRow::is_locked),
         ),
         help_area,
     );

--- a/src/select/bookmark_gen.rs
+++ b/src/select/bookmark_gen.rs
@@ -506,6 +506,8 @@ mod tests {
             state,
             generated_name: Some(default_bookmark_name(change_id)),
             is_trunk,
+            is_immutable: false,
+            excluded_bookmarks: vec![],
             author: Signature {
                 name: "Test".to_string(),
                 email: "test@test.com".to_string(),

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -94,6 +94,11 @@ pub struct BookmarkRow {
     pub existing_bookmark_idx: usize,
     /// Whether this is the trunk row (not toggleable).
     pub is_trunk: bool,
+    /// Whether jj considers this commit immutable.
+    pub is_immutable: bool,
+    /// Local bookmark names on this commit that the graph's bookmarks revset
+    /// filtered out (shown as a hint on locked rows).
+    pub excluded_bookmarks: Vec<String>,
     /// Author signature.
     pub author: Signature,
     /// Files changed by this commit.
@@ -103,10 +108,19 @@ pub struct BookmarkRow {
 }
 
 impl BookmarkRow {
+    /// Whether this row is locked: its commit is immutable and carries no
+    /// bookmark known to the graph, so any name assigned here would be
+    /// filtered out by the bookmarks revset on the post-creation graph
+    /// rebuild. Immutable rows that *are* segment boundaries (possible under
+    /// custom revsets without `~ immutable()`) stay fully functional.
+    pub fn is_locked(&self) -> bool {
+        !self.is_trunk && self.is_immutable && self.existing_bookmarks.is_empty()
+    }
+
     /// Get the effective bookmark name for this row.
     #[cfg_attr(not(test), expect(dead_code, reason = "used in tests for validation"))]
     pub fn effective_name(&self) -> Option<&str> {
-        if self.is_trunk {
+        if self.is_trunk || self.is_locked() {
             return None;
         }
         match &self.state {
@@ -238,6 +252,8 @@ impl BookmarkAssignmentState {
                     tfidf_name: None,
                     user_input_name: None,
                     is_trunk: node.is_trunk,
+                    is_immutable: node.is_immutable,
+                    excluded_bookmarks: node.excluded_bookmarks.clone(),
                     author: node.author.clone(),
                     files: node.files.clone(),
                     has_bookmark_command,
@@ -276,7 +292,7 @@ impl BookmarkAssignmentState {
         let Some(row) = self.rows.get(cursor) else {
             return;
         };
-        if row.is_trunk {
+        if row.is_trunk || row.is_locked() {
             return;
         }
 
@@ -349,7 +365,7 @@ impl BookmarkAssignmentState {
         let Some(row) = self.rows.get(cursor) else {
             return;
         };
-        if row.is_trunk {
+        if row.is_trunk || row.is_locked() {
             return;
         }
 
@@ -512,7 +528,7 @@ impl BookmarkAssignmentState {
         let Some(row) = self.rows.get(cursor) else {
             return VaryResult::Noop;
         };
-        if row.is_trunk {
+        if row.is_trunk || row.is_locked() {
             return VaryResult::Noop;
         }
 
@@ -556,7 +572,7 @@ impl BookmarkAssignmentState {
         let Some(row) = self.rows.get(cursor) else {
             return VaryResult::Noop;
         };
-        if row.is_trunk {
+        if row.is_trunk || row.is_locked() {
             return VaryResult::Noop;
         }
 
@@ -877,7 +893,16 @@ impl<'a> BookmarkWidget<'a> {
                     }
                 }
                 RowState::Unchecked => {
-                    if let Some(first) = row.existing_bookmarks.first() {
+                    if row.is_locked() {
+                        if row.excluded_bookmarks.is_empty() {
+                            "(immutable)".to_string()
+                        } else {
+                            format!(
+                                "(immutable \u{2014} bookmark {} excluded by --bookmarks-revset)",
+                                row.excluded_bookmarks.join(", ")
+                            )
+                        }
+                    } else if let Some(first) = row.existing_bookmarks.first() {
                         first.clone()
                     } else {
                         "(Space to assign)".to_string()
@@ -970,6 +995,7 @@ pub fn bookmark_help_line(
     editing: bool,
     current_row_state: Option<&RowState>,
     existing_count: usize,
+    current_row_locked: bool,
 ) -> Line<'static> {
     let key_style = Style::default()
         .fg(Color::Yellow)
@@ -982,6 +1008,18 @@ pub fn bookmark_help_line(
             Span::raw(" delete  "),
             Span::styled("Esc/Enter", key_style),
             Span::raw(" done"),
+        ]);
+    }
+
+    if current_row_locked {
+        return Line::from(vec![
+            Span::styled(" \u{2191}\u{2193}/jk", key_style),
+            Span::raw(" navigate  "),
+            Span::raw("immutable \u{2014} locked  "),
+            Span::styled("Enter", key_style),
+            Span::raw(" confirm  "),
+            Span::styled("Esc/q", key_style),
+            Span::raw(" back"),
         ]);
     }
 
@@ -1043,6 +1081,8 @@ mod tests {
             summary: summary.to_string(),
             description: summary.to_string(),
             bookmark_names: bookmarks.iter().map(ToString::to_string).collect(),
+            excluded_bookmarks: vec![],
+            is_immutable: false,
             is_trunk,
             is_leaf,
             stack_index: 0,
@@ -1440,6 +1480,8 @@ mod tests {
             custom_name: None,
             tfidf_name: None,
             is_trunk: false,
+            is_immutable: false,
+            excluded_bookmarks: vec![],
             author: crate::jj::types::Signature {
                 name: "Test".to_string(),
                 email: "test@test.com".to_string(),
@@ -2062,5 +2104,143 @@ mod tests {
         state.toggle_current(); // UseGenerated
         state.toggle_current(); // Should skip UseCustom → Unchecked
         assert_eq!(state.rows[1].state, RowState::Unchecked);
+    }
+
+    // -- Locked (immutable) row tests --
+
+    /// A node on an immutable commit with no boundary bookmarks, carrying
+    /// bookmark names the graph's revset filtered out.
+    fn make_immutable_node(change_id: &str, summary: &str, excluded: &[&str]) -> LayoutNode {
+        let mut node = make_node(change_id, summary, &[], false, false);
+        node.is_immutable = true;
+        node.excluded_bookmarks = excluded.iter().map(ToString::to_string).collect();
+        node
+    }
+
+    fn make_locked_state(excluded: &[&str]) -> BookmarkAssignmentState {
+        let nodes = [
+            make_node("", "trunk", &[], true, false),
+            make_immutable_node("ch_imm", "pinned work", excluded),
+            make_node("ch_leaf", "leaf work", &["leaf"], false, true),
+        ];
+        let refs: Vec<&LayoutNode> = nodes.iter().collect();
+        BookmarkAssignmentState::from_path(&refs, false, None)
+    }
+
+    #[test]
+    fn locked_row_toggle_is_noop() {
+        let mut state = make_locked_state(&["pinned"]);
+        assert!(state.rows[1].is_locked());
+        state.cursor = 1;
+        state.toggle_current();
+        assert_eq!(state.rows[1].state, RowState::Unchecked);
+        state.toggle_current_reverse();
+        assert_eq!(state.rows[1].state, RowState::Unchecked);
+    }
+
+    #[test]
+    fn locked_row_vary_is_noop() {
+        let mut state = make_locked_state(&["pinned"]);
+        state.cursor = 1;
+        assert_eq!(state.vary_current(), VaryResult::Noop);
+        assert_eq!(state.vary_current_reverse(), VaryResult::Noop);
+        assert_eq!(state.rows[1].state, RowState::Unchecked);
+    }
+
+    /// Immutable rows that are segment boundaries (existing bookmarks —
+    /// possible under custom revsets without `~ immutable()`) are not
+    /// locked; the workaround path stays fully functional.
+    #[test]
+    fn immutable_row_with_existing_bookmarks_still_toggles() {
+        let nodes = [make_node("", "trunk", &[], true, false), {
+            let mut node = make_node("ch_a", "work", &["feat"], false, true);
+            node.is_immutable = true;
+            node
+        }];
+        let refs: Vec<&LayoutNode> = nodes.iter().collect();
+        let mut state = BookmarkAssignmentState::from_path(&refs, false, None);
+
+        assert!(!state.rows[1].is_locked());
+        assert_eq!(state.rows[1].state, RowState::UseExisting(0));
+        state.toggle_current();
+        assert_ne!(state.rows[1].state, RowState::UseExisting(0));
+    }
+
+    #[test]
+    fn locked_row_excluded_from_build_result() {
+        let state = make_locked_state(&["pinned"]);
+        let result = state.build_result().unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].bookmark_name, "leaf");
+    }
+
+    #[test]
+    fn effective_name_none_for_locked_row() {
+        let mut row = make_bare_row(RowState::Unchecked);
+        row.existing_bookmarks = vec![];
+        row.is_immutable = true;
+        assert!(row.is_locked());
+        assert_eq!(row.effective_name(), None);
+    }
+
+    #[test]
+    fn locked_row_renders_immutable_hint() {
+        let state = make_locked_state(&["pinned"]);
+        let widget = BookmarkWidget::new(&state, 0, None, None);
+
+        let area = Rect::new(0, 0, 80, 10);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let content: String = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            content.contains("(immutable \u{2014} bookmark pinned excluded"),
+            "expected immutable hint with excluded names, got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn locked_row_renders_plain_immutable_hint_without_excluded() {
+        let state = make_locked_state(&[]);
+        let widget = BookmarkWidget::new(&state, 0, None, None);
+
+        let area = Rect::new(0, 0, 80, 10);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let content: String = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            content.contains("(immutable)"),
+            "expected plain immutable hint, got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn help_line_locked_omits_cycle_keys() {
+        let line = bookmark_help_line(false, false, Some(&RowState::Unchecked), 0, true);
+        let text: String = line.spans.iter().map(|s| s.content.clone()).collect();
+        assert!(text.contains("immutable \u{2014} locked"));
+        assert!(!text.contains("Space"));
+        assert!(!text.contains("skip"));
+
+        let unlocked = bookmark_help_line(false, false, Some(&RowState::Unchecked), 0, false);
+        let text: String = unlocked.spans.iter().map(|s| s.content.clone()).collect();
+        assert!(text.contains("Space"));
     }
 }

--- a/src/select/graph_layout.rs
+++ b/src/select/graph_layout.rs
@@ -23,8 +23,16 @@ pub struct LayoutNode {
     pub summary: String,
     /// Full commit description.
     pub description: String,
-    /// Bookmark names on this commit (may be empty).
+    /// Segment-boundary bookmark names on this commit (may be empty). Only
+    /// the last commit of a segment carries them — not to be conflated with
+    /// `excluded_bookmarks`.
     pub bookmark_names: Vec<String>,
+    /// Local bookmark names on this commit that are *not* segment-boundary
+    /// names — bookmarks the graph's bookmarks revset filtered out (e.g. on
+    /// immutable commits).
+    pub excluded_bookmarks: Vec<String>,
+    /// Whether jj considers this commit immutable.
+    pub is_immutable: bool,
     /// Whether this node is the trunk node.
     pub is_trunk: bool,
     /// Whether this node is a leaf (no children).
@@ -112,6 +120,8 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
         summary: "trunk".to_string(),
         description: String::new(),
         bookmark_names: vec![],
+        excluded_bookmarks: vec![],
+        is_immutable: false,
         is_trunk: true,
         is_leaf: false,
         stack_index: 0,
@@ -160,6 +170,13 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
                     vec![]
                 };
 
+                let excluded_bookmarks: Vec<String> = commit
+                    .local_bookmark_names
+                    .iter()
+                    .filter(|name| !bookmark_names.contains(name))
+                    .cloned()
+                    .collect();
+
                 let summary = commit
                     .description
                     .lines()
@@ -182,6 +199,8 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
                     summary,
                     description: commit.description.clone(),
                     bookmark_names,
+                    excluded_bookmarks,
+                    is_immutable: commit.is_immutable,
                     is_trunk: false,
                     is_leaf,
                     stack_index: stack_idx,
@@ -302,6 +321,8 @@ mod tests {
                     },
                     files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
+                    is_immutable: false,
+                    local_bookmark_names: vec![],
                 })
                 .collect(),
         }
@@ -507,6 +528,48 @@ mod tests {
         assert!(path[0].is_trunk);
         assert_eq!(path[1].change_id, "ch_shared");
         assert_eq!(path[2].change_id, "ch_b");
+    }
+
+    #[test]
+    fn immutable_flag_and_excluded_bookmarks_threaded() {
+        // Two-commit segment: the mid-segment commit is immutable and carries
+        // a bookmark that the graph filtered out; the boundary commit carries
+        // its own boundary name plus a filtered-out extra.
+        let mut segment = make_segment(&["feat"], "ch_a", &["second commit", "first commit"]);
+        // Commits are newest-first: [0] = boundary ("second"), [1] = mid.
+        segment.commits[0].local_bookmark_names =
+            vec!["feat".to_string(), "other-user".to_string()];
+        segment.commits[1].is_immutable = true;
+        segment.commits[1].local_bookmark_names = vec!["pinned".to_string()];
+
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![segment],
+        }]);
+        let layout = build_layout(&graph);
+
+        let trunk = &layout.nodes[0];
+        assert!(trunk.is_trunk);
+        assert!(!trunk.is_immutable);
+        assert!(trunk.excluded_bookmarks.is_empty());
+
+        let mid = layout
+            .nodes
+            .iter()
+            .find(|n| n.summary == "first commit")
+            .unwrap();
+        assert!(mid.is_immutable);
+        assert!(mid.bookmark_names.is_empty());
+        assert_eq!(mid.excluded_bookmarks, vec!["pinned"]);
+
+        // Boundary names are subtracted from excluded_bookmarks.
+        let boundary = layout
+            .nodes
+            .iter()
+            .find(|n| n.summary == "second commit")
+            .unwrap();
+        assert!(!boundary.is_immutable);
+        assert_eq!(boundary.bookmark_names, vec!["feat"]);
+        assert_eq!(boundary.excluded_bookmarks, vec!["other-user"]);
     }
 
     #[test]

--- a/src/select/graph_widget.rs
+++ b/src/select/graph_widget.rs
@@ -405,6 +405,8 @@ mod tests {
                     },
                     files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
+                    is_immutable: false,
+                    local_bookmark_names: vec![],
                 })
                 .collect(),
         }

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -51,6 +51,33 @@ pub enum SubmitError {
     )]
     BookmarkNotFound { bookmark: String },
 
+    /// Selected bookmarks were never consumed by any segment in the target
+    /// stack — typically because their commits are immutable in jj, so the
+    /// bookmarks revset excluded them from the change graph.
+    #[error(
+        "selected bookmark(s) not in the submission stack: {} ({} on immutable commit(s))",
+        missing.join(", "),
+        if immutable.is_empty() { "none".to_string() } else { immutable.join(", ") }
+    )]
+    #[diagnostic(
+        code(stakk::submit::selected_bookmarks_excluded),
+        help(
+            "the bookmark(s) exist and point at the right commits, but the commits are immutable \
+             in jj, so the default --bookmarks-revset (mine() ~ trunk() ~ immutable()) excludes \
+             them from the graph — usually caused by stale untracked remote bookmarks pinning the \
+             commits. Fix the cause with `jj bookmark forget --include-remotes 'glob:<pattern>'`, \
+             or include immutable commits for one run with `--bookmarks-revset 'mine() ~ \
+             trunk()'` (env: STAKK_BOOKMARKS_REVSET)"
+        )
+    )]
+    SelectedBookmarksExcluded {
+        /// Selected names not consumed by any segment (sorted).
+        missing: Vec<String>,
+        /// Subset of `missing` found on immutable commits in the stack
+        /// (sorted).
+        immutable: Vec<String>,
+    },
+
     /// A segment in the change graph has no bookmark name.
     #[error("segment for change {change_id} has no bookmark name")]
     #[diagnostic(
@@ -283,6 +310,40 @@ pub fn analyze_submission(
         } else {
             accumulated_commits.extend(seg.commits.iter().cloned());
         }
+    }
+
+    // Every selected bookmark must be a segment boundary somewhere in the
+    // stack. A selected name matching no segment means the graph excluded it
+    // (its commit is in the stack, but the bookmarks revset filtered the
+    // bookmark — typically because the commit is immutable). Silently folding
+    // it away would submit fewer PRs than the user selected. Selected names
+    // above the target are fine: they're boundaries, just not part of this
+    // submission.
+    let known: HashSet<&str> = stack
+        .segments
+        .iter()
+        .flat_map(|s| &s.bookmark_names)
+        .map(String::as_str)
+        .collect();
+    let mut missing: Vec<String> = selected_bookmarks
+        .iter()
+        .filter(|name| !known.contains(name.as_str()))
+        .cloned()
+        .collect();
+    if !missing.is_empty() {
+        missing.sort_unstable();
+        let immutable: Vec<String> = missing
+            .iter()
+            .filter(|name| {
+                stack
+                    .segments
+                    .iter()
+                    .flat_map(|s| &s.commits)
+                    .any(|c| c.is_immutable && c.local_bookmark_names.contains(name))
+            })
+            .cloned()
+            .collect();
+        return Err(SubmitError::SelectedBookmarksExcluded { missing, immutable });
     }
 
     Ok(SubmissionAnalysis {
@@ -881,6 +942,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: change_id[..4.min(change_id.len())].to_string(),
             }],
         }
@@ -1280,6 +1343,67 @@ mod tests {
         assert_eq!(result.segments[0].commits.len(), 1); // A's own only
         assert_eq!(result.segments[1].bookmark_names, vec!["feat-c"]);
         assert_eq!(result.segments[1].commits.len(), 2); // C's own + B's inherited
+    }
+
+    /// A selected bookmark that never becomes a segment boundary must error
+    /// loudly, with immutable-commit diagnosis from the graph data.
+    #[test]
+    fn analyze_errors_when_selected_bookmark_excluded() {
+        let seg_a = make_segment(&["feat-a"], "ch_a", "feature a");
+        // feat-a's segment contains an immutable mid-segment commit carrying
+        // the filtered-out bookmark "ghost".
+        let mut seg_b = make_segment(&["feat-b"], "ch_b", "feature b");
+        seg_b.commits[0].is_immutable = true;
+        seg_b.commits[0].local_bookmark_names = vec!["ghost".to_string()];
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![seg_a, seg_b],
+        }]);
+
+        let selected = HashSet::from(["feat-b".to_string(), "ghost".to_string()]);
+        let result = analyze_submission("feat-b", &graph, "main", &selected);
+        match result {
+            Err(SubmitError::SelectedBookmarksExcluded { missing, immutable }) => {
+                assert_eq!(missing, vec!["ghost"]);
+                assert_eq!(immutable, vec!["ghost"]);
+            }
+            other => panic!("expected SelectedBookmarksExcluded, got {other:?}"),
+        }
+    }
+
+    /// A missing selected name on no known commit still errors, but without
+    /// the immutable diagnosis.
+    #[test]
+    fn analyze_excluded_error_distinguishes_non_immutable_missing() {
+        let seg_a = make_segment(&["feat-a"], "ch_a", "feature a");
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![seg_a],
+        }]);
+
+        let selected = HashSet::from(["feat-a".to_string(), "vanished".to_string()]);
+        let result = analyze_submission("feat-a", &graph, "main", &selected);
+        match result {
+            Err(SubmitError::SelectedBookmarksExcluded { missing, immutable }) => {
+                assert_eq!(missing, vec!["vanished"]);
+                assert!(immutable.is_empty());
+            }
+            other => panic!("expected SelectedBookmarksExcluded, got {other:?}"),
+        }
+    }
+
+    /// The explicit `--bookmark <name>` path (selected == {target}) can never
+    /// trigger the excluded-bookmarks guard.
+    #[test]
+    fn analyze_explicit_single_bookmark_never_triggers_guard() {
+        let seg_a = make_segment(&["feat-a"], "ch_a", "feature a");
+        let seg_b = make_segment(&["feat-b"], "ch_b", "feature b");
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![seg_a, seg_b],
+        }]);
+
+        let selected = HashSet::from(["feat-b".to_string()]);
+        let result = analyze_submission("feat-b", &graph, "main", &selected).unwrap();
+        assert_eq!(result.segments.len(), 1);
+        assert_eq!(result.segments[0].bookmark_names, vec!["feat-b"]);
     }
 
     // -----------------------------------------------------------------------
@@ -2215,6 +2339,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2242,6 +2368,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2267,6 +2395,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch1".to_string(),
             },
             SegmentCommit {
@@ -2284,6 +2414,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch2".to_string(),
             },
         ];
@@ -2320,6 +2452,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2344,6 +2478,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2369,6 +2505,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch1".to_string(),
             },
             SegmentCommit {
@@ -2386,6 +2524,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch2".to_string(),
             },
         ];
@@ -2416,6 +2556,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2443,6 +2585,8 @@ mod tests {
                 timestamp: "T".to_string(),
             },
             files: vec![],
+            is_immutable: false,
+            local_bookmark_names: vec![],
             short_change_id: "ch1".to_string(),
         }];
 
@@ -2468,6 +2612,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch1".to_string(),
             },
             SegmentCommit {
@@ -2485,6 +2631,8 @@ mod tests {
                     timestamp: "T".to_string(),
                 },
                 files: vec![],
+                is_immutable: false,
+                local_bookmark_names: vec![],
                 short_change_id: "ch2".to_string(),
             },
         ];


### PR DESCRIPTION
Bookmarks on immutable commits are excluded by the default `--bookmarks-revset` (`mine() ~ trunk() ~ immutable()`), so they never became segment boundaries. The TUI offered their commits as bare rows, the post-creation graph rebuild filtered the new bookmarks out again, and `analyze_submission` silently folded the selected names away — a 6-bookmark stack could submit as 2 PRs with no error.

Two-part fix:

- **Thread immutability through the pipeline.** `LOG_TEMPLATE` now emits jj's `immutable` keyword, carried through `LogEntry → SegmentCommit → LayoutNode → BookmarkRow` together with the commit's *unfiltered* `local_bookmark_names`. `LogEntryRaw` is deliberately not serde-defaulted so template/parser drift fails loudly.
- **Lock doomed rows and error loudly.** TUI rows on immutable commits with no boundary bookmark are locked (permanently `[ ]`, mutating keys no-op) and render a hint naming the excluded bookmarks. Immutable rows that are boundaries (custom revsets without `~ immutable()`) stay fully functional. `analyze_submission` now returns `SelectedBookmarksExcluded` (code `stakk::submit::selected_bookmarks_excluded`) when a selected bookmark is a boundary in no segment, diagnosing the immutable cause from graph data alone and pointing at the workarounds (`jj bookmark forget --include-remotes`, `--bookmarks-revset 'mine() ~ trunk()'`).

Fixes #89