### PR TITLE
fix(select): clarify unchecked commit behavior in bookmark TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,14 +179,14 @@ Each non-trunk row cycles through state *types* via Space (forward) / `b`
 
 (`[*]custom` only present when `--bookmark-command` is configured.)
 
-| Checkbox | State             | Color        | Description                                       |
-|----------|-------------------|--------------|---------------------------------------------------|
-| `[x]`   | UseExisting(idx)  | green, bold  | Use an existing bookmark; `r`/`R` cycles when >1  |
-| `[~]`   | UseTfidf          | blue, bold   | TF-IDF name from commit description + files        |
-| `[>]`   | UserInput         | lt-yellow    | Manual entry — press `i` to edit, validates live   |
-| `[+]`   | UseGenerated      | yellow, bold | Auto `stakk-<change_id[:12]>`                      |
-| `[*]`   | UseCustom         | cyan, bold   | External `--bookmark-command` with async spinner   |
-| `[ ]`   | Unchecked         | dark gray    | Excluded from submission                           |
+| Checkbox | State            | Color        | Description                                      |
+|----------|------------------|--------------|--------------------------------------------------|
+| `[x]`    | UseExisting(idx) | green, bold  | Use an existing bookmark; `r`/`R` cycles when >1 |
+| `[~]`    | UseTfidf         | blue, bold   | TF-IDF name from commit description + files      |
+| `[>]`    | UserInput        | lt-yellow    | Manual entry — press `i` to edit, validates live |
+| `[+]`    | UseGenerated     | yellow, bold | Auto `stakk-<change_id[:12]>`                    |
+| `[*]`    | UseCustom        | cyan, bold   | External `--bookmark-command` with async spinner |
+| `[ ]`    | Unchecked        | dark gray    | Excluded from submission                         |
 
 States are **skipped** when they would produce no name or a duplicate of
 another state's name (e.g., UseTfidf skipped if it matches an existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,14 +179,14 @@ Each non-trunk row cycles through state *types* via Space (forward) / `b`
 
 (`[*]custom` only present when `--bookmark-command` is configured.)
 
-| Checkbox | State            | Color        | Description                                      |
-|----------|------------------|--------------|--------------------------------------------------|
-| `[x]`    | UseExisting(idx) | green, bold  | Use an existing bookmark; `r`/`R` cycles when >1 |
-| `[~]`    | UseTfidf         | blue, bold   | TF-IDF name from commit description + files      |
-| `[>]`    | UserInput        | lt-yellow    | Manual entry — press `i` to edit, validates live |
-| `[+]`    | UseGenerated     | yellow, bold | Auto `stakk-<change_id[:12]>`                    |
-| `[*]`    | UseCustom        | cyan, bold   | External `--bookmark-command` with async spinner |
-| `[ ]`    | Unchecked        | dark gray    | Excluded from submission                         |
+| Checkbox | State            | Color        | Description                                                 |
+|----------|------------------|--------------|-------------------------------------------------------------|
+| `[x]`    | UseExisting(idx) | green, bold  | Use an existing bookmark; `r`/`R` cycles when >1            |
+| `[~]`    | UseTfidf         | blue, bold   | TF-IDF name from commit description + files                 |
+| `[>]`    | UserInput        | lt-yellow    | Manual entry — press `i` to edit, validates live            |
+| `[+]`    | UseGenerated     | yellow, bold | Auto `stakk-<change_id[:12]>`                               |
+| `[*]`    | UseCustom        | cyan, bold   | External `--bookmark-command` with async spinner            |
+| `[ ]`    | Unchecked        | dark gray    | No PR of its own; the commit is included in the PR above it |
 
 States are **skipped** when they would produce no name or a duplicate of
 another state's name (e.g., UseTfidf skipped if it matches an existing

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -725,7 +725,8 @@ fn render_bookmark_screen(
         )])
     } else {
         Line::from(vec![Span::styled(
-            " Checked commits ([x]/[+]/[~]/[*]) will be pushed and have PRs created or updated.",
+            " Checked commits ([x]/[+]/[~]/[*]) will get own PRs. Unchecked will be part of the \
+             PR above them.",
             Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
         )])
     };

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -61,7 +61,7 @@ pub enum RowState {
     UseCustom(CustomNameState),
     /// Included in submission; a user-typed bookmark name.
     UserInput(String),
-    /// Excluded from submission.
+    /// No PR of its own; the commit will be included in the PR above it.
     Unchecked,
 }
 


### PR DESCRIPTION
Neat tool!

I remember being a bit confused when I first saw the following line in the bookmark TUI, as it made me think for a second that unchecked commits _wouldn't_ be pushed:

> Checked commits ([x]/[+]/[~]/[*]) will be pushed and have PRs created or updated

What do you think about changing it to something like this?