### PR TITLE
Allow disabling comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(submit)* add `--stack-placement none` to disable stack comments/body
+  fences entirely; existing stakk stack artifacts are removed on the next
+  submit (e.g. when relying on GitHub's native stacked PRs)
+
 ## [1.17.2](https://github.com/glennib/stakk/compare/v1.17.1...v1.17.2) - 2026-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- *(submit)* add `--stack-placement none` to disable stack comments/body
-  fences entirely; existing stakk stack artifacts are removed on the next
-  submit (e.g. when relying on GitHub's native stacked PRs)
-
 ## [1.17.2](https://github.com/glennib/stakk/compare/v1.17.1...v1.17.2) - 2026-07-28
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,15 @@ are in-flight to animate the spinner (10-frame animation).
 - `format_stack_comment` returns `Result` because user templates can fail.
 - Body-mode fences (`STAKK_BODY_START`/`STAKK_BODY_END`) are HTML comments,
   invisible on GitHub. Migration between placement modes is automatic.
+- `--stack-placement none` writes no stack info and instead runs
+  `cleanup_stack_artifacts` on every PR, deleting the stack comment and
+  stripping the body fence. Single-bookmark submissions take the same
+  cleanup path (one PR is not a stack), so the two share one branch that
+  runs *before* the template and context setup that only `comment`/`body`
+  need. PRs created in the same run are skipped — they cannot yet carry a
+  stack comment. In `none` mode the custom `--template` is never read or
+  compiled, so a broken template does not fail a submission that will not
+  render it.
 - ratatui inline viewport: `enable_raw_mode()` before, `disable_raw_mode()` after.
 - Graph layout deduplicates shared segments by `commit_id` (not `change_id`).
 - Auto-generated bookmark names: `stakk-<first 12 chars of change_id>`.
@@ -303,6 +312,10 @@ are in-flight to animate the spinner (10-frame animation).
   enables updating existing PRs. Change detection avoids redundant API calls.
   In `--stack-placement body` mode, body sync skips the per-bookmark API call
   and lets the fence-splicing phase handle it in one update.
+- **`--stack-placement none` also removes** — disabling stack info retires
+  the existing artifacts rather than leaving them stale, so the feature can
+  be turned off cleanly. Deletion is not previewed by `--dry-run`, which
+  returns before the execute phase.
 - **`--dry-run` not in env vars** — one-off decision, surprising as a default.
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
 - **Three-phase submission** — analyze (pure) → plan (queries forge) → execute.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ idempotent updates.
   branches so each PR shows only its own diff.
 - **Stack-awareness comments** — adds a comment to every PR listing the full
   stack with links, updated in place on re-runs. Optionally, the stack info
-  can be placed in the PR body instead (`--stack-placement body`). Comments
+  can be placed in the PR body instead (`--stack-placement body`) or disabled
+  entirely (`--stack-placement none`, which also removes existing stack
+  comments/body fences). Comments
   are rendered with [minijinja](https://github.com/mitsuhiko/minijinja)
   templates and can be customized with `--template` or the `STAKK_TEMPLATE`
   environment variable.
@@ -201,7 +203,9 @@ pr_mode = "draft"
 # Path to a custom minijinja template for stack comments
 template = "/path/to/my-template.md.jinja"
 
-# Where to place stack info: "comment" or "body" (default: "comment")
+# Where to place stack info: "comment", "body", or "none" (default: "comment")
+# "none" writes no stack info and removes existing stack comments/body fences
+# on the next submit (e.g. if you rely on GitHub's native stacked PRs).
 stack_placement = "body"
 
 # Prefix for auto-generated bookmark names (default: none)
@@ -294,7 +298,7 @@ stack_placement = "comment"
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_DRAFT` | Set to `true` to always create draft PRs (overridden by `--draft`) |
 | `STAKK_TEMPLATE` | Path to a custom minijinja template for stack comments (overridden by `--template`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default) or `body` (overridden by `--stack-placement`) |
+| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, or `none` (overridden by `--stack-placement`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
 | `STAKK_TRAILERS` | Whether to keep or strip git commit trailers in PR bodies: `keep` (default) or `strip` (overridden by `--trailers`) |
@@ -327,7 +331,7 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | `--draft` | `STAKK_DRAFT` | Create new PRs as drafts |
 | `--remote <name>` | `STAKK_REMOTE` | Push to a specific remote (default: `origin`) |
 | `--template <path>` | `STAKK_TEMPLATE` | Use a custom minijinja template for stack comments |
-| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default) or in the PR `body` |
+| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default), in the PR `body`, or write none at all with `none` |
 | `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
 | `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
 | `--trailers <mode>` | `STAKK_TRAILERS` | Keep or strip git commit trailers in PR bodies: `keep` (default), `strip` |

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ idempotent updates.
   stack with links, updated in place on re-runs. Optionally, the stack info
   can be placed in the PR body instead (`--stack-placement body`) or disabled
   entirely (`--stack-placement none`, which also removes existing stack
-  comments/body fences). Comments
-  are rendered with [minijinja](https://github.com/mitsuhiko/minijinja)
-  templates and can be customized with `--template` or the `STAKK_TEMPLATE`
-  environment variable.
+  comments and body fences). Comments are rendered with
+  [minijinja](https://github.com/mitsuhiko/minijinja) templates and can be
+  customized with `--template` or the `STAKK_TEMPLATE` environment variable.
 - **Idempotent** — re-running `stakk submit` is always safe. Existing PRs are
   updated, never duplicated.
 - **Dry-run mode** — `--dry-run` shows exactly what would happen without

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -298,6 +298,29 @@ mod tests {
         assert_eq!(submit_args(&cli).stack_placement, StackPlacement::Comment);
     }
 
+    #[test]
+    fn stack_placement_config_none() {
+        let config = Config {
+            stack_placement: Some(StackPlacement::None),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "bm"]);
+        assert_eq!(submit_args(&cli).stack_placement, StackPlacement::None);
+    }
+
+    #[test]
+    fn stack_placement_cli_none_overrides_config() {
+        let config = Config {
+            stack_placement: Some(StackPlacement::Body),
+            ..Default::default()
+        };
+        let cli = parse_with_config(
+            config,
+            &["stakk", "submit", "--stack-placement", "none", "bm"],
+        );
+        assert_eq!(submit_args(&cli).stack_placement, StackPlacement::None);
+    }
+
     // -- sync_pr_content tests --
 
     #[test]
@@ -527,6 +550,12 @@ heads_revset = "heads(all())"
     fn toml_stack_placement_kebab_case() {
         let config: Config = toml::from_str(r#"stack_placement = "comment""#).unwrap();
         assert_eq!(config.stack_placement, Some(StackPlacement::Comment));
+    }
+
+    #[test]
+    fn toml_stack_placement_none() {
+        let config: Config = toml::from_str(r#"stack_placement = "none""#).unwrap();
+        assert_eq!(config.stack_placement, Some(StackPlacement::None));
     }
 
     #[test]

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -151,6 +151,10 @@ pub struct SubmitArgs {
     /// Do not edit the fenced section by hand — it is overwritten on
     /// every run.
     ///
+    /// In none mode no stack info is written at all. Existing stack
+    /// comments and body fences are removed from each PR on submit, so
+    /// the feature can be retired cleanly.
+    ///
     /// Switching modes migrates automatically: moving to body mode
     /// deletes the old stack comment, and moving to comment mode strips
     /// the fenced section from the PR body.

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -22,6 +22,9 @@ pub enum StackPlacement {
     Comment,
     /// Place the stack content in a fenced section of the PR body.
     Body,
+    /// Write no stack info at all. Existing stack comments and body
+    /// fences are removed on submit.
+    None,
 }
 
 impl std::fmt::Display for StackPlacement {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use crate::cli::submit::SubmitArgs;
 use crate::error::StakkError::Interrupted;
 use crate::error::StakkError::{self};
 use crate::forge::Forge;
+use crate::forge::comment::StackPlacement;
 use crate::jj::Jj;
 use crate::jj::remote::parse_github_url;
 use crate::jj::runner::RealJjRunner;
@@ -256,17 +257,17 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
         return Ok(());
     }
 
-    // Load template.
-    let template_source = match &args.template {
-        Some(path) => {
-            Some(
-                std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
-                    path: path.clone(),
-                    reason: e.to_string(),
-                })?,
-            )
-        }
-        None => None,
+    // Load template. In `none` placement no stack content is ever rendered,
+    // so a custom template is neither read nor compiled — a broken or missing
+    // one must not fail a submission that will not use it.
+    let template_source = match (&args.template, args.stack_placement) {
+        (Some(path), StackPlacement::Comment | StackPlacement::Body) => Some(
+            std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
+                path: path.clone(),
+                reason: e.to_string(),
+            })?,
+        ),
+        _ => None,
     };
     let comment_env = forge::comment::build_comment_env(template_source.as_deref())?;
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -699,9 +699,38 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     }
 
     // Step 3: Concurrently create/update stack comments on all PRs.
-    // For single-bookmark submissions, skip stack info entirely and just
-    // clean up any stale stack artifacts from a previously larger stack.
-    if stack_entries.len() > 1 {
+    //
+    // Two cases write no stack info and instead retire any artifacts left on
+    // the PRs: `none` placement, and single-bookmark submissions, which are
+    // not a stack at all (the artifacts are stale leftovers from when the PR
+    // belonged to a larger stack).
+    let cleanup_only = placement == StackPlacement::None || stack_entries.len() == 1;
+
+    if cleanup_only {
+        pb.set_message("Cleaning up stack artifacts...");
+        let cleanup_futures: Vec<_> = stack_entries
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                let bp = &plan.bookmark_plans[i];
+                let existing_body = effective_body(bp).unwrap_or_default();
+                // A PR created moments ago in this very run carries neither a
+                // stack comment nor a body fence — nothing to look for.
+                let created_now = bp.needs_create;
+                let pb = &pb;
+                async move {
+                    if created_now {
+                        return Ok(());
+                    }
+                    cleanup_stack_artifacts(forge, entry.pr_number, &existing_body, pb).await
+                }
+            })
+            .collect();
+        let results = futures::future::join_all(cleanup_futures).await;
+        for result in results {
+            result?;
+        }
+    } else if stack_entries.len() > 1 {
         pb.set_message("Updating stack comments...");
         let comment_data = StackCommentData {
             version: 0,
@@ -848,33 +877,10 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
                     result?;
                 }
             }
-            StackPlacement::None => {
-                pb.set_message("Cleaning up stack artifacts...");
-                let cleanup_futures: Vec<_> = stack_entries
-                    .iter()
-                    .enumerate()
-                    .map(|(i, entry)| {
-                        let existing_body =
-                            effective_body(&plan.bookmark_plans[i]).unwrap_or_default();
-                        let pb = &pb;
-                        async move {
-                            cleanup_stack_artifacts(forge, entry.pr_number, &existing_body, pb)
-                                .await
-                        }
-                    })
-                    .collect();
-                let results = futures::future::join_all(cleanup_futures).await;
-                for result in results {
-                    result?;
-                }
-            }
+            // Handled by the cleanup branch above, which runs before any of
+            // the rendering setup this arm would not use.
+            StackPlacement::None => {}
         }
-    } else if stack_entries.len() == 1 {
-        // Single bookmark — not a stack. Clean up any stale stack artifacts
-        // from when this PR was part of a larger stack.
-        let entry = &stack_entries[0];
-        let existing_body = effective_body(&plan.bookmark_plans[0]).unwrap_or_default();
-        cleanup_stack_artifacts(forge, entry.pr_number, &existing_body, &pb).await?;
     }
 
     pb.finish_and_clear();
@@ -1029,6 +1035,9 @@ mod tests {
         updated_bodies: Mutex<Vec<(u64, String)>>,
         deleted_comments: Mutex<Vec<u64>>,
         existing_comments: HashMap<u64, Vec<Comment>>,
+        /// PR numbers `list_comments` was called for, to assert that no
+        /// lookup is made on PRs that cannot carry a stack comment.
+        listed_comments: Mutex<Vec<u64>>,
         next_pr_number: Mutex<u64>,
         ops: Option<OpLog>,
     }
@@ -1045,6 +1054,7 @@ mod tests {
                 updated_bodies: Mutex::new(Vec::new()),
                 deleted_comments: Mutex::new(Vec::new()),
                 existing_comments: HashMap::new(),
+                listed_comments: Mutex::new(Vec::new()),
                 next_pr_number: Mutex::new(100),
                 ops: None,
             }
@@ -1134,6 +1144,7 @@ mod tests {
             &self,
             pr_number: u64,
         ) -> impl std::future::Future<Output = Result<Vec<Comment>, ForgeError>> + Send {
+            self.listed_comments.lock().unwrap().push(pr_number);
             let comments = self
                 .existing_comments
                 .get(&pr_number)
@@ -3193,6 +3204,11 @@ mod tests {
         assert_eq!(updated_comments.len(), 0);
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 0);
+
+        // Both PRs were created in this run, so neither can carry a stack
+        // comment — cleanup must not spend an API call looking.
+        let listed = forge.listed_comments.lock().unwrap();
+        assert!(listed.is_empty(), "unexpected comment lookups: {listed:?}");
     }
 
     #[tokio::test]
@@ -3296,6 +3312,11 @@ mod tests {
         // No new comments should be created.
         let created = forge.created_comments.lock().unwrap();
         assert_eq!(created.len(), 0);
+
+        // Only the pre-existing PR is inspected; feat-b was created in this
+        // run and is skipped.
+        let listed = forge.listed_comments.lock().unwrap();
+        assert_eq!(*listed, vec![50]);
     }
 
     #[tokio::test]

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -848,43 +848,75 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
                     result?;
                 }
             }
+            StackPlacement::None => {
+                pb.set_message("Cleaning up stack artifacts...");
+                let cleanup_futures: Vec<_> = stack_entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, entry)| {
+                        let existing_body =
+                            effective_body(&plan.bookmark_plans[i]).unwrap_or_default();
+                        let pb = &pb;
+                        async move {
+                            cleanup_stack_artifacts(forge, entry.pr_number, &existing_body, pb)
+                                .await
+                        }
+                    })
+                    .collect();
+                let results = futures::future::join_all(cleanup_futures).await;
+                for result in results {
+                    result?;
+                }
+            }
         }
     } else if stack_entries.len() == 1 {
         // Single bookmark — not a stack. Clean up any stale stack artifacts
         // from when this PR was part of a larger stack.
         let entry = &stack_entries[0];
-        let pr_number = entry.pr_number;
-        let existing_body = effective_body(&plan.bookmark_plans[0]);
-
-        // Clean up old stack comment (from either comment mode or pre-migration).
-        let comments = forge
-            .list_comments(pr_number)
-            .await
-            .map_err(|source| SubmitError::CommentFailed { pr_number, source })?;
-        if let Some(old) = find_stack_comment(&comments)
-            && let Err(e) = forge.delete_comment(old.id).await
-        {
-            pb.println(format!(
-                "  Warning: failed to clean up old stack comment on PR #{pr_number}: {e}"
-            ));
-        }
-
-        // Clean up old body fence (from body mode).
-        if let Some(body) = &existing_body
-            && find_stack_in_body(body).is_some()
-        {
-            let stripped = strip_stack_from_body(body);
-            if let Err(e) = forge.update_pr_body(pr_number, &stripped).await {
-                pb.println(format!(
-                    "  Warning: failed to strip stack from PR #{pr_number} body: {e}"
-                ));
-            }
-        }
+        let existing_body = effective_body(&plan.bookmark_plans[0]).unwrap_or_default();
+        cleanup_stack_artifacts(forge, entry.pr_number, &existing_body, &pb).await?;
     }
 
     pb.finish_and_clear();
 
     Ok(SubmissionResult { stack_entries })
+}
+
+/// Remove any stack artifacts (stack comment and body fence) from a single PR.
+///
+/// Used when stack info is disabled (`StackPlacement::None`) or when a
+/// submission no longer forms a stack, to retire stakk's footprint on
+/// already-created PRs.
+async fn cleanup_stack_artifacts<F: Forge>(
+    forge: &F,
+    pr_number: u64,
+    existing_body: &str,
+    pb: &indicatif::ProgressBar,
+) -> Result<(), SubmitError> {
+    // Clean up the old stack comment (from comment mode or pre-migration).
+    let comments = forge
+        .list_comments(pr_number)
+        .await
+        .map_err(|source| SubmitError::CommentFailed { pr_number, source })?;
+    if let Some(old) = find_stack_comment(&comments)
+        && let Err(e) = forge.delete_comment(old.id).await
+    {
+        pb.println(format!(
+            "  Warning: failed to clean up old stack comment on PR #{pr_number}: {e}"
+        ));
+    }
+
+    // Clean up the old body fence (from body mode).
+    if find_stack_in_body(existing_body).is_some() {
+        let stripped = strip_stack_from_body(existing_body);
+        if let Err(e) = forge.update_pr_body(pr_number, &stripped).await {
+            pb.println(format!(
+                "  Warning: failed to strip stack from PR #{pr_number} body: {e}"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -3102,8 +3134,169 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Interleaved push+update ordering tests (issue #35)
+    // None placement (stack info disabled) tests
     // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn execute_none_placement_writes_no_comments_or_bodies() {
+        let plan = SubmissionPlan {
+            bookmark_plans: vec![
+                BookmarkPlan {
+                    bookmark_name: "feat-a".to_string(),
+                    base: "main".to_string(),
+                    title: "feature a".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+                BookmarkPlan {
+                    bookmark_name: "feat-b".to_string(),
+                    base: "feat-a".to_string(),
+                    title: "feature b".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+            ],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let forge = MockForge::new();
+        let env = test_comment_env();
+
+        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.stack_entries.len(), 2);
+
+        // PRs should be created...
+        let created_prs = forge.created_prs.lock().unwrap();
+        assert_eq!(created_prs.len(), 2);
+
+        // ...but no stack comments and no body updates.
+        let created_comments = forge.created_comments.lock().unwrap();
+        assert_eq!(created_comments.len(), 0);
+        let updated_comments = forge.updated_comments.lock().unwrap();
+        assert_eq!(updated_comments.len(), 0);
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(updated_bodies.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn execute_none_placement_cleans_up_existing_artifacts() {
+        use crate::forge::comment::splice_stack_into_body;
+
+        // PR #50 carries both an old stack comment and a body fence.
+        let body_with_fence = splice_stack_into_body("Original PR body", "old stack content");
+        let env = test_comment_env();
+        let tmpl = env.get_template("stack_comment").unwrap();
+        let old_comment_body = format_stack_comment(
+            &StackCommentData {
+                version: 0,
+                stack: vec![StackEntry {
+                    bookmark_name: "feat-a".to_string(),
+                    pr_url: "https://example.com/1".to_string(),
+                    pr_number: 50,
+                }],
+            },
+            &StackCommentContext {
+                stack: vec![StackEntryContext {
+                    bookmark_name: "feat-a".to_string(),
+                    pr_url: "https://example.com/1".to_string(),
+                    pr_number: 50,
+                    title: "feature a".to_string(),
+                    base: "main".to_string(),
+                    is_draft: false,
+                    position: 1,
+                    is_current: true,
+                }],
+                stack_size: 1,
+                default_branch: "main".to_string(),
+                current_bookmark: "feat-a".to_string(),
+                stakk_url: STAKK_REPO_URL.to_string(),
+            },
+            &tmpl,
+        )
+        .unwrap();
+
+        let plan = SubmissionPlan {
+            bookmark_plans: vec![
+                BookmarkPlan {
+                    bookmark_name: "feat-a".to_string(),
+                    base: "main".to_string(),
+                    title: "feature a".to_string(),
+                    body: None,
+                    existing_pr: Some(make_pr_with_body(50, "feat-a", "main", &body_with_fence)),
+                    needs_push: true,
+                    needs_create: false,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+                BookmarkPlan {
+                    bookmark_name: "feat-b".to_string(),
+                    base: "feat-a".to_string(),
+                    title: "feature b".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+            ],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let forge = MockForge::new().with_existing_comments(
+            50,
+            vec![Comment {
+                id: 999,
+                body: old_comment_body,
+            }],
+        );
+
+        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
+            .await
+            .unwrap();
+
+        // Old stack comment on PR #50 should be deleted.
+        let deleted = forge.deleted_comments.lock().unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0], 999);
+
+        // Body fence on PR #50 should be stripped.
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(updated_bodies.len(), 1);
+        assert!(
+            !updated_bodies[0].1.contains("STAKK_BODY_START"),
+            "fence should be stripped: {}",
+            updated_bodies[0].1
+        );
+        assert!(updated_bodies[0].1.contains("Original PR body"));
+
+        // No new comments should be created.
+        let created = forge.created_comments.lock().unwrap();
+        assert_eq!(created.len(), 0);
+    }
 
     #[tokio::test]
     async fn execute_interleaves_push_and_base_update() {


### PR DESCRIPTION
Add `none` as possible option for `stack-placement`. When this set, existing comments will be removed during the update.

Addresses #171 