### PR TITLE
chore: release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0](https://github.com/glennib/stakk/compare/v1.16.3...v1.17.0) - 2026-06-25
+
+### Added
+
+- *(tfidf)* order auto bookmark name terms by occurrence
+
 ## [1.16.3](https://github.com/glennib/stakk/compare/v1.16.2...v1.16.3) - 2026-06-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.16.3"
+version = "1.17.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.16.3"
+version = "1.17.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.16.3 -> 1.17.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.17.0](https://github.com/glennib/stakk/compare/v1.16.3...v1.17.0) - 2026-06-25

### Added

- *(tfidf)* order auto bookmark name terms by occurrence
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).