### PR TITLE
chore: release v1.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.3](https://github.com/glennib/stakk/compare/v1.16.2...v1.16.3) - 2026-06-22
+
+### Fixed
+
+- stop silently dropping selected bookmarks on jj-immutable revs
+
+### Other
+
+- *(deps)* lock file maintenance ([#126](https://github.com/glennib/stakk/pull/126))
+- *(deps)* update dependency cargo-binstall to v1.20.1 ([#125](https://github.com/glennib/stakk/pull/125))
+- *(deps)* update rust crate ratatui to v0.30.2 ([#124](https://github.com/glennib/stakk/pull/124))
+- *(deps)* update rust crate minijinja to v2.21.0 ([#122](https://github.com/glennib/stakk/pull/122))
+- *(deps)* lock file maintenance ([#121](https://github.com/glennib/stakk/pull/121))
+
 ## [1.16.2](https://github.com/glennib/stakk/compare/v1.16.1...v1.16.2) - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.16.2"
+version = "1.16.3"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.16.2"
+version = "1.16.3"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.16.2 -> 1.16.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.16.3](https://github.com/glennib/stakk/compare/v1.16.2...v1.16.3) - 2026-06-22

### Fixed

- stop silently dropping selected bookmarks on jj-immutable revs

### Other

- *(deps)* lock file maintenance ([#126](https://github.com/glennib/stakk/pull/126))
- *(deps)* update dependency cargo-binstall to v1.20.1 ([#125](https://github.com/glennib/stakk/pull/125))
- *(deps)* update rust crate ratatui to v0.30.2 ([#124](https://github.com/glennib/stakk/pull/124))
- *(deps)* update rust crate minijinja to v2.21.0 ([#122](https://github.com/glennib/stakk/pull/122))
- *(deps)* lock file maintenance ([#121](https://github.com/glennib/stakk/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).