### PR TITLE
chore: release v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0](https://github.com/glennib/stakk/compare/v1.18.0...v1.19.0) - 2026-08-11
+
+### Added
+
+- *(submit)* separate execution output from the plan and persist stack-info status
+- *(select)* collapse the TUI viewport on exit and size it per screen
+
 ## [1.18.0](https://github.com/glennib/stakk/compare/v1.17.2...v1.18.0) - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,7 +2724,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.18.0 -> 1.19.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.19.0](https://github.com/glennib/stakk/compare/v1.18.0...v1.19.0) - 2026-08-11

### Added

- *(submit)* separate execution output from the plan and persist stack-info status
- *(select)* collapse the TUI viewport on exit and size it per screen
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).