### PR TITLE
chore: release v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1](https://github.com/glennib/stakk/compare/v1.17.0...v1.17.1) - 2026-06-29
+
+### Other
+
+- *(deps)* lock file maintenance ([#130](https://github.com/glennib/stakk/pull/130))
+- *(deps)* update actions/checkout action to v7
+- *(deps)* update actions/cache action to v6
+
 ## [1.17.0](https://github.com/glennib/stakk/compare/v1.16.3...v1.17.0) - 2026-06-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.17.0"
+version = "1.17.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.17.0 -> 1.17.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.17.1](https://github.com/glennib/stakk/compare/v1.17.0...v1.17.1) - 2026-06-29

### Other

- *(deps)* lock file maintenance ([#130](https://github.com/glennib/stakk/pull/130))
- *(deps)* update actions/checkout action to v7
- *(deps)* update actions/cache action to v6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).