### PR TITLE
feat(select): redesign branch-stack screen as jj-log-style single graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,8 @@ src/
 ├── select/          # Interactive TUI selection (ratatui inline viewport)
 │   ├── mod.rs       # Public API: resolve_bookmark_interactively(), SelectionResult
 │   ├── app.rs       # App state machine, event loop, terminal init
-│   ├── graph_layout.rs  # Convert ChangeGraph → 2D positioned nodes + edges
-│   ├── graph_widget.rs  # Screen 1: tree graph widget (leaf selection)
+│   ├── graph_layout.rs  # Convert ChangeGraph → jj-log-style row list (commit tree + display rows)
+│   ├── graph_widget.rs  # Screen 1: jj-log-style graph widget (leaf selection, collapsing, scrolling)
 │   ├── bookmark_widget.rs # Screen 2: bookmark toggle/assignment widget
 │   ├── bookmark_gen.rs # Bookmark validation and external command execution
 │   ├── tfidf.rs     # TF-IDF algorithm for auto-generated bookmark names
@@ -159,9 +159,24 @@ bookmarks to commits.
 
 ### Screens
 
-1. **GraphView** — Select a leaf node (branch tip) from the change graph.
-   Navigate leaves with `←`/`→` (`h`/`l`), confirm with Enter.
-   Help line: `◄►/hl navigate  Enter select  q/Esc quit`
+1. **GraphView** — Select a leaf node (branch tip) from a jj-log-style graph:
+   one row per commit, `│ `-cell edge gutter on the left, `├─╯` connector rows
+   where a sibling subtree merges into its parent's column. Every row
+   permanently carries its bookmark names and `"description"`; navigation only
+   re-colors the selected trunk→leaf path. Glyphs: `●` selected path (cyan;
+   the leaf is bold with a trailing `◀`), `○` other commits (dark gray), `◆`
+   trunk, `⋯ n commits` collapsed runs. Sibling subtrees are ordered
+   newest-first by committer timestamp (jiff-parsed, offset-aware; tiebreak on
+   the subtree root's change_id), so leaf 1 is the most recent stack.
+   Runs of consecutive unselected commits that carry no bookmark and are
+   neither leaves nor trunk collapse into `⋯ n commits`; the selected path is
+   always fully expanded. When the (collapsed) graph exceeds the viewport, it
+   scrolls to anchor the selected leaf at the top. The title row shows a
+   right-aligned `leaf i/n` indicator; the viewport is sized to the max
+   collapsed height over all leaves so leaf switches never resize it.
+   Navigate leaves with `←`/`→` (`h`/`l`) or `↑`/`↓` (`k`/`j`), wrapping;
+   confirm with Enter.
+   Help line: `←→↑↓/hjkl leaf  Enter select  q/Esc quit`
 
 2. **BookmarkAssignment** — Assign bookmark names to each commit in the
    selected path. Navigate rows with `↑`/`↓` (`j`/`k`). Rows are displayed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +814,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1339,6 +1376,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1426,42 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "js-sys"
@@ -2062,6 +2147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2835,8 @@ dependencies = [
  "futures",
  "http",
  "indicatif",
+ "insta",
+ "jiff",
  "miette",
  "minijinja",
  "octocrab",
@@ -2854,6 +2956,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "io-util"] }
 directories = "6"
 toml = "1.0.7"
+jiff = { version = "0.2.35", default-features = false, features = ["std"] }
 
 # The profile that 'dist' will build with
 [profile.dist]
@@ -46,3 +47,6 @@ inherits = "release"
 strip = true
 lto = "fat"
 codegen-units = 1
+
+[dev-dependencies]
+insta = "1.48.0"

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ cargo-binstall = "1.21.1"
 "cargo:cargo-edit" = "0.13.13"
 "cargo:cargo-nextest" = "0.9.143"
 "cargo:release-plz" = "0.3.160"
+cargo-insta = "latest"
 
 [tasks.fmt]
 description = "Format code"

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -383,7 +383,15 @@ fn group_segments_into_stacks(
         let ts_a = collect_timestamps_desc(a);
         let ts_b = collect_timestamps_desc(b);
         // Reverse comparison: largest (newest) timestamps first.
-        ts_b.cmp(&ts_a)
+        ts_b.cmp(&ts_a).then_with(|| {
+            fn leaf_change_id(s: &BranchStack) -> &str {
+                s.segments
+                    .last()
+                    .map(|seg| seg.change_id.as_str())
+                    .unwrap_or_default()
+            }
+            leaf_change_id(a).cmp(leaf_change_id(b))
+        })
     });
 
     stacks

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -41,11 +41,10 @@ use super::event::map_event;
 use super::event::map_event_editing;
 use super::graph_layout::GraphLayout;
 use super::graph_layout::build_layout;
-use super::graph_layout::path_to_leaf;
 use super::graph_widget::GraphViewState;
 use super::graph_widget::GraphWidget;
-use super::graph_widget::display_line_count;
 use super::graph_widget::graph_help_line;
+use super::graph_widget::max_collapsed_height;
 use crate::error::StakkError::Interrupted;
 use crate::error::StakkError::{self};
 use crate::graph::types::ChangeGraph;
@@ -145,9 +144,10 @@ fn viewport_height_for(content_rows: usize) -> io::Result<u16> {
     Ok(u16::try_from(height).expect("viewport height fits in u16"))
 }
 
-/// Viewport height for the graph screen.
+/// Viewport height for the graph screen: sized to the tallest collapsed
+/// view over all leaves, so switching leaves never needs a viewport resize.
 fn graph_viewport_height(layout: &GraphLayout) -> io::Result<u16> {
-    viewport_height_for(display_line_count(layout.total_rows))
+    viewport_height_for(max_collapsed_height(layout))
 }
 
 /// Create an inline-viewport terminal of the given height at the current
@@ -282,26 +282,25 @@ fn run_event_loop(
             Screen::GraphView => {
                 let action = map_event(&ev);
                 match action {
-                    Action::Left => {
-                        let leaves = layout.leaf_nodes();
+                    // Leaves are ordered top-to-bottom, so Up moves to the
+                    // previous leaf and Down to the next, like Left/Right.
+                    Action::Left | Action::Up => {
                         if graph_state.selected_leaf > 0 {
                             graph_state.selected_leaf -= 1;
                         } else {
-                            graph_state.selected_leaf = leaves.len().saturating_sub(1);
+                            graph_state.selected_leaf = layout.leaves.len().saturating_sub(1);
                         }
                     }
-                    Action::Right => {
-                        let leaves = layout.leaf_nodes();
-                        if graph_state.selected_leaf < leaves.len().saturating_sub(1) {
+                    Action::Right | Action::Down => {
+                        if graph_state.selected_leaf < layout.leaves.len().saturating_sub(1) {
                             graph_state.selected_leaf += 1;
                         } else {
                             graph_state.selected_leaf = 0;
                         }
                     }
                     Action::Select => {
-                        let leaves = layout.leaf_nodes();
-                        if let Some(leaf) = leaves.get(graph_state.selected_leaf) {
-                            let path = path_to_leaf(layout, leaf.row, leaf.col);
+                        if let Some(&leaf) = layout.leaves.get(graph_state.selected_leaf) {
+                            let path = layout.path_to_leaf(leaf);
                             let state = BookmarkAssignmentState::from_path(
                                 &path,
                                 has_bookmark_command,
@@ -318,9 +317,7 @@ fn run_event_loop(
                     Action::Quit => {
                         return Err(Interrupted);
                     }
-                    Action::Up
-                    | Action::Down
-                    | Action::Toggle
+                    Action::Toggle
                     | Action::ReverseToggle
                     | Action::EnterEdit
                     | Action::Vary
@@ -737,6 +734,17 @@ fn render_graph_screen(
             .add_modifier(Modifier::BOLD),
     )]);
     frame.render_widget(title, title_area);
+
+    // Leaf position indicator, right-aligned over the same title row.
+    let leaf_count = layout.leaves.len();
+    if leaf_count > 0 {
+        let indicator = Line::from(vec![Span::styled(
+            format!("leaf {}/{leaf_count} ", state.selected_leaf + 1),
+            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+        )])
+        .right_aligned();
+        frame.render_widget(indicator, title_area);
+    }
 
     let subtitle = Line::from(vec![Span::styled(
         " The highlighted branch will be submitted as a stack of pull requests.",

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -1075,8 +1075,6 @@ mod tests {
         is_leaf: bool,
     ) -> LayoutNode {
         LayoutNode {
-            row: 0,
-            col: 0,
             change_id: change_id.to_string(),
             commit_id: format!("commit_{change_id}"),
             summary: summary.to_string(),
@@ -1086,7 +1084,7 @@ mod tests {
             is_immutable: false,
             is_trunk,
             is_leaf,
-            stack_index: 0,
+            parent: None,
             short_change_id: change_id[..4.min(change_id.len())].to_string(),
             author: crate::jj::types::Signature {
                 name: "Test".to_string(),

--- a/src/select/graph_layout.rs
+++ b/src/select/graph_layout.rs
@@ -1,20 +1,21 @@
-//! Convert a `ChangeGraph` into a 2D layout for rendering.
+//! Convert a `ChangeGraph` into a jj-log-style row layout for rendering.
 //!
-//! Walks from trunk upward, assigning row/column positions to each commit node.
-//! The first stack gets column 0; branches fork rightward at split points.
+//! Commits are deduplicated by `commit_id` into a tree rooted at a trunk
+//! pseudo-node, then flattened into display rows: one row per commit plus
+//! connector rows (`├─╯`) where a sibling subtree merges into its parent's
+//! column. Sibling subtrees are ordered newest-first by committer timestamp,
+//! like jj log.
 
 use std::collections::HashMap;
+
+use jiff::Timestamp;
 
 use crate::graph::types::ChangeGraph;
 use crate::jj::types::Signature;
 
-/// A positioned node in the 2D graph layout.
+/// A commit node in the layout tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LayoutNode {
-    /// Row in the layout (0 = bottommost / trunk).
-    pub row: usize,
-    /// Column in the layout (0 = leftmost / main path).
-    pub col: usize,
     /// The jj change ID for this commit.
     pub change_id: String,
     /// The jj commit ID.
@@ -37,84 +38,95 @@ pub struct LayoutNode {
     pub is_trunk: bool,
     /// Whether this node is a leaf (no children).
     pub is_leaf: bool,
-    /// Index of the stack this node belongs to.
-    pub stack_index: usize,
     /// Shortest unique change ID prefix (from jj).
     pub short_change_id: String,
     /// Author signature.
     pub author: Signature,
     /// Files changed by this commit.
     pub files: Vec<String>,
+    /// Index of the parent node (toward trunk); `None` for the trunk node.
+    pub parent: Option<usize>,
 }
 
-/// An edge connecting two nodes in the layout.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LayoutEdge {
-    /// Row of the parent (lower) node.
-    pub from_row: usize,
-    /// Column of the parent (lower) node.
-    pub from_col: usize,
-    /// Row of the child (upper) node.
-    pub to_row: usize,
-    /// Column of the child (upper) node.
-    pub to_col: usize,
+/// One display row of the graph, in top-to-bottom order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphRow {
+    /// A commit (or trunk) row: node index into `GraphLayout::nodes`, drawn
+    /// at the given gutter column.
+    Commit { node: usize, col: usize },
+    /// A connector row (`├─╯`) merging column `col` into `col - 1`.
+    Connector { col: usize },
 }
 
-/// The complete 2D layout of the change graph.
+/// The complete jj-log-style layout of the change graph.
 #[derive(Debug, Clone)]
 pub struct GraphLayout {
-    /// All nodes, ordered by row (bottom to top).
+    /// All nodes. Index 0 is the trunk pseudo-node (when non-empty).
     pub nodes: Vec<LayoutNode>,
-    /// All edges connecting nodes.
-    pub edges: Vec<LayoutEdge>,
-    /// Total number of rows.
-    pub total_rows: usize,
-    /// Total number of columns.
-    pub total_cols: usize,
+    /// Display rows, top to bottom (trunk last).
+    pub rows: Vec<GraphRow>,
+    /// Node indices of leaves, in display order (top to bottom).
+    pub leaves: Vec<usize>,
 }
 
 impl GraphLayout {
-    /// Find a node by its (row, col) position.
-    pub fn node_at(&self, row: usize, col: usize) -> Option<&LayoutNode> {
-        self.nodes.iter().find(|n| n.row == row && n.col == col)
+    /// Return all leaf nodes (selectable branch tips) in display order (top
+    /// to bottom), so that index 0 is the topmost leaf.
+    pub fn leaf_nodes(&self) -> Vec<&LayoutNode> {
+        self.leaves.iter().map(|&i| &self.nodes[i]).collect()
     }
 
-    /// Return all leaf nodes (selectable branch tips), sorted left-to-right by
-    /// column so that index 0 is the leftmost leaf.
-    pub fn leaf_nodes(&self) -> Vec<&LayoutNode> {
-        let mut leaves: Vec<&LayoutNode> = self.nodes.iter().filter(|n| n.is_leaf).collect();
-        leaves.sort_by_key(|n| n.col);
-        leaves
+    /// Node indices on the path from trunk to the given node, trunk first.
+    pub fn path_node_indices(&self, node: usize) -> Vec<usize> {
+        let mut path = Vec::new();
+        let mut current = Some(node);
+        while let Some(i) = current {
+            path.push(i);
+            current = self.nodes[i].parent;
+        }
+        path.reverse();
+        path
+    }
+
+    /// Collect all nodes on the path from trunk to the given node.
+    ///
+    /// Returns nodes in trunk-to-leaf order.
+    pub fn path_to_leaf(&self, node: usize) -> Vec<&LayoutNode> {
+        self.path_node_indices(node)
+            .into_iter()
+            .map(|i| &self.nodes[i])
+            .collect()
+    }
+
+    /// Display row index of the commit row for a node.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used in tests; useful layout diagnostic")
+    )]
+    pub fn row_of_node(&self, node: usize) -> Option<usize> {
+        self.rows.iter().position(|r| match r {
+            GraphRow::Commit { node: n, .. } => *n == node,
+            GraphRow::Connector { .. } => false,
+        })
     }
 }
 
-/// Build a 2D graph layout from a `ChangeGraph`.
+/// Build a jj-log-style graph layout from a `ChangeGraph`.
 ///
-/// The layout places trunk at the bottom (row 0) and grows upward. Each stack
-/// gets its own column, with shared segments placed in the leftmost column that
-/// uses them.
+/// The trunk pseudo-node sits at the bottom; each commit appears exactly
+/// once. Sibling subtrees are ordered by their most recent committer
+/// timestamp, newest topmost, with the subtree root's `change_id` as a
+/// deterministic tiebreaker.
 pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
     if graph.stacks.is_empty() {
         return GraphLayout {
             nodes: vec![],
-            edges: vec![],
-            total_rows: 0,
-            total_cols: 0,
+            rows: vec![],
+            leaves: vec![],
         };
     }
 
-    // Track which commit_ids we've already placed (for shared segments).
-    // We key by commit_id since it's unique per commit, while change_id is
-    // shared by all commits in a segment.
-    let mut placed: HashMap<String, (usize, usize)> = HashMap::new();
-    let mut nodes: Vec<LayoutNode> = Vec::new();
-    let mut edges: Vec<LayoutEdge> = Vec::new();
-
-    // We build a trunk node at row 0.
-    let trunk_row = 0;
-    nodes.push(LayoutNode {
-        row: trunk_row,
-        col: 0,
+    let mut nodes: Vec<LayoutNode> = vec![LayoutNode {
         change_id: String::new(),
         commit_id: String::new(),
         summary: "trunk".to_string(),
@@ -124,7 +136,6 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
         is_immutable: false,
         is_trunk: true,
         is_leaf: false,
-        stack_index: 0,
         short_change_id: String::new(),
         author: Signature {
             name: String::new(),
@@ -132,37 +143,34 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
             timestamp: String::new(),
         },
         files: vec![],
-    });
+        parent: None,
+    }];
+    let mut children: Vec<Vec<usize>> = vec![vec![]];
+    // Committer timestamp per node; unparseable timestamps sort as oldest.
+    let mut own_ts: Vec<Option<Timestamp>> = vec![None];
+    // commit_id → node index, for deduplicating shared segments across
+    // stacks (change_id is shared by all commits in a segment, so key by
+    // commit_id).
+    let mut placed: HashMap<String, usize> = HashMap::new();
 
-    let num_stacks = graph.stacks.len();
-    let mut max_row: usize = 0;
-
-    for (stack_idx, stack) in graph.stacks.iter().enumerate() {
-        let col = stack_idx;
-        // Depth from trunk — each commit gets the next depth. For shared
-        // commits (already placed), we resume from the shared commit's row.
-        let mut depth: usize = 1;
-        let mut prev_row = trunk_row;
-        let mut prev_col: usize = 0;
+    for stack in &graph.stacks {
+        let mut prev: usize = 0; // trunk
 
         for (seg_idx, segment) in stack.segments.iter().enumerate() {
             let is_last_segment = seg_idx == stack.segments.len() - 1;
 
-            // Process commits in this segment (they are newest-first in the
-            // segment, but we want to lay them out bottom-to-top, so reverse).
+            // Commits are newest-first in the segment; walk them
+            // trunk-to-leaf.
             let commits: Vec<_> = segment.commits.iter().rev().collect();
 
             for (commit_idx, commit) in commits.iter().enumerate() {
-                let is_last_commit_in_segment = commit_idx == commits.len() - 1;
-
-                // Check if this commit was already placed (shared segment).
-                if let Some(&(existing_row, existing_col)) = placed.get(&commit.commit_id) {
-                    // Shared node: continue from its depth.
-                    prev_row = existing_row;
-                    prev_col = existing_col;
-                    depth = existing_row + 1;
+                // Shared node (prefix of an earlier stack): continue from it.
+                if let Some(&existing) = placed.get(&commit.commit_id) {
+                    prev = existing;
                     continue;
                 }
+
+                let is_last_commit_in_segment = commit_idx == commits.len() - 1;
 
                 let bookmark_names = if is_last_commit_in_segment {
                     segment.bookmark_names.clone()
@@ -186,14 +194,8 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
                     .unwrap_or("(no description)")
                     .to_string();
 
-                let is_leaf = is_last_segment && is_last_commit_in_segment;
-
-                let row = depth;
-                depth += 1;
-
+                let idx = nodes.len();
                 nodes.push(LayoutNode {
-                    row,
-                    col,
                     change_id: commit.change_id.clone(),
                     commit_id: commit.commit_id.clone(),
                     summary,
@@ -202,73 +204,99 @@ pub fn build_layout(graph: &ChangeGraph) -> GraphLayout {
                     excluded_bookmarks,
                     is_immutable: commit.is_immutable,
                     is_trunk: false,
-                    is_leaf,
-                    stack_index: stack_idx,
+                    is_leaf: is_last_segment && is_last_commit_in_segment,
                     short_change_id: commit.short_change_id.clone(),
                     author: commit.author.clone(),
                     files: commit.files.clone(),
+                    parent: Some(prev),
                 });
-
-                edges.push(LayoutEdge {
-                    from_row: prev_row,
-                    from_col: prev_col,
-                    to_row: row,
-                    to_col: col,
-                });
-
-                placed.insert(commit.commit_id.clone(), (row, col));
-                max_row = max_row.max(row);
-                prev_row = row;
-                prev_col = col;
+                children.push(vec![]);
+                own_ts.push(commit.committer.timestamp.parse().ok());
+                children[prev].push(idx);
+                placed.insert(commit.commit_id.clone(), idx);
+                prev = idx;
             }
         }
     }
 
-    // Sort nodes by row for consistent iteration.
-    nodes.sort_by_key(|n| (n.row, n.col));
+    // Max committer timestamp per subtree. Parents are always created before
+    // their children, so a reverse index scan sees children first.
+    let mut subtree_ts = own_ts;
+    for i in (0..nodes.len()).rev() {
+        for &child in &children[i] {
+            if subtree_ts[child] > subtree_ts[i] {
+                subtree_ts[i] = subtree_ts[child];
+            }
+        }
+    }
 
-    let total_rows = max_row + 1;
-    let total_cols = num_stacks.max(1);
+    // Order siblings newest-subtree-first, tiebreaking on the subtree root's
+    // change_id for determinism.
+    for siblings in &mut children {
+        siblings.sort_by(|&a, &b| {
+            subtree_ts[b]
+                .cmp(&subtree_ts[a])
+                .then_with(|| nodes[a].change_id.cmp(&nodes[b].change_id))
+        });
+    }
+
+    let rows = build_rows(&children);
+
+    let leaves: Vec<usize> = rows
+        .iter()
+        .filter_map(|row| match row {
+            GraphRow::Commit { node, .. } if nodes[*node].is_leaf => Some(*node),
+            _ => None,
+        })
+        .collect();
 
     GraphLayout {
         nodes,
-        edges,
-        total_rows,
-        total_cols,
+        rows,
+        leaves,
     }
 }
 
-/// Collect all nodes on the path from trunk to a given leaf node.
+/// Flatten the tree into display rows, top to bottom.
 ///
-/// Returns nodes in trunk-to-leaf order (bottom-to-top in the layout).
-pub fn path_to_leaf(layout: &GraphLayout, leaf_row: usize, leaf_col: usize) -> Vec<&LayoutNode> {
-    let mut path = Vec::new();
-
-    // Walk backward from leaf to trunk using edges.
-    let mut current_row = leaf_row;
-    let mut current_col = leaf_col;
-
-    while let Some(node) = layout.node_at(current_row, current_col) {
-        path.push(node);
-        if node.is_trunk {
-            break;
-        }
-
-        // Find the edge that leads to this node.
-        let Some(edge) = layout
-            .edges
-            .iter()
-            .find(|e| e.to_row == current_row && e.to_col == current_col)
-        else {
-            break;
-        };
-
-        current_row = edge.from_row;
-        current_col = edge.from_col;
+/// For a node at column `col`, its first (newest) child subtree continues at
+/// `col` directly above it; each further sibling subtree renders at
+/// `col + 1`, followed by a connector row merging back into `col`. The
+/// node's own row comes last (lowest).
+fn build_rows(children: &[Vec<usize>]) -> Vec<GraphRow> {
+    enum Work {
+        Visit { node: usize, col: usize },
+        EmitCommit { node: usize, col: usize },
+        EmitConnector { col: usize },
     }
 
-    path.reverse(); // trunk-to-leaf order
-    path
+    let mut rows = Vec::new();
+    let mut work = vec![Work::Visit { node: 0, col: 0 }];
+
+    while let Some(item) = work.pop() {
+        match item {
+            Work::Visit { node, col } => {
+                // Emission order: first child's subtree, then each further
+                // sibling's subtree followed by its connector, then this
+                // node's own row. Push in reverse (LIFO).
+                work.push(Work::EmitCommit { node, col });
+                for &sibling in children[node].iter().skip(1).rev() {
+                    work.push(Work::EmitConnector { col: col + 1 });
+                    work.push(Work::Visit {
+                        node: sibling,
+                        col: col + 1,
+                    });
+                }
+                if let Some(&first) = children[node].first() {
+                    work.push(Work::Visit { node: first, col });
+                }
+            }
+            Work::EmitCommit { node, col } => rows.push(GraphRow::Commit { node, col }),
+            Work::EmitConnector { col } => rows.push(GraphRow::Connector { col }),
+        }
+    }
+
+    rows
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +327,17 @@ mod tests {
     }
 
     fn make_segment(names: &[&str], change_id: &str, descriptions: &[&str]) -> BookmarkSegment {
+        make_segment_at(names, change_id, descriptions, "T")
+    }
+
+    /// Like `make_segment`, with an explicit committer timestamp for
+    /// ordering tests. The default "T" is unparseable and sorts as oldest.
+    fn make_segment_at(
+        names: &[&str],
+        change_id: &str,
+        descriptions: &[&str],
+        timestamp: &str,
+    ) -> BookmarkSegment {
         BookmarkSegment {
             bookmark_names: names.iter().map(ToString::to_string).collect(),
             change_id: change_id.to_string(),
@@ -317,7 +356,7 @@ mod tests {
                     committer: crate::jj::types::Signature {
                         name: "Test".to_string(),
                         email: "test@test.com".to_string(),
-                        timestamp: "T".to_string(),
+                        timestamp: timestamp.to_string(),
                     },
                     files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
@@ -328,12 +367,29 @@ mod tests {
         }
     }
 
+    /// Render the display rows as plain text for structural assertions:
+    /// `col:summary` for commit rows, `col:├─╯` for connectors.
+    fn rows_to_string(layout: &GraphLayout) -> String {
+        layout
+            .rows
+            .iter()
+            .map(|row| match row {
+                GraphRow::Commit { node, col } => {
+                    format!("{col}:{}", layout.nodes[*node].summary)
+                }
+                GraphRow::Connector { col } => format!("{col}:├─╯"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn empty_graph_layout() {
         let graph = make_graph(vec![]);
         let layout = build_layout(&graph);
         assert!(layout.nodes.is_empty());
-        assert_eq!(layout.total_rows, 0);
+        assert!(layout.rows.is_empty());
+        assert!(layout.leaves.is_empty());
     }
 
     #[test]
@@ -349,60 +405,104 @@ mod tests {
 
         // trunk + 2 commits = 3 nodes
         assert_eq!(layout.nodes.len(), 3);
-        assert_eq!(layout.total_rows, 3);
-        assert_eq!(layout.total_cols, 1);
-
-        // Row 0 is trunk.
         assert!(layout.nodes[0].is_trunk);
 
-        // Row 1 is base commit.
-        assert_eq!(layout.nodes[1].row, 1);
-        assert_eq!(layout.nodes[1].bookmark_names, vec!["base"]);
-        assert!(!layout.nodes[1].is_leaf);
+        let base = &layout.nodes[1];
+        assert_eq!(base.bookmark_names, vec!["base"]);
+        assert!(!base.is_leaf);
+        assert_eq!(base.parent, Some(0));
 
-        // Row 2 is leaf commit.
-        assert_eq!(layout.nodes[2].row, 2);
-        assert_eq!(layout.nodes[2].bookmark_names, vec!["leaf"]);
-        assert!(layout.nodes[2].is_leaf);
+        let leaf = &layout.nodes[2];
+        assert_eq!(leaf.bookmark_names, vec!["leaf"]);
+        assert!(leaf.is_leaf);
+        assert_eq!(leaf.parent, Some(1));
 
-        // 2 edges: trunk→base, base→leaf.
-        assert_eq!(layout.edges.len(), 2);
+        // Display order: leaf on top, trunk at the bottom, all at column 0.
+        assert_eq!(rows_to_string(&layout), "0:add leaf\n0:add base\n0:trunk");
     }
 
     #[test]
-    fn two_branching_stacks() {
+    fn two_branching_stacks_ordered_newest_first() {
         let graph = make_graph(vec![
             BranchStack {
-                segments: vec![make_segment(&["alpha"], "ch_alpha", &["alpha work"])],
+                segments: vec![make_segment_at(
+                    &["alpha"],
+                    "ch_alpha",
+                    &["alpha work"],
+                    "2026-01-01T00:00:00Z",
+                )],
             },
             BranchStack {
-                segments: vec![make_segment(&["beta"], "ch_beta", &["beta work"])],
+                segments: vec![make_segment_at(
+                    &["beta"],
+                    "ch_beta",
+                    &["beta work"],
+                    "2026-02-01T00:00:00Z",
+                )],
             },
         ]);
 
         let layout = build_layout(&graph);
 
-        // trunk + 2 commits = 3 nodes
+        // trunk + 2 commits = 3 nodes; beta is newer so it renders topmost
+        // at column 0, alpha below it at column 1 with a connector.
         assert_eq!(layout.nodes.len(), 3);
-        assert_eq!(layout.total_cols, 2);
+        assert_eq!(
+            rows_to_string(&layout),
+            "0:beta work\n1:alpha work\n1:├─╯\n0:trunk"
+        );
 
-        // alpha is in col 0
-        let alpha = layout
-            .nodes
-            .iter()
-            .find(|n| n.bookmark_names.contains(&"alpha".to_string()))
-            .unwrap();
-        assert_eq!(alpha.col, 0);
-        assert!(alpha.is_leaf);
+        // Leaves in display order: beta first (topmost).
+        let leaves = layout.leaf_nodes();
+        assert_eq!(leaves[0].bookmark_names, vec!["beta"]);
+        assert_eq!(leaves[1].bookmark_names, vec!["alpha"]);
+    }
 
-        // beta is in col 1
-        let beta = layout
-            .nodes
-            .iter()
-            .find(|n| n.bookmark_names.contains(&"beta".to_string()))
-            .unwrap();
-        assert_eq!(beta.col, 1);
-        assert!(beta.is_leaf);
+    #[test]
+    fn sibling_order_uses_offset_aware_timestamps() {
+        // 12:00+00:00 is *later* than 12:30+02:00 (= 10:30 UTC), but
+        // lexicographic string comparison would say otherwise.
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["utc"],
+                    "ch_utc",
+                    &["utc work"],
+                    "2026-01-01T12:00:00+00:00",
+                )],
+            },
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["offset"],
+                    "ch_offset",
+                    &["offset work"],
+                    "2026-01-01T12:30:00+02:00",
+                )],
+            },
+        ]);
+
+        let layout = build_layout(&graph);
+        let leaves = layout.leaf_nodes();
+        assert_eq!(leaves[0].bookmark_names, vec!["utc"]);
+        assert_eq!(leaves[1].bookmark_names, vec!["offset"]);
+    }
+
+    #[test]
+    fn sibling_order_tiebreaks_on_change_id() {
+        // Identical (unparseable) timestamps: order falls back to change_id.
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment(&["zeta"], "ch_z", &["z work"])],
+            },
+            BranchStack {
+                segments: vec![make_segment(&["alpha"], "ch_a", &["a work"])],
+            },
+        ]);
+
+        let layout = build_layout(&graph);
+        let leaves = layout.leaf_nodes();
+        assert_eq!(leaves[0].bookmark_names, vec!["alpha"]);
+        assert_eq!(leaves[1].bookmark_names, vec!["zeta"]);
     }
 
     #[test]
@@ -412,38 +512,35 @@ mod tests {
             BranchStack {
                 segments: vec![
                     make_segment(&["base"], "ch_shared", &["shared base"]),
-                    make_segment(&["feat-a"], "ch_a", &["feature a"]),
+                    make_segment_at(&["feat-a"], "ch_a", &["feature a"], "2026-02-01T00:00:00Z"),
                 ],
             },
             BranchStack {
                 segments: vec![
                     make_segment(&["base"], "ch_shared", &["shared base"]),
-                    make_segment(&["feat-b"], "ch_b", &["feature b"]),
+                    make_segment_at(&["feat-b"], "ch_b", &["feature b"], "2026-01-01T00:00:00Z"),
                 ],
             },
         ]);
 
         let layout = build_layout(&graph);
 
-        // trunk + shared_base + feat_a + feat_b = 4 nodes
+        // trunk + shared base + feat-a + feat-b = 4 nodes; the shared base
+        // appears exactly once.
         assert_eq!(layout.nodes.len(), 4);
-
-        // The shared base should only appear once.
-        let shared_nodes: Vec<_> = layout
+        let shared: Vec<_> = layout
             .nodes
             .iter()
             .filter(|n| n.change_id == "ch_shared")
             .collect();
-        assert_eq!(shared_nodes.len(), 1);
-        assert_eq!(shared_nodes[0].col, 0); // placed in first stack's column
+        assert_eq!(shared.len(), 1);
 
-        // Both feat-a and feat-b should be separate.
-        let feat_a = layout.nodes.iter().find(|n| n.change_id == "ch_a").unwrap();
-        let feat_b = layout.nodes.iter().find(|n| n.change_id == "ch_b").unwrap();
-        assert_eq!(feat_a.col, 0);
-        assert_eq!(feat_b.col, 1);
-        assert!(feat_a.is_leaf);
-        assert!(feat_b.is_leaf);
+        // feat-a is newer: it continues in the shared base's column; feat-b
+        // branches off at column 1.
+        assert_eq!(
+            rows_to_string(&layout),
+            "0:feature a\n1:feature b\n1:├─╯\n0:shared base\n0:trunk"
+        );
     }
 
     #[test]
@@ -458,11 +555,14 @@ mod tests {
 
         let layout = build_layout(&graph);
 
-        // trunk + 2 commits = 3 nodes
+        // trunk + 2 commits = 3 nodes; newest commit on top.
         assert_eq!(layout.nodes.len(), 3);
+        assert_eq!(
+            rows_to_string(&layout),
+            "0:second commit\n0:first commit\n0:trunk"
+        );
 
-        // Commits are laid out bottom-to-top (reversed from newest-first).
-        // "first commit" should be at a lower row than "second commit".
+        // Only the last commit in the segment carries the bookmark.
         let first = layout
             .nodes
             .iter()
@@ -473,9 +573,6 @@ mod tests {
             .iter()
             .find(|n| n.summary == "second commit")
             .unwrap();
-        assert!(first.row < second.row);
-
-        // Only the last commit in the segment gets bookmark names.
         assert!(first.bookmark_names.is_empty());
         assert_eq!(second.bookmark_names, vec!["feat"]);
     }
@@ -490,8 +587,7 @@ mod tests {
         }]);
 
         let layout = build_layout(&graph);
-        let leaf = layout.leaf_nodes()[0];
-        let path = path_to_leaf(&layout, leaf.row, leaf.col);
+        let path = layout.path_to_leaf(layout.leaves[0]);
 
         // trunk → base → leaf
         assert_eq!(path.len(), 3);
@@ -520,8 +616,12 @@ mod tests {
         let layout = build_layout(&graph);
 
         // Path to feat-b should go through the shared base.
-        let feat_b = layout.nodes.iter().find(|n| n.change_id == "ch_b").unwrap();
-        let path = path_to_leaf(&layout, feat_b.row, feat_b.col);
+        let feat_b = layout
+            .nodes
+            .iter()
+            .position(|n| n.change_id == "ch_b")
+            .unwrap();
+        let path = layout.path_to_leaf(feat_b);
 
         // trunk → shared → feat_b
         assert_eq!(path.len(), 3);
@@ -590,5 +690,73 @@ mod tests {
         let leaves = layout.leaf_nodes();
         assert_eq!(leaves.len(), 2);
         assert!(leaves.iter().all(|n| n.is_leaf));
+    }
+
+    #[test]
+    fn row_of_node_finds_commit_rows() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![
+                make_segment(&["base"], "ch_a", &["base work"]),
+                make_segment(&["leaf"], "ch_b", &["leaf work"]),
+            ],
+        }]);
+
+        let layout = build_layout(&graph);
+        // Leaf on top (row 0), base below (row 1), trunk at the bottom.
+        assert_eq!(layout.row_of_node(layout.leaves[0]), Some(0));
+        assert_eq!(layout.row_of_node(0), Some(2));
+    }
+
+    #[test]
+    fn nested_siblings_layout() {
+        // trunk → auth → {email chain (newest), api chain}; the api chain
+        // itself forks into {integration (newest), ratelimit}.
+        let auth = make_segment_at(&["auth"], "ch_auth", &["auth work"], "2026-01-01T00:00:00Z");
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![
+                    auth.clone(),
+                    make_segment_at(
+                        &["email"],
+                        "ch_email",
+                        &["email work"],
+                        "2026-06-01T00:00:00Z",
+                    ),
+                ],
+            },
+            BranchStack {
+                segments: vec![
+                    auth.clone(),
+                    make_segment_at(&["api"], "ch_api", &["api work"], "2026-02-01T00:00:00Z"),
+                    make_segment_at(
+                        &["integration"],
+                        "ch_int",
+                        &["integration work"],
+                        "2026-04-01T00:00:00Z",
+                    ),
+                ],
+            },
+            BranchStack {
+                segments: vec![
+                    auth,
+                    make_segment_at(&["api"], "ch_api", &["api work"], "2026-02-01T00:00:00Z"),
+                    make_segment_at(
+                        &["ratelimit"],
+                        "ch_rate",
+                        &["ratelimit work"],
+                        "2026-03-01T00:00:00Z",
+                    ),
+                ],
+            },
+        ]);
+
+        let layout = build_layout(&graph);
+
+        insta::assert_snapshot!(rows_to_string(&layout));
+
+        // Leaves in display order.
+        let leaves = layout.leaf_nodes();
+        let names: Vec<_> = leaves.iter().map(|l| l.bookmark_names[0].clone()).collect();
+        assert_eq!(names, vec!["email", "integration", "ratelimit"]);
     }
 }

--- a/src/select/graph_widget.rs
+++ b/src/select/graph_widget.rs
@@ -1,8 +1,12 @@
-//! Screen 1: Graph view widget.
+//! Screen 1: jj-log-style graph view widget.
 //!
-//! Renders the positioned graph layout as a tree with Unicode box-drawing
-//! characters. Users navigate with arrow keys to select a leaf node.
+//! Renders the layout's display rows top-down: one row per commit with a
+//! `│ `-cell gutter on the left, `├─╯` connector rows where sibling subtrees
+//! merge, and `⋯ n commits` rows for collapsed runs of unselected commits.
+//! Every row permanently carries its bookmark names and description; leaf
+//! navigation only re-colors the selected trunk→leaf path.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use ratatui::buffer::Buffer;
@@ -15,51 +19,116 @@ use ratatui::text::Span;
 use ratatui::widgets::Widget;
 
 use super::graph_layout::GraphLayout;
-use super::graph_layout::path_to_leaf;
+use super::graph_layout::GraphRow;
+use super::graph_layout::LayoutNode;
 
 /// State for the graph view widget.
 #[derive(Debug)]
 pub struct GraphViewState {
-    /// Index of the currently selected leaf node (into
-    /// `GraphLayout::leaf_nodes()`).
+    /// Index of the currently selected leaf (into `GraphLayout::leaves`).
     pub selected_leaf: usize,
-    /// Scroll offset (row from bottom that is at the top of the viewport).
-    pub scroll_offset: usize,
 }
 
 impl GraphViewState {
     pub fn new() -> Self {
-        Self {
-            selected_leaf: 0,
-            scroll_offset: 0,
+        Self { selected_leaf: 0 }
+    }
+}
+
+/// Characters used for rendering.
+const NODE_SELECTED: &str = "\u{25cf}"; // ●
+const NODE_OTHER: &str = "\u{25cb}"; // ○
+const TRUNK_CHAR: &str = "\u{25c6}"; // ◆
+const ELLIPSIS: &str = "\u{22ef}"; // ⋯
+const GUTTER_CELL: &str = "\u{2502} "; // "│ "
+const CONNECTOR_TEE: &str = "\u{251c}"; // ├
+const CONNECTOR_TAIL: &str = "\u{2500}\u{256f}"; // ─╯
+const LEAF_MARKER: &str = "\u{25c0}"; // ◀
+
+/// A row after collapsing, ready for rendering.
+enum DisplayRow<'a> {
+    /// A commit (or trunk) row.
+    Commit {
+        node_idx: usize,
+        node: &'a LayoutNode,
+        col: usize,
+    },
+    /// A collapsed run of `count` unselected commits.
+    Collapsed { count: usize, col: usize },
+    /// A connector row (`├─╯`) merging column `col` into `col - 1`.
+    Connector { col: usize },
+}
+
+/// Collapse runs of unselected commits into `⋯ n commits` rows.
+///
+/// A commit row collapses when it is not on the selected path, is neither a
+/// segment boundary (no bookmark names) nor a leaf nor trunk. Consecutive
+/// collapsible rows in the same column merge into one `Collapsed` row.
+fn collapse_rows<'a>(layout: &'a GraphLayout, path: &HashSet<usize>) -> Vec<DisplayRow<'a>> {
+    let mut out: Vec<DisplayRow<'a>> = Vec::new();
+    let mut run: Option<(usize, usize)> = None; // (col, count)
+
+    let flush = |run: &mut Option<(usize, usize)>, out: &mut Vec<DisplayRow<'a>>| {
+        if let Some((col, count)) = run.take() {
+            out.push(DisplayRow::Collapsed { count, col });
+        }
+    };
+
+    for row in &layout.rows {
+        match *row {
+            GraphRow::Commit { node, col } => {
+                let n = &layout.nodes[node];
+                let collapsible = !path.contains(&node)
+                    && !n.is_trunk
+                    && !n.is_leaf
+                    && n.bookmark_names.is_empty();
+                if collapsible {
+                    match &mut run {
+                        Some((c, count)) if *c == col => *count += 1,
+                        _ => {
+                            flush(&mut run, &mut out);
+                            run = Some((col, 1));
+                        }
+                    }
+                } else {
+                    flush(&mut run, &mut out);
+                    out.push(DisplayRow::Commit {
+                        node_idx: node,
+                        node: n,
+                        col,
+                    });
+                }
+            }
+            GraphRow::Connector { col } => {
+                flush(&mut run, &mut out);
+                out.push(DisplayRow::Connector { col });
+            }
         }
     }
+    flush(&mut run, &mut out);
+
+    out
 }
 
-/// Width of one column in characters (node char + spacing).
-const COL_WIDTH: usize = 4;
-/// Characters used for rendering.
-const NODE_CHAR: &str = "\u{25cb}"; // ○
-const TRUNK_CHAR: &str = "\u{25c6}"; // ◆
-const VERT_LINE: &str = "\u{2502}"; // │
-const BRANCH_TEE: &str = "\u{251c}"; // ├
-const BRANCH_HORIZ: &str = "\u{2500}"; // ─
-const BRANCH_CORNER: &str = "\u{256f}"; // ╯  (UP+LEFT arc — endpoint of branch)
-const BRANCH_SRC: &str = "\u{2570}"; // ╰  (UP+RIGHT arc — source with no vertical above)
-const CROSS: &str = "\u{253c}"; // ┼  (horizontal branch crossing a vertical edge)
-
-/// Number of display lines for a graph with the given number of rows.
-/// Each row produces a node line, plus a connector line between adjacent rows.
-pub fn display_line_count(total_rows: usize) -> usize {
-    if total_rows == 0 {
-        0
-    } else {
-        // node lines + connector lines between them
-        total_rows + total_rows.saturating_sub(1)
-    }
+/// Number of display rows when the given leaf is selected (its path is fully
+/// expanded; everything else collapses).
+pub fn collapsed_height(layout: &GraphLayout, leaf: usize) -> usize {
+    let path: HashSet<usize> = layout.path_node_indices(leaf).into_iter().collect();
+    collapse_rows(layout, &path).len()
 }
 
-/// Renders the graph layout with cursor highlighting.
+/// Maximum display height over all selectable leaves — sizing the viewport
+/// to this means switching leaves never needs a viewport resize.
+pub fn max_collapsed_height(layout: &GraphLayout) -> usize {
+    layout
+        .leaves
+        .iter()
+        .map(|&leaf| collapsed_height(layout, leaf))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Renders the graph layout with selected-path highlighting.
 pub struct GraphWidget<'a> {
     layout: &'a GraphLayout,
     state: &'a GraphViewState,
@@ -70,238 +139,212 @@ impl<'a> GraphWidget<'a> {
         Self { layout, state }
     }
 
-    /// Build the lines for the graph, bottom-to-top (trunk at bottom).
-    /// Returns lines in display order (top of screen = highest row).
-    ///
-    /// For each graph row, renders a node line. Between adjacent rows, renders
-    /// a connector line showing │ for vertical edges and ├─╮ for branches.
-    fn build_lines(&self) -> Vec<Line<'a>> {
-        let mut lines = Vec::new();
-
-        if self.layout.nodes.is_empty() {
-            return lines;
-        }
-
-        // Compute the selected path for highlighting.
-        let leaves = self.layout.leaf_nodes();
-        let selected_leaf = leaves.get(self.state.selected_leaf);
-        let selected_path: HashSet<(usize, usize)> = if let Some(leaf) = selected_leaf {
-            path_to_leaf(self.layout, leaf.row, leaf.col)
-                .iter()
-                .map(|n| (n.row, n.col))
-                .collect()
-        } else {
-            HashSet::new()
+    /// Build the display lines (top to bottom) and the display-row index of
+    /// the selected leaf (for scrolling).
+    fn build_lines(&self) -> (Vec<Line<'a>>, usize) {
+        let Some(&leaf) = self.layout.leaves.get(self.state.selected_leaf) else {
+            return (vec![], 0);
         };
 
-        // Edges on the selected path (for connector highlighting).
-        let selected_edges: HashSet<(usize, usize, usize, usize)> = self
-            .layout
-            .edges
+        let path_indices = self.layout.path_node_indices(leaf);
+        let path: HashSet<usize> = path_indices.iter().copied().collect();
+        let rows = collapse_rows(self.layout, &path);
+
+        // Display row index per node (commit rows only).
+        let row_of: HashMap<usize, usize> = rows
             .iter()
-            .filter(|e| {
-                selected_path.contains(&(e.from_row, e.from_col))
-                    && selected_path.contains(&(e.to_row, e.to_col))
+            .enumerate()
+            .filter_map(|(i, row)| match row {
+                DisplayRow::Commit { node_idx, .. } => Some((*node_idx, i)),
+                _ => None,
             })
-            .map(|e| (e.from_row, e.from_col, e.to_row, e.to_col))
+            .collect();
+        let col_of: HashMap<usize, usize> = rows
+            .iter()
+            .filter_map(|row| match row {
+                DisplayRow::Commit { node_idx, col, .. } => Some((*node_idx, *col)),
+                _ => None,
+            })
             .collect();
 
-        let max_row = self.layout.total_rows.saturating_sub(1);
-
-        for row in (0..=max_row).rev() {
-            // Node line.
-            lines.push(self.build_node_line(row, &selected_path, selected_leaf));
-
-            // Connector line between this row and the one below.
-            if row > 0 {
-                lines.push(self.build_connector_line(row, row - 1, &selected_edges));
+        // Gutter cells and connector rows that carry the selected path.
+        // For each parent→child pair on the path (parent below, child
+        // above): a same-column child's edge runs vertically through the
+        // child's column in every row between them; a sibling child's edge
+        // passes through its connector row (directly under the child) and
+        // then continues in the parent's column.
+        let mut path_gutter: HashSet<(usize, usize)> = HashSet::new();
+        let mut path_connectors: HashSet<usize> = HashSet::new();
+        for pair in path_indices.windows(2) {
+            let (parent, child) = (pair[0], pair[1]);
+            let (Some(&pr), Some(&cr)) = (row_of.get(&parent), row_of.get(&child)) else {
+                continue;
+            };
+            let (Some(&pcol), Some(&ccol)) = (col_of.get(&parent), col_of.get(&child)) else {
+                continue;
+            };
+            if pcol == ccol {
+                for r in (cr + 1)..pr {
+                    path_gutter.insert((r, ccol));
+                }
+            } else {
+                if matches!(rows.get(cr + 1), Some(DisplayRow::Connector { col }) if *col == ccol) {
+                    path_connectors.insert(cr + 1);
+                }
+                for r in (cr + 2)..pr {
+                    path_gutter.insert((r, pcol));
+                }
             }
         }
 
-        lines
+        let leaf_row = row_of.get(&leaf).copied().unwrap_or(0);
+
+        let lines = rows
+            .iter()
+            .enumerate()
+            .map(|(r, row)| {
+                Self::build_row_line(r, row, &path, leaf, &path_gutter, &path_connectors)
+            })
+            .collect();
+
+        (lines, leaf_row)
     }
 
-    /// Render a single node line for the given row.
-    fn build_node_line(
-        &self,
-        row: usize,
-        selected_path: &HashSet<(usize, usize)>,
-        selected_leaf: Option<&&super::graph_layout::LayoutNode>,
+    fn build_row_line(
+        r: usize,
+        row: &DisplayRow<'a>,
+        path: &HashSet<usize>,
+        leaf: usize,
+        path_gutter: &HashSet<(usize, usize)>,
+        path_connectors: &HashSet<usize>,
     ) -> Line<'a> {
-        let mut spans: Vec<Span> = Vec::new();
-        let mut pending_labels: Vec<Vec<Span>> = Vec::new();
+        let on_path_style = Style::default().fg(Color::Cyan);
+        let dim_style = Style::default().fg(Color::DarkGray);
 
-        for col in 0..self.layout.total_cols {
-            let is_on_path = selected_path.contains(&(row, col));
+        let mut spans: Vec<Span> = vec![Span::raw(" ")];
 
-            if let Some(node) = self.layout.node_at(row, col) {
-                let node_char = if node.is_trunk { TRUNK_CHAR } else { NODE_CHAR };
-
-                let is_selected_leaf =
-                    selected_leaf.is_some_and(|l| l.row == node.row && l.col == node.col);
-
-                let style = if is_selected_leaf {
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
-                } else if is_on_path {
-                    Style::default().fg(Color::Cyan)
+        let gutter = |spans: &mut Vec<Span>, cols: usize| {
+            for g in 0..cols {
+                let style = if path_gutter.contains(&(r, g)) {
+                    on_path_style
                 } else {
-                    Style::default().fg(Color::DarkGray)
+                    dim_style
                 };
-
-                spans.push(Span::styled(format!("{node_char:<COL_WIDTH$}"), style));
-
-                if is_on_path || is_selected_leaf {
-                    let label_spans = Self::node_label_spans(node);
-                    if !label_spans.is_empty() {
-                        pending_labels.push(label_spans);
-                    }
-                }
-            } else {
-                // Empty column — just space.
-                spans.push(Span::raw(format!("{:<COL_WIDTH$}", " ")));
+                spans.push(Span::styled(GUTTER_CELL, style));
             }
-        }
+        };
 
-        // Append labels after all columns.
-        for (i, label_spans) in pending_labels.into_iter().enumerate() {
-            if i > 0 {
+        match row {
+            DisplayRow::Commit {
+                node_idx,
+                node,
+                col,
+            } => {
+                gutter(&mut spans, *col);
+
+                let is_on_path = path.contains(node_idx);
+                let is_selected_leaf = *node_idx == leaf;
+
+                let glyph = if node.is_trunk {
+                    TRUNK_CHAR
+                } else if is_on_path {
+                    NODE_SELECTED
+                } else {
+                    NODE_OTHER
+                };
+                let glyph_style = if is_selected_leaf {
+                    on_path_style.add_modifier(Modifier::BOLD)
+                } else if is_on_path {
+                    on_path_style
+                } else {
+                    dim_style
+                };
+                spans.push(Span::styled(glyph, glyph_style));
                 spans.push(Span::raw("  "));
-            }
-            spans.extend(label_spans);
-        }
 
-        Line::from(spans)
-    }
+                spans.extend(Self::label_spans(node, is_on_path));
 
-    /// Render the connector line between `row_above` and `row_below`.
-    ///
-    /// Shows │ for vertical edges, ├─╮ for branch forks.
-    fn build_connector_line(
-        &self,
-        row_above: usize,
-        row_below: usize,
-        selected_edges: &HashSet<(usize, usize, usize, usize)>,
-    ) -> Line<'a> {
-        // Determine what character each column gets.
-        let total_cols = self.layout.total_cols;
-        let mut col_chars: Vec<&str> = vec![" "; total_cols];
-        let mut col_on_path: Vec<bool> = vec![false; total_cols];
-
-        for edge in &self.layout.edges {
-            let is_selected =
-                selected_edges.contains(&(edge.from_row, edge.from_col, edge.to_row, edge.to_col));
-
-            if edge.from_col == edge.to_col {
-                // Vertical edge — check if it spans this connector gap.
-                let col = edge.from_col;
-                if edge.from_row <= row_below && edge.to_row >= row_above {
-                    col_chars[col] = VERT_LINE;
-                    if is_selected {
-                        col_on_path[col] = true;
-                    }
+                if is_selected_leaf {
+                    spans.push(Span::raw("  "));
+                    spans.push(Span::styled(
+                        LEAF_MARKER,
+                        on_path_style.add_modifier(Modifier::BOLD),
+                    ));
                 }
-            } else {
-                // Cross-column (branch) edge at this connector level.
-                if edge.from_row == row_below && edge.to_row == row_above {
-                    let min_col = edge.from_col.min(edge.to_col);
-                    let max_col = edge.from_col.max(edge.to_col);
-
-                    // At from_col: ├ if there's already a vertical edge (child
-                    // above in the same column), ╰ if only the branch exits here.
-                    if col_chars[edge.from_col] == VERT_LINE {
-                        col_chars[edge.from_col] = BRANCH_TEE; // ├
+            }
+            DisplayRow::Collapsed { count, col } => {
+                gutter(&mut spans, *col);
+                spans.push(Span::styled(ELLIPSIS, dim_style));
+                let noun = if *count == 1 { "commit" } else { "commits" };
+                spans.push(Span::styled(
+                    format!("  {count} {noun}"),
+                    dim_style.add_modifier(Modifier::DIM),
+                ));
+            }
+            DisplayRow::Connector { col } => {
+                gutter(&mut spans, col.saturating_sub(1));
+                // The ├ cell carries the parent column's vertical line, so
+                // it stays path-colored when the path passes through that
+                // column even if this connector itself is off-path.
+                let tee_on_path = path_connectors.contains(&r)
+                    || path_gutter.contains(&(r, col.saturating_sub(1)));
+                spans.push(Span::styled(
+                    CONNECTOR_TEE,
+                    if tee_on_path {
+                        on_path_style
                     } else {
-                        col_chars[edge.from_col] = BRANCH_SRC; // ╰
-                    }
-                    if is_selected {
-                        col_on_path[edge.from_col] = true;
-                    }
-
-                    // At to_col: ╯
-                    col_chars[edge.to_col] = BRANCH_CORNER;
-                    if is_selected {
-                        col_on_path[edge.to_col] = true;
-                    }
-
-                    // Between: ─, or ┼ where a vertical edge crosses
-                    for c in (min_col + 1)..max_col {
-                        col_chars[c] = if col_chars[c] == VERT_LINE {
-                            CROSS
-                        } else {
-                            BRANCH_HORIZ
-                        };
-                        if is_selected {
-                            col_on_path[c] = true;
-                        }
-                    }
-                }
+                        dim_style
+                    },
+                ));
+                spans.push(Span::styled(
+                    CONNECTOR_TAIL,
+                    if path_connectors.contains(&r) {
+                        on_path_style
+                    } else {
+                        dim_style
+                    },
+                ));
             }
-        }
-
-        let mut spans: Vec<Span> = Vec::new();
-        for col in 0..total_cols {
-            let style = if col_on_path[col] {
-                Style::default().fg(Color::Cyan)
-            } else if col_chars[col] != " " {
-                Style::default().fg(Color::DarkGray)
-            } else {
-                Style::default()
-            };
-
-            // For horizontal branch characters, fill the full column width with
-            // ─ to create a continuous line. Source chars (├, ╰) and crossings
-            // (┼) also extend rightward with dashes.
-            let cell = if col_chars[col] == BRANCH_HORIZ {
-                BRANCH_HORIZ.repeat(COL_WIDTH)
-            } else if col_chars[col] == BRANCH_TEE
-                || col_chars[col] == BRANCH_SRC
-                || col_chars[col] == CROSS
-            {
-                format!("{}{}", col_chars[col], BRANCH_HORIZ.repeat(COL_WIDTH - 1))
-            } else {
-                format!("{:<COL_WIDTH$}", col_chars[col])
-            };
-
-            spans.push(Span::styled(cell, style));
         }
 
         Line::from(spans)
     }
 
-    fn node_label_spans(node: &super::graph_layout::LayoutNode) -> Vec<Span<'static>> {
+    fn label_spans(node: &LayoutNode, is_on_path: bool) -> Vec<Span<'static>> {
         let mut spans = Vec::new();
 
-        if !node.bookmark_names.is_empty() {
-            spans.push(Span::styled(
-                node.bookmark_names.join(", "),
-                Style::default().fg(Color::White),
-            ));
-            spans.push(Span::styled("  ", Style::default()));
-        }
+        let name_style = if is_on_path {
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let text_style = if is_on_path {
+            Style::default().fg(Color::White)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
 
         if node.is_trunk {
-            if spans.is_empty() {
-                spans.push(Span::styled("trunk", Style::default().fg(Color::White)));
-            }
-        } else {
+            spans.push(Span::styled("trunk", text_style));
+            return spans;
+        }
+
+        if !node.bookmark_names.is_empty() {
+            spans.push(Span::styled(node.bookmark_names.join(", "), name_style));
+            spans.push(Span::raw("  "));
+        }
+
+        if node.summary == "(no description)" {
             spans.push(Span::styled(
-                format!("{:<4}", node.short_change_id),
-                Style::default().fg(Color::Magenta),
+                "(no description set)",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
             ));
-            let summary = &node.summary;
-            if summary == "(no description)" {
-                spans.push(Span::styled(
-                    " (no description set)",
-                    Style::default().fg(Color::DarkGray),
-                ));
-            } else {
-                spans.push(Span::styled(
-                    format!(" \"{summary}\""),
-                    Style::default().fg(Color::White),
-                ));
-            }
+        } else {
+            spans.push(Span::styled(format!("\"{}\"", node.summary), text_style));
         }
 
         spans
@@ -310,13 +353,14 @@ impl<'a> GraphWidget<'a> {
 
 impl Widget for GraphWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let lines = self.build_lines();
+        let (lines, leaf_row) = self.build_lines();
 
-        // Apply scroll offset.
+        // Scroll so the selected leaf sits at the top of the viewport when
+        // the content overflows — its path extends downward from there.
         let visible_height = area.height as usize;
         let total = lines.len();
         let start = if total > visible_height {
-            self.state.scroll_offset.min(total - visible_height)
+            leaf_row.min(total - visible_height)
         } else {
             0
         };
@@ -335,12 +379,12 @@ impl Widget for GraphWidget<'_> {
 pub fn graph_help_line() -> Line<'static> {
     Line::from(vec![
         Span::styled(
-            " \u{2190}\u{2192}/hl",
+            " \u{2190}\u{2192}\u{2191}\u{2193}/hjkl",
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::raw(" navigate  "),
+        Span::raw(" leaf  "),
         Span::styled(
             "Enter",
             Style::default()
@@ -383,6 +427,15 @@ mod tests {
     }
 
     fn make_segment(names: &[&str], change_id: &str, descriptions: &[&str]) -> BookmarkSegment {
+        make_segment_at(names, change_id, descriptions, "T")
+    }
+
+    fn make_segment_at(
+        names: &[&str],
+        change_id: &str,
+        descriptions: &[&str],
+        timestamp: &str,
+    ) -> BookmarkSegment {
         BookmarkSegment {
             bookmark_names: names.iter().map(ToString::to_string).collect(),
             change_id: change_id.to_string(),
@@ -401,7 +454,7 @@ mod tests {
                     committer: crate::jj::types::Signature {
                         name: "Test".to_string(),
                         email: "test@test.com".to_string(),
-                        timestamp: "T".to_string(),
+                        timestamp: timestamp.to_string(),
                     },
                     files: vec![],
                     short_change_id: change_id[..4.min(change_id.len())].to_string(),
@@ -412,11 +465,10 @@ mod tests {
         }
     }
 
-    fn render_to_string(graph: &ChangeGraph) -> String {
+    fn render_to_string_with_state(graph: &ChangeGraph, state: &GraphViewState) -> String {
         let layout = build_layout(graph);
-        let state = GraphViewState::new();
-        let widget = GraphWidget::new(&layout, &state);
-        let lines = widget.build_lines();
+        let widget = GraphWidget::new(&layout, state);
+        let (lines, _) = widget.build_lines();
         lines
             .iter()
             .map(|line| {
@@ -424,13 +476,19 @@ mod tests {
                     .iter()
                     .map(|s| s.content.as_ref())
                     .collect::<String>()
+                    .trim_end()
+                    .to_string()
             })
             .collect::<Vec<_>>()
             .join("\n")
     }
 
+    fn render_to_string(graph: &ChangeGraph) -> String {
+        render_to_string_with_state(graph, &GraphViewState::new())
+    }
+
     #[test]
-    fn linear_stack_has_connectors() {
+    fn linear_stack_single_column() {
         let graph = make_graph(vec![BranchStack {
             segments: vec![
                 make_segment(&["base"], "ch_a", &["add base"]),
@@ -438,47 +496,170 @@ mod tests {
             ],
         }]);
 
-        let layout = build_layout(&graph);
-        let state = GraphViewState::new();
-        let widget = GraphWidget::new(&layout, &state);
-        let lines = widget.build_lines();
-
-        // 3 rows → 3 node lines + 2 connector lines = 5 display lines.
-        assert_eq!(lines.len(), 5);
-
-        let text = render_to_string(&graph);
-        // Should contain vertical connector lines.
-        assert!(text.contains('\u{2502}'), "expected │ in output: {text}");
+        insta::assert_snapshot!(render_to_string(&graph));
     }
 
     #[test]
     fn branching_shows_fork_characters() {
         let graph = make_graph(vec![
             BranchStack {
-                segments: vec![make_segment(&["alpha"], "ch_alpha", &["alpha work"])],
+                segments: vec![make_segment_at(
+                    &["alpha"],
+                    "ch_alpha",
+                    &["alpha work"],
+                    "2026-02-01T00:00:00Z",
+                )],
             },
             BranchStack {
-                segments: vec![make_segment(&["beta"], "ch_beta", &["beta work"])],
+                segments: vec![make_segment_at(
+                    &["beta"],
+                    "ch_beta",
+                    &["beta work"],
+                    "2026-01-01T00:00:00Z",
+                )],
             },
         ]);
 
-        let text = render_to_string(&graph);
-        // Should contain branch fork characters.
-        assert!(text.contains('\u{251c}'), "expected ├ in output:\n{text}");
-        assert!(text.contains('\u{256f}'), "expected ╯ in output:\n{text}");
+        insta::assert_snapshot!(render_to_string(&graph));
     }
 
     #[test]
-    fn renders_to_buffer() {
-        let graph = make_graph(vec![BranchStack {
-            segments: vec![make_segment(&["feat"], "ch_a", &["my feature"])],
-        }]);
+    fn collapses_unselected_runs() {
+        // The selected (newest) chain stays fully expanded; the unselected
+        // chain collapses its unbookmarked middle commits but keeps its leaf
+        // and boundary visible.
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["feat"],
+                    "ch_feat",
+                    &["feat top", "feat mid", "feat bottom"],
+                    "2026-02-01T00:00:00Z",
+                )],
+            },
+            BranchStack {
+                segments: vec![
+                    make_segment_at(
+                        &["other-base"],
+                        "ch_ob",
+                        &["other base"],
+                        "2026-01-01T00:00:00Z",
+                    ),
+                    make_segment_at(
+                        &["other"],
+                        "ch_o",
+                        &["other top", "other mid 2", "other mid 1"],
+                        "2026-01-01T00:00:00Z",
+                    ),
+                ],
+            },
+        ]);
+
+        insta::assert_snapshot!(render_to_string(&graph));
+    }
+
+    #[test]
+    fn selecting_other_leaf_moves_highlight_not_rows() {
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["alpha"],
+                    "ch_alpha",
+                    &["alpha work"],
+                    "2026-02-01T00:00:00Z",
+                )],
+            },
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["beta"],
+                    "ch_beta",
+                    &["beta work", "beta base"],
+                    "2026-01-01T00:00:00Z",
+                )],
+            },
+        ]);
+
+        // Selecting beta expands its run and moves ● + ◀ there; alpha's row
+        // text stays in place.
+        insta::assert_snapshot!(render_to_string_with_state(
+            &graph,
+            &GraphViewState { selected_leaf: 1 }
+        ));
+    }
+
+    #[test]
+    fn nested_fork_gutters() {
+        let auth = make_segment_at(&["auth"], "ch_auth", &["auth work"], "2026-01-01T00:00:00Z");
+        let api = make_segment_at(&["api"], "ch_api", &["api work"], "2026-02-01T00:00:00Z");
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![
+                    auth.clone(),
+                    make_segment_at(
+                        &["email"],
+                        "ch_email",
+                        &["email work"],
+                        "2026-06-01T00:00:00Z",
+                    ),
+                ],
+            },
+            BranchStack {
+                segments: vec![
+                    auth.clone(),
+                    api.clone(),
+                    make_segment_at(
+                        &["integration"],
+                        "ch_int",
+                        &["integration work"],
+                        "2026-04-01T00:00:00Z",
+                    ),
+                ],
+            },
+            BranchStack {
+                segments: vec![
+                    auth,
+                    api,
+                    make_segment_at(
+                        &["ratelimit"],
+                        "ch_rate",
+                        &["ratelimit work"],
+                        "2026-03-01T00:00:00Z",
+                    ),
+                ],
+            },
+        ]);
+
+        insta::assert_snapshot!(render_to_string(&graph));
+    }
+
+    #[test]
+    fn renders_to_buffer_with_scroll() {
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["alpha"],
+                    "ch_alpha",
+                    &["alpha work"],
+                    "2026-02-01T00:00:00Z",
+                )],
+            },
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["beta"],
+                    "ch_beta",
+                    &["beta work"],
+                    "2026-01-01T00:00:00Z",
+                )],
+            },
+        ]);
 
         let layout = build_layout(&graph);
-        let state = GraphViewState::new();
-        let widget = GraphWidget::new(&layout, &state);
 
-        let area = Rect::new(0, 0, 40, 10);
+        // Viewport shorter than the content: selecting beta (display row 1)
+        // anchors it at the top.
+        let state = GraphViewState { selected_leaf: 1 };
+        let widget = GraphWidget::new(&layout, &state);
+        let area = Rect::new(0, 0, 40, 2);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
 
@@ -491,43 +672,82 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
+        assert!(content.contains("beta"), "expected beta visible: {content}");
         assert!(
-            content.contains('\u{25cb}') || content.contains('\u{25c6}'),
-            "expected node characters in rendered output"
+            !content.contains("alpha"),
+            "expected alpha scrolled out: {content}"
         );
     }
 
     #[test]
-    fn shared_root_shows_branch() {
+    fn path_styling_is_cyan_and_others_dim() {
         let graph = make_graph(vec![
             BranchStack {
-                segments: vec![
-                    make_segment(&["base"], "ch_shared", &["shared base"]),
-                    make_segment(&["feat-a"], "ch_a", &["feature a"]),
-                ],
+                segments: vec![make_segment_at(
+                    &["alpha"],
+                    "ch_alpha",
+                    &["alpha work"],
+                    "2026-02-01T00:00:00Z",
+                )],
             },
             BranchStack {
-                segments: vec![
-                    make_segment(&["base"], "ch_shared", &["shared base"]),
-                    make_segment(&["feat-b"], "ch_b", &["feature b"]),
-                ],
+                segments: vec![make_segment_at(
+                    &["beta"],
+                    "ch_beta",
+                    &["beta work"],
+                    "2026-01-01T00:00:00Z",
+                )],
             },
         ]);
 
-        let text = render_to_string(&graph);
-        // Should have both ○ nodes, ◆ trunk, │ connectors, and ├╮ branch.
-        assert!(text.contains('\u{25cb}'), "expected ○:\n{text}");
-        assert!(text.contains('\u{25c6}'), "expected ◆:\n{text}");
-        assert!(text.contains('\u{2502}'), "expected │:\n{text}");
-        assert!(text.contains('\u{251c}'), "expected ├:\n{text}");
-        assert!(text.contains('\u{256f}'), "expected ╯:\n{text}");
+        let layout = build_layout(&graph);
+        let state = GraphViewState::new();
+        let widget = GraphWidget::new(&layout, &state);
+        let (lines, leaf_row) = widget.build_lines();
+
+        assert_eq!(leaf_row, 0);
+
+        // Selected leaf row: glyph span is cyan + bold.
+        let leaf_glyph = &lines[0].spans[1];
+        assert_eq!(leaf_glyph.content.as_ref(), NODE_SELECTED);
+        assert_eq!(leaf_glyph.style.fg, Some(Color::Cyan));
+        assert!(leaf_glyph.style.add_modifier.contains(Modifier::BOLD));
+
+        // Off-path commit row: glyph is ○ and dark gray.
+        let other_glyph = &lines[1].spans[2];
+        assert_eq!(other_glyph.content.as_ref(), NODE_OTHER);
+        assert_eq!(other_glyph.style.fg, Some(Color::DarkGray));
     }
 
     #[test]
-    fn display_line_count_correct() {
-        assert_eq!(display_line_count(0), 0);
-        assert_eq!(display_line_count(1), 1);
-        assert_eq!(display_line_count(2), 3);
-        assert_eq!(display_line_count(3), 5);
+    fn collapsed_height_and_max() {
+        let graph = make_graph(vec![
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["long"],
+                    "ch_long",
+                    &["l4", "l3", "l2", "l1"],
+                    "2026-02-01T00:00:00Z",
+                )],
+            },
+            BranchStack {
+                segments: vec![make_segment_at(
+                    &["short"],
+                    "ch_short",
+                    &["s1"],
+                    "2026-01-01T00:00:00Z",
+                )],
+            },
+        ]);
+
+        let layout = build_layout(&graph);
+
+        // Selecting `long` expands its 4 commits: 4 + short leaf + connector
+        // + trunk = 7 rows.
+        assert_eq!(collapsed_height(&layout, layout.leaves[0]), 7);
+        // Selecting `short` collapses long's 3 unbookmarked commits into one
+        // ⋯ row: leaf + ⋯ + short + connector + trunk = 5 rows.
+        assert_eq!(collapsed_height(&layout, layout.leaves[1]), 5);
+        assert_eq!(max_collapsed_height(&layout), 7);
     }
 }

--- a/src/select/snapshots/stakk__select__graph_layout__tests__nested_siblings_layout.snap
+++ b/src/select/snapshots/stakk__select__graph_layout__tests__nested_siblings_layout.snap
@@ -1,0 +1,12 @@
+---
+source: src/select/graph_layout.rs
+expression: rows_to_string(&layout)
+---
+0:email work
+1:integration work
+2:ratelimit work
+2:├─╯
+1:api work
+1:├─╯
+0:auth work
+0:trunk

--- a/src/select/snapshots/stakk__select__graph_widget__tests__branching_shows_fork_characters.snap
+++ b/src/select/snapshots/stakk__select__graph_widget__tests__branching_shows_fork_characters.snap
@@ -1,0 +1,8 @@
+---
+source: src/select/graph_widget.rs
+expression: render_to_string(&graph)
+---
+ ●  alpha  "alpha work"  ◀
+ │ ○  beta  "beta work"
+ ├─╯
+ ◆  trunk

--- a/src/select/snapshots/stakk__select__graph_widget__tests__collapses_unselected_runs.snap
+++ b/src/select/snapshots/stakk__select__graph_widget__tests__collapses_unselected_runs.snap
@@ -1,0 +1,12 @@
+---
+source: src/select/graph_widget.rs
+expression: render_to_string(&graph)
+---
+ ●  feat  "feat top"  ◀
+ ●  "feat mid"
+ ●  "feat bottom"
+ │ ○  other  "other top"
+ │ ⋯  2 commits
+ │ ○  other-base  "other base"
+ ├─╯
+ ◆  trunk

--- a/src/select/snapshots/stakk__select__graph_widget__tests__linear_stack_single_column.snap
+++ b/src/select/snapshots/stakk__select__graph_widget__tests__linear_stack_single_column.snap
@@ -1,0 +1,7 @@
+---
+source: src/select/graph_widget.rs
+expression: render_to_string(&graph)
+---
+ ●  leaf  "add leaf"  ◀
+ ●  base  "add base"
+ ◆  trunk

--- a/src/select/snapshots/stakk__select__graph_widget__tests__nested_fork_gutters.snap
+++ b/src/select/snapshots/stakk__select__graph_widget__tests__nested_fork_gutters.snap
@@ -1,0 +1,12 @@
+---
+source: src/select/graph_widget.rs
+expression: render_to_string(&graph)
+---
+ ●  email  "email work"  ◀
+ │ ○  integration  "integration work"
+ │ │ ○  ratelimit  "ratelimit work"
+ │ ├─╯
+ │ ○  api  "api work"
+ ├─╯
+ ●  auth  "auth work"
+ ◆  trunk

--- a/src/select/snapshots/stakk__select__graph_widget__tests__selecting_other_leaf_moves_highlight_not_rows.snap
+++ b/src/select/snapshots/stakk__select__graph_widget__tests__selecting_other_leaf_moves_highlight_not_rows.snap
@@ -1,0 +1,9 @@
+---
+source: src/select/graph_widget.rs
+expression: "render_to_string_with_state(&graph, &GraphViewState { selected_leaf: 1 })"
+---
+ ○  alpha  "alpha work"
+ │ ●  beta  "beta work"  ◀
+ │ ●  "beta base"
+ ├─╯
+ ◆  trunk


### PR DESCRIPTION
Render the change graph once on the selection TUI's first screen, the way `jj log` does: one row per commit with a `│ `-cell edge gutter and `├─╯` connector rows, instead of one lane per root→leaf path. Every row permanently carries its bookmark names and description; leaf navigation (`←`/`→`/`↑`/`↓`, `hjkl`, wrapping) only re-colors the selected trunk→leaf path (`●` cyan, bold `◀` on the leaf) — labels never move, topology is real, and each commit appears exactly once.

- `graph_layout.rs`: build a commit tree deduplicated by `commit_id` with parent links, flattened into display rows. Sibling subtrees are ordered newest-first by subtree max committer timestamp, parsed offset-aware with the new `jiff` dependency, tiebroken on `change_id`.
- `graph_widget.rs`: collapse runs of unselected, unbookmarked, non-leaf commits into `⋯ n commits` rows (the selected path is always fully expanded); scroll to anchor the selected leaf at the viewport top when the graph overflows.
- `app.rs`: right-aligned `leaf i/n` indicator in the title row; the viewport is sized to the max collapsed height over all leaves so leaf switches never resize it.
- `graph/mod.rs`: add the leaf-`change_id` tiebreaker to the stack sort that its comment documented but never implemented; equal-timestamp stacks were ordered by randomized `HashSet` iteration.
- Add `insta` (first dev-dependency) with file-based snapshot tests for the layout rows and widget rendering.

Closes #175