### PR TITLE
feat(cli): default `--stack-placement` to `auto-comment`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,9 +390,12 @@ following, update `scripts/record-demo.py` in the same change:
   the server-side stack and placing stakk's stack-info text are separate
   decisions (native + comment is valid while GitHub's preview UI is not
   universally rendered). The `auto-comment`/`auto-body` placements resolve
-  the redundancy per run instead of forbidding it. The intended GA default
-  flip is `native_stacks = auto` + `stack_placement = auto-comment`, which
-  never overrides an explicit comment/body choice.
+  the redundancy per run instead of forbidding it. `stack_placement`
+  already defaults to `auto-comment` (identical to `comment` while
+  `native_stacks` is `off`), so the intended GA change is a single default
+  flip — `native_stacks` to `auto` — which never overrides an explicit
+  comment/body choice. The `--native-stacks` docs advertise that the
+  default may change.
 - **Native stacks layer on, not replace** — GitHub's native stack is
   layered on top of chained base branches, so the execute phase
   (interleaved push → base update → create) runs unchanged and the stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,15 +307,46 @@ following, update `scripts/record-demo.py` in the same change:
 - `format_stack_comment` returns `Result` because user templates can fail.
 - Body-mode fences (`STAKK_BODY_START`/`STAKK_BODY_END`) are HTML comments,
   invisible on GitHub. Migration between placement modes is automatic.
-- `--stack-placement none` writes no stack info and instead runs
-  `cleanup_stack_artifacts` on every PR, deleting the stack comment and
-  stripping the body fence. Single-bookmark submissions take the same
-  cleanup path (one PR is not a stack), so the two share one branch that
-  runs *before* the template and context setup that only `comment`/`body`
-  need. PRs created in the same run are skipped — they cannot yet carry a
-  stack comment. In `none` mode the custom `--template` is never read or
+- `execute_submission_plan` resolves `StackPlacement` + `NativeStacks` to
+  an `EffectivePlacement` (comment/body/cleanup/ignore) up front; step 3
+  and the body-sync deferral branch on that, never on the raw enums.
+  Cleanup-resolved placements (`none`, auto-\* with native in effect) run
+  `cleanup_stack_artifacts` on every PR — deleting the stack comment and
+  stripping the body fence — as do single-bookmark submissions (one PR is
+  not a stack). This shared branch runs *before* the template and context
+  setup that only comment/body rendering needs. PRs created in the same
+  run are skipped — they cannot yet carry a stack comment. Ignore-resolved
+  placements (`ignore`, auto-\* with native support indeterminate) touch
+  no artifacts at all, not even on single-bookmark submissions. In
+  `none`/`ignore` placement the custom `--template` is never read or
   compiled, so a broken template does not fail a submission that will not
-  render it.
+  render it; auto-\* placements may render, so theirs is always loaded.
+- `--native-stacks on|auto` reconciles GitHub's server-side stack *after*
+  the artifact step: query every submitted PR's stack membership, then
+  no-op on exact match, `/add` when the existing stack is a bottom-prefix
+  of the desired list, otherwise unstack-and-recreate (`unstack` removes
+  all unmerged PRs wholesale — the preview API has no per-PR removal).
+  Comparison uses open PRs only, so merged bottoms drop out naturally.
+  Reconcile failures hard-fail the submit (same precedent as
+  `CommentFailed`); the diagnostics state that branches/PRs were submitted
+  normally and re-running is safe. Single-bookmark submissions never touch
+  the stacks API.
+- `--native-stacks auto` probes via `Forge::supports_native_stacks`
+  (`GET /stacks?per_page=1`; 200 = supported, 404 = not enabled, other
+  errors = indeterminate). The probe is skipped when its answer would
+  never be consulted (single bookmark with a fixed placement). Only a
+  definitive answer may flip auto-\* placements into the destructive
+  cleanup direction; indeterminate resolves them to ignore for the run.
+- The stacks endpoints need `x-github-api-version: 2026-03-10`; octocrab
+  sends no version header by default, so `GitHubForge` holds a second
+  `Octocrab` (`stacks_client`) solely to carry it. Stack calls use
+  octocrab's generic typed `get`/`post` (which run `map_github_error`
+  internally) with stakk-defined DTOs — never raw `_get`/`_post`, which
+  skip GitHub-error mapping so 401/403 would not become `AuthFailed`. The
+  one exception is `unstack` (204 has no body): it uses `_post` and
+  reinstates `octocrab::map_github_error` manually. A 404 on a stack route
+  maps to `ForgeError::StacksUnavailable` (preview not enabled for the
+  repo), 409/422 to `ForgeError::StackConflict`.
 - ratatui inline viewport: `enable_raw_mode()` before, `disable_raw_mode()` after.
 - The inline viewport is sized per screen (graph vs bookmark rows). ratatui
   cannot resize an inline viewport in place, so screen transitions erase the
@@ -355,6 +386,20 @@ following, update `scripts/record-demo.py` in the same change:
   the existing artifacts rather than leaving them stale, so the feature can
   be turned off cleanly. Deletion is not previewed by `--dry-run`, which
   returns before the execute phase.
+- **`--native-stacks` is orthogonal to `--stack-placement`** — registering
+  the server-side stack and placing stakk's stack-info text are separate
+  decisions (native + comment is valid while GitHub's preview UI is not
+  universally rendered). The `auto-comment`/`auto-body` placements resolve
+  the redundancy per run instead of forbidding it. The intended GA default
+  flip is `native_stacks = auto` + `stack_placement = auto-comment`, which
+  never overrides an explicit comment/body choice.
+- **Native stacks layer on, not replace** — GitHub's native stack is
+  layered on top of chained base branches, so the execute phase
+  (interleaved push → base update → create) runs unchanged and the stack
+  object is reconciled afterwards. The reconcile is idempotent; it is not
+  previewed by `--dry-run` (same as `none`-mode deletion). Once octocrab
+  ships typed stacks support (XAMPPRocky/octocrab#934), the hand-rolled
+  DTOs in `forge/github.rs` should migrate to it.
 - **`--dry-run` not in env vars** — one-off decision, surprising as a default.
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
 - **Three-phase submission** — analyze (pure) → plan (queries forge) → execute.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ idempotent updates.
   branches so each PR shows only its own diff.
 - **Stack-awareness comments** — adds a comment to every PR listing the full
   stack with links, updated in place on re-runs. Optionally, the stack info
-  can be placed in the PR body instead (`--stack-placement body`) or disabled
+  can be placed in the PR body instead (`--stack-placement body`), disabled
   entirely (`--stack-placement none`, which also removes existing stack
-  comments and body fences). Comments are rendered with
+  comments and body fences), or resolved automatically against native stacks
+  (`--stack-placement auto-comment`/`auto-body`). Comments are rendered with
   [minijinja](https://github.com/mitsuhiko/minijinja) templates and can be
   customized with `--template` or the `STAKK_TEMPLATE` environment variable.
+- **Native GitHub stacks** — `--native-stacks on` (or `auto`) registers every
+  submitted stack as a first-class
+  [GitHub stack](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests)
+  (public preview), independent of where stakk writes its own stack info.
 - **Idempotent** — re-running `stakk submit` is always safe. Existing PRs are
   updated, never duplicated.
 - **Dry-run mode** — `--dry-run` shows exactly what would happen without
@@ -202,10 +207,19 @@ pr_mode = "draft"
 # Path to a custom minijinja template for stack comments
 template = "/path/to/my-template.md.jinja"
 
-# Where to place stack info: "comment", "body", or "none" (default: "comment")
-# "none" writes no stack info and removes existing stack comments/body fences
-# on the next submit (e.g. if you rely on GitHub's native stacked PRs).
+# Where to place stack info: "comment", "body", "none", "ignore",
+# "auto-comment", or "auto-body" (default: "comment").
+# "none" writes nothing and removes existing stack comments/body fences on
+# the next submit; "ignore" writes nothing and leaves them untouched.
+# "auto-comment"/"auto-body" behave like "none" when a native stack is in
+# effect (see native_stacks) and like "comment"/"body" otherwise.
 stack_placement = "body"
+
+# Register submitted stacks with GitHub's native stacked pull requests
+# (public preview): "off", "on", or "auto" (default: "off").
+# "on" fails the submit if the feature is not enabled for the repository;
+# "auto" probes once per submit and skips silently where unavailable.
+native_stacks = "auto"
 
 # Prefix for auto-generated bookmark names (default: none)
 auto_prefix = "gb-"
@@ -297,7 +311,8 @@ stack_placement = "comment"
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_DRAFT` | Set to `true` to always create draft PRs (overridden by `--draft`) |
 | `STAKK_TEMPLATE` | Path to a custom minijinja template for stack comments (overridden by `--template`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, or `none` (overridden by `--stack-placement`) |
+| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, `none`, `ignore`, `auto-comment`, or `auto-body` (overridden by `--stack-placement`) |
+| `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs: `off` (default), `on`, or `auto` (overridden by `--native-stacks`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
 | `STAKK_TRAILERS` | Whether to keep or strip git commit trailers in PR bodies: `keep` (default) or `strip` (overridden by `--trailers`) |
@@ -330,7 +345,8 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | `--draft` | `STAKK_DRAFT` | Create new PRs as drafts |
 | `--remote <name>` | `STAKK_REMOTE` | Push to a specific remote (default: `origin`) |
 | `--template <path>` | `STAKK_TEMPLATE` | Use a custom minijinja template for stack comments |
-| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default), in the PR `body`, or write none at all with `none` |
+| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default) or in the PR `body`; write none with `none` (removes existing) or `ignore` (leaves existing); `auto-comment`/`auto-body` defer to native stacks |
+| `--native-stacks <mode>` | `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs (public preview): `off` (default), `on` (fail if unavailable), `auto` (skip if unavailable) |
 | `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
 | `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
 | `--trailers <mode>` | `STAKK_TRAILERS` | Keep or strip git commit trailers in PR bodies: `keep` (default), `strip` |
@@ -343,6 +359,29 @@ manually edited PR descriptions are never overwritten. Use
 `--sync-pr-content` to update existing PRs: `title` syncs only the title,
 `body` only the body, or `all` for both. Only fields that actually changed
 are updated.
+
+With `--native-stacks on` or `auto`, stakk additionally registers the stack
+on GitHub itself via the
+[stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests)
+API — GitHub then renders the stack natively (stack icon, merge-box stack
+map) and takes over retargeting the remaining PRs as the stack merges
+bottom-up. The feature is in public preview and must be enabled for the
+repository. With `on`, a repository without it fails the submit with
+guidance *after* branches and PRs have been submitted normally (re-running
+is safe); with `auto`, stakk probes once per submit and skips silently
+where unavailable. A single-bookmark submission is not a stack, so it never
+touches the stacks API.
+
+Native stacks are independent of `--stack-placement`: GitHub's own stack
+rendering makes stakk's stack comment redundant, but it is still written
+unless placement says otherwise. The `auto-comment`/`auto-body` placements
+resolve this automatically — they behave like `none` (write nothing, retire
+existing artifacts) on runs where a native stack is in effect, and like
+`comment`/`body` otherwise, so `native_stacks = "auto"` +
+`stack_placement = "auto-comment"` gives native rendering where available
+and stack comments everywhere else, never both. If native support cannot be
+determined (e.g. a transient network error), auto placements behave like
+`ignore` for that run — nothing is written or removed.
 
 ### `stakk show`
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ pr_mode = "draft"
 template = "/path/to/my-template.md.jinja"
 
 # Where to place stack info: "comment", "body", "none", "ignore",
-# "auto-comment", or "auto-body" (default: "comment").
+# "auto-comment", or "auto-body" (default: "auto-comment", which is
+# identical to "comment" as long as native_stacks is off).
 # "none" writes nothing and removes existing stack comments/body fences on
 # the next submit; "ignore" writes nothing and leaves them untouched.
 # "auto-comment"/"auto-body" behave like "none" when a native stack is in
@@ -216,7 +217,8 @@ template = "/path/to/my-template.md.jinja"
 stack_placement = "body"
 
 # Register submitted stacks with GitHub's native stacked pull requests
-# (public preview): "off", "on", or "auto" (default: "off").
+# (public preview): "off", "on", or "auto" (default: "off"; the default
+# may change to "auto" once the feature reaches general availability).
 # "on" fails the submit if the feature is not enabled for the repository;
 # "auto" probes once per submit and skips silently where unavailable.
 native_stacks = "auto"
@@ -311,7 +313,7 @@ stack_placement = "comment"
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_DRAFT` | Set to `true` to always create draft PRs (overridden by `--draft`) |
 | `STAKK_TEMPLATE` | Path to a custom minijinja template for stack comments (overridden by `--template`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, `none`, `ignore`, `auto-comment`, or `auto-body` (overridden by `--stack-placement`) |
+| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment`, `body`, `none`, `ignore`, `auto-comment` (default), or `auto-body` (overridden by `--stack-placement`) |
 | `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs: `off` (default), `on`, or `auto` (overridden by `--native-stacks`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
@@ -345,7 +347,7 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | `--draft` | `STAKK_DRAFT` | Create new PRs as drafts |
 | `--remote <name>` | `STAKK_REMOTE` | Push to a specific remote (default: `origin`) |
 | `--template <path>` | `STAKK_TEMPLATE` | Use a custom minijinja template for stack comments |
-| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default) or in the PR `body`; write none with `none` (removes existing) or `ignore` (leaves existing); `auto-comment`/`auto-body` defer to native stacks |
+| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` or in the PR `body`; write none with `none` (removes existing) or `ignore` (leaves existing); `auto-comment` (default)/`auto-body` defer to native stacks |
 | `--native-stacks <mode>` | `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs (public preview): `off` (default), `on` (fail if unavailable), `auto` (skip if unavailable) |
 | `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
 | `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
@@ -379,7 +381,10 @@ resolve this automatically — they behave like `none` (write nothing, retire
 existing artifacts) on runs where a native stack is in effect, and like
 `comment`/`body` otherwise, so `native_stacks = "auto"` +
 `stack_placement = "auto-comment"` gives native rendering where available
-and stack comments everywhere else, never both. If native support cannot be
+and stack comments everywhere else, never both. `auto-comment` is already
+the default placement (identical to `comment` while `native_stacks` is
+`off`), and the `native_stacks` default may change to `auto` once the
+GitHub feature reaches general availability. If native support cannot be
 determined (e.g. a transient network error), auto placements behave like
 `ignore` for that run — nothing is written or removed.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -275,7 +275,10 @@ mod tests {
     #[test]
     fn stack_placement_default_no_config() {
         let cli = parse_with_config(Config::default(), &["stakk", "submit", "bm"]);
-        assert_eq!(submit_args(&cli).stack_placement, StackPlacement::Comment);
+        assert_eq!(
+            submit_args(&cli).stack_placement,
+            StackPlacement::AutoComment
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -102,6 +102,9 @@ fn apply_submit_defaults(config: &Config, mut cmd: Command) -> Command {
     if let Some(sp) = config.stack_placement {
         cmd = set_default(cmd, "stack_placement", &sp.to_string());
     }
+    if let Some(ns) = config.native_stacks {
+        cmd = set_default(cmd, "native_stacks", &ns.to_string());
+    }
     if let Some(spc) = config.sync_pr_content {
         cmd = set_default(cmd, "sync_pr_content", &spc.to_string());
     }
@@ -321,6 +324,36 @@ mod tests {
         assert_eq!(submit_args(&cli).stack_placement, StackPlacement::None);
     }
 
+    // -- native_stacks tests --
+
+    use crate::cli::submit::NativeStacks;
+
+    #[test]
+    fn native_stacks_default_no_config() {
+        let cli = parse_with_config(Config::default(), &["stakk", "submit", "bm"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::Off);
+    }
+
+    #[test]
+    fn native_stacks_config_on() {
+        let config = Config {
+            native_stacks: Some(NativeStacks::On),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "bm"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::On);
+    }
+
+    #[test]
+    fn native_stacks_cli_overrides_config() {
+        let config = Config {
+            native_stacks: Some(NativeStacks::On),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "--native-stacks", "off", "bm"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::Off);
+    }
+
     // -- sync_pr_content tests --
 
     #[test]
@@ -500,6 +533,7 @@ remote = "upstream"
 pr_mode = "draft"
 template = "/path/to/template.jinja"
 stack_placement = "body"
+native_stacks = "on"
 sync_pr_content = "all"
 trailers = "strip"
 auto_prefix = "gb-"
@@ -512,6 +546,7 @@ heads_revset = "heads(all())"
         assert_eq!(config.pr_mode, Some(PrMode::Draft));
         assert_eq!(config.template.as_deref(), Some("/path/to/template.jinja"));
         assert_eq!(config.stack_placement, Some(StackPlacement::Body));
+        assert_eq!(config.native_stacks, Some(NativeStacks::On));
         assert_eq!(
             config.sync_pr_content,
             Some(crate::cli::submit::SyncPrContent::All),
@@ -556,6 +591,30 @@ heads_revset = "heads(all())"
     fn toml_stack_placement_none() {
         let config: Config = toml::from_str(r#"stack_placement = "none""#).unwrap();
         assert_eq!(config.stack_placement, Some(StackPlacement::None));
+    }
+
+    #[test]
+    fn toml_native_stacks_on() {
+        let config: Config = toml::from_str(r#"native_stacks = "on""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::On));
+    }
+
+    #[test]
+    fn toml_native_stacks_auto() {
+        let config: Config = toml::from_str(r#"native_stacks = "auto""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::Auto));
+    }
+
+    #[test]
+    fn toml_stack_placement_auto_comment() {
+        let config: Config = toml::from_str(r#"stack_placement = "auto-comment""#).unwrap();
+        assert_eq!(config.stack_placement, Some(StackPlacement::AutoComment));
+    }
+
+    #[test]
+    fn toml_stack_placement_auto_body() {
+        let config: Config = toml::from_str(r#"stack_placement = "auto-body""#).unwrap();
+        assert_eq!(config.stack_placement, Some(StackPlacement::AutoBody));
     }
 
     #[test]

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -73,6 +73,33 @@ impl std::fmt::Display for TrailerHandling {
     }
 }
 
+/// Whether to register submitted stacks with the forge's native
+/// server-side stack feature (GitHub's stacked pull requests, public
+/// preview).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum NativeStacks {
+    /// Never touch the forge's stack API.
+    #[default]
+    Off,
+    /// Register/update the server-side stack on every submit; fail the
+    /// submit if the feature is not available on the repository.
+    On,
+    /// Probe the repository once per submit and register/update the
+    /// server-side stack when the feature is available; silently skip
+    /// it otherwise.
+    Auto,
+}
+
+impl std::fmt::Display for NativeStacks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pv = self
+            .to_possible_value()
+            .expect("all variants have possible values");
+        f.write_str(pv.get_name())
+    }
+}
+
 /// Arguments for the submit subcommand.
 #[derive(Debug, Args)]
 pub struct SubmitArgs {
@@ -153,7 +180,14 @@ pub struct SubmitArgs {
     ///
     /// In none mode no stack info is written at all. Existing stack
     /// comments and body fences are removed from each PR on submit, so
-    /// the feature can be retired cleanly.
+    /// the feature can be retired cleanly. Ignore mode also writes
+    /// nothing but leaves existing stack comments and body fences
+    /// untouched.
+    ///
+    /// The auto-comment and auto-body modes defer to native stacks (see
+    /// --native-stacks): when a native server-side stack is in effect
+    /// they behave like none, otherwise like comment/body. If native
+    /// support cannot be determined they behave like ignore for the run.
     ///
     /// Switching modes migrates automatically: moving to body mode
     /// deletes the old stack comment, and moving to comment mode strips
@@ -166,6 +200,31 @@ pub struct SubmitArgs {
         verbatim_doc_comment
     )]
     pub stack_placement: StackPlacement,
+
+    /// Whether to register submitted stacks with GitHub's native
+    /// stacked-pull-requests feature (public preview).
+    ///
+    /// When on, the server-side stack is created or updated after every
+    /// submit, and the submit fails with guidance if the feature is not
+    /// enabled for the repository (branches and PRs are still submitted
+    /// normally first). GitHub then renders the stack natively and
+    /// retargets the remaining PRs as the stack merges bottom-up.
+    ///
+    /// When auto, the repository is probed once per submit and the
+    /// server-side stack is registered only where the feature is
+    /// available — repositories without it are skipped silently.
+    ///
+    /// The native stack is independent of --stack-placement: stack
+    /// comments or body fences are still written unless placement is
+    /// none, ignore, or an auto mode that resolved to native.
+    #[arg(
+        long,
+        env = "STAKK_NATIVE_STACKS",
+        default_value = "off",
+        value_enum,
+        verbatim_doc_comment
+    )]
+    pub native_stacks: NativeStacks,
 
     /// Controls whether existing PR titles and/or bodies are updated
     /// from jj commit descriptions on every submit.

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -188,6 +188,8 @@ pub struct SubmitArgs {
     /// --native-stacks): when a native server-side stack is in effect
     /// they behave like none, otherwise like comment/body. If native
     /// support cannot be determined they behave like ignore for the run.
+    /// The default is auto-comment, which is identical to comment as
+    /// long as native stacks are off.
     ///
     /// Switching modes migrates automatically: moving to body mode
     /// deletes the old stack comment, and moving to comment mode strips
@@ -195,7 +197,7 @@ pub struct SubmitArgs {
     #[arg(
         long,
         env = "STAKK_STACK_PLACEMENT",
-        default_value = "comment",
+        default_value = "auto-comment",
         value_enum,
         verbatim_doc_comment
     )]
@@ -217,6 +219,9 @@ pub struct SubmitArgs {
     /// The native stack is independent of --stack-placement: stack
     /// comments or body fences are still written unless placement is
     /// none, ignore, or an auto mode that resolved to native.
+    ///
+    /// The default may change to auto once GitHub's stacked pull
+    /// requests reach general availability.
     #[arg(
         long,
         env = "STAKK_NATIVE_STACKS",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+use crate::cli::submit::NativeStacks;
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
 use crate::cli::submit::TrailerHandling;
@@ -51,6 +52,7 @@ pub struct Config {
     pub pr_mode: Option<PrMode>,
     pub template: Option<String>,
     pub stack_placement: Option<StackPlacement>,
+    pub native_stacks: Option<NativeStacks>,
     pub sync_pr_content: Option<SyncPrContent>,
     pub trailers: Option<TrailerHandling>,
     pub auto_prefix: Option<String>,
@@ -67,6 +69,7 @@ impl Default for Config {
             pr_mode: None,
             template: None,
             stack_placement: None,
+            native_stacks: None,
             sync_pr_content: None,
             trailers: None,
             auto_prefix: None,
@@ -135,6 +138,7 @@ impl Config {
             pr_mode: self.pr_mode.or(fallback.pr_mode),
             template: self.template.or(fallback.template),
             stack_placement: self.stack_placement.or(fallback.stack_placement),
+            native_stacks: self.native_stacks.or(fallback.native_stacks),
             sync_pr_content: self.sync_pr_content.or(fallback.sync_pr_content),
             trailers: self.trailers.or(fallback.trailers),
             auto_prefix: self.auto_prefix.or(fallback.auto_prefix),

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -18,7 +18,6 @@ use crate::submit::SubmitError;
 #[serde(rename_all = "kebab-case")]
 pub enum StackPlacement {
     /// Place the stack comment as a separate PR comment (issue comment).
-    #[default]
     Comment,
     /// Place the stack content in a fenced section of the PR body.
     Body,
@@ -31,6 +30,7 @@ pub enum StackPlacement {
     /// Behave like `none` when a native server-side stack is in effect
     /// for this run, like `comment` otherwise. If native support cannot
     /// be determined, behaves like `ignore`.
+    #[default]
     AutoComment,
     /// Behave like `none` when a native server-side stack is in effect
     /// for this run, like `body` otherwise. If native support cannot

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -28,6 +28,14 @@ pub enum StackPlacement {
     /// Write no stack info and leave existing stack comments and body
     /// fences untouched.
     Ignore,
+    /// Behave like `none` when a native server-side stack is in effect
+    /// for this run, like `comment` otherwise. If native support cannot
+    /// be determined, behaves like `ignore`.
+    AutoComment,
+    /// Behave like `none` when a native server-side stack is in effect
+    /// for this run, like `body` otherwise. If native support cannot
+    /// be determined, behaves like `ignore`.
+    AutoBody,
 }
 
 impl std::fmt::Display for StackPlacement {

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -8,12 +8,22 @@ use super::Comment;
 use super::CreatePrParams;
 use super::Forge;
 use super::ForgeError;
+use super::ForgeStack;
 use super::PrState;
 use super::PullRequest;
+
+/// API version required by the stacked-pull-requests endpoints (public
+/// preview). octocrab sends no `X-GitHub-Api-Version` header by default,
+/// which GitHub treats as 2022-11-28 — too old for the stack routes.
+const STACKS_API_VERSION: &str = "2026-03-10";
 
 /// GitHub implementation of the `Forge` trait.
 pub struct GitHubForge {
     client: Octocrab,
+    /// Separate client that carries the `x-github-api-version` header the
+    /// stack endpoints require, so the main client's requests keep GitHub's
+    /// default API version.
+    stacks_client: Octocrab,
     owner: String,
     repo: String,
 }
@@ -21,22 +31,36 @@ pub struct GitHubForge {
 impl GitHubForge {
     /// Create a new `GitHubForge` for the given repository.
     pub fn new(token: &str, owner: String, repo: String) -> Result<Self, ForgeError> {
+        let wrap_build_error = |e: octocrab::Error| {
+            let message = format!("failed to create GitHub client: {e}");
+            ForgeError::Api {
+                message,
+                source: Box::new(e),
+            }
+        };
         let client = Octocrab::builder()
             .personal_token(token.to_string())
             .build()
-            .map_err(|e| {
-                let message = format!("failed to create GitHub client: {e}");
-                ForgeError::Api {
-                    message,
-                    source: Box::new(e),
-                }
-            })?;
+            .map_err(wrap_build_error)?;
+        let stacks_client = Octocrab::builder()
+            .personal_token(token.to_string())
+            .add_header(
+                http::header::HeaderName::from_static("x-github-api-version"),
+                STACKS_API_VERSION.to_string(),
+            )
+            .build()
+            .map_err(wrap_build_error)?;
 
         Ok(Self {
             client,
+            stacks_client,
             owner,
             repo,
         })
+    }
+
+    fn stacks_route(&self) -> String {
+        format!("/repos/{}/{}/stacks", self.owner, self.repo)
     }
 }
 
@@ -166,6 +190,76 @@ impl Forge for GitHubForge {
             .map_err(map_octocrab_error)?;
         Ok(())
     }
+
+    async fn get_stacks_for_pr(&self, pr_number: u64) -> Result<Vec<ForgeStack>, ForgeError> {
+        let stacks: Vec<StackDto> = self
+            .stacks_client
+            .get(self.stacks_route(), Some(&[("pull_request", pr_number)]))
+            .await
+            .map_err(map_octocrab_stack_error)?;
+        Ok(stacks.into_iter().map(convert_stack).collect())
+    }
+
+    async fn create_stack(&self, pr_numbers: &[u64]) -> Result<ForgeStack, ForgeError> {
+        let stack: StackDto = self
+            .stacks_client
+            .post(
+                self.stacks_route(),
+                Some(&serde_json::json!({ "pull_requests": pr_numbers })),
+            )
+            .await
+            .map_err(map_octocrab_stack_error)?;
+        Ok(convert_stack(stack))
+    }
+
+    async fn add_to_stack(
+        &self,
+        stack_number: u64,
+        pr_numbers: &[u64],
+    ) -> Result<ForgeStack, ForgeError> {
+        let stack: StackDto = self
+            .stacks_client
+            .post(
+                format!("{}/{stack_number}/add", self.stacks_route()),
+                Some(&serde_json::json!({ "pull_requests": pr_numbers })),
+            )
+            .await
+            .map_err(map_octocrab_stack_error)?;
+        Ok(convert_stack(stack))
+    }
+
+    async fn supports_native_stacks(&self) -> Result<bool, ForgeError> {
+        let result: Result<Vec<serde_json::Value>, octocrab::Error> = self
+            .stacks_client
+            .get(self.stacks_route(), Some(&[("per_page", 1_u64)]))
+            .await;
+        match result.map_err(map_octocrab_stack_error) {
+            Ok(_) => Ok(true),
+            // A definitive 404: the preview feature is not enabled here.
+            Err(ForgeError::StacksUnavailable { .. }) => Ok(false),
+            // Anything else (auth, network, rate limit) is not an answer.
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn unstack(&self, stack_number: u64) -> Result<(), ForgeError> {
+        // The response is 200 (stack remains) or 204 (stack dissolved, empty
+        // body); the typed `post` can't deserialize an empty body, so use the
+        // raw `_post` and reinstate octocrab's GitHub-error mapping manually
+        // to keep status codes flowing into `map_octocrab_stack_error`.
+        let response = self
+            .stacks_client
+            ._post(
+                format!("{}/{stack_number}/unstack", self.stacks_route()),
+                None::<&()>,
+            )
+            .await
+            .map_err(map_octocrab_stack_error)?;
+        octocrab::map_github_error(response)
+            .await
+            .map_err(map_octocrab_stack_error)?;
+        Ok(())
+    }
 }
 
 /// Convert an octocrab pull request into the forge-agnostic type.
@@ -213,4 +307,57 @@ fn map_pr_state(state: Option<&IssueState>, has_merged_at: bool) -> PrState {
     } else {
         PrState::Open
     }
+}
+
+/// Wire format of a stack object from the stacks endpoints.
+#[derive(Debug, serde::Deserialize)]
+struct StackDto {
+    number: u64,
+    pull_requests: Vec<StackPrDto>,
+}
+
+/// Wire format of a stack member PR.
+#[derive(Debug, serde::Deserialize)]
+struct StackPrDto {
+    number: u64,
+    state: String,
+    merged_at: Option<String>,
+}
+
+fn convert_stack(dto: StackDto) -> ForgeStack {
+    ForgeStack {
+        number: dto.number,
+        open_pr_numbers: dto
+            .pull_requests
+            .into_iter()
+            .filter(|p| p.state == "open" && p.merged_at.is_none())
+            .map(|p| p.number)
+            .collect(),
+    }
+}
+
+/// Error mapping for the stack endpoints, layered on `map_octocrab_error`.
+///
+/// A 404 on a stack route means the stacked-PRs preview feature is not
+/// enabled for the repository — we only reach these routes after having
+/// talked to the repo successfully. 409/422 signal that a stack mutation
+/// conflicts with current server state (e.g. PRs that don't chain).
+fn map_octocrab_stack_error(e: octocrab::Error) -> ForgeError {
+    if let octocrab::Error::GitHub { source, .. } = &e {
+        if source.status_code == http::StatusCode::NOT_FOUND {
+            return ForgeError::StacksUnavailable {
+                message: source.message.clone(),
+                source: Box::new(e),
+            };
+        }
+        if source.status_code == http::StatusCode::CONFLICT
+            || source.status_code == http::StatusCode::UNPROCESSABLE_ENTITY
+        {
+            return ForgeError::StackConflict {
+                message: source.message.clone(),
+                source: Box::new(e),
+            };
+        }
+    }
+    map_octocrab_error(e)
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -30,6 +30,28 @@ pub enum ForgeError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[error("native stacked pull requests are not available on this repository: {message}")]
+    #[diagnostic(
+        code(stakk::forge::stacks_unavailable),
+        help(
+            "GitHub's stacked pull requests are a preview feature that must be enabled for the \
+             repository — set `--native-stacks auto` to use it only where available, or `off`"
+        )
+    )]
+    StacksUnavailable {
+        message: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("stack operation conflicted with current server state: {message}")]
+    #[diagnostic(code(stakk::forge::stack_conflict))]
+    StackConflict {
+        message: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 /// State of a pull request.
@@ -59,6 +81,16 @@ pub struct PullRequest {
     pub state: PrState,
     /// The PR body/description text.
     pub body: Option<String>,
+}
+
+/// A server-side stack of pull requests, forge-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgeStack {
+    /// Stack number, used to address the stack in later calls.
+    pub number: u64,
+    /// Numbers of the stack's *open* PRs, bottom-to-top. Merged and closed
+    /// members are filtered out by the implementation.
+    pub open_pr_numbers: Vec<u64>,
 }
 
 /// A comment on a pull request.
@@ -146,4 +178,37 @@ pub trait Forge: Send + Sync {
         &self,
         comment_id: u64,
     ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
+
+    /// List the server-side stacks containing the given PR (empty if none).
+    fn get_stacks_for_pr(
+        &self,
+        pr_number: u64,
+    ) -> impl std::future::Future<Output = Result<Vec<ForgeStack>, ForgeError>> + Send;
+
+    /// Create a server-side stack from PR numbers ordered bottom-to-top.
+    fn create_stack(
+        &self,
+        pr_numbers: &[u64],
+    ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send;
+
+    /// Append PRs (ordered bottom-to-top) on top of an existing stack.
+    fn add_to_stack(
+        &self,
+        stack_number: u64,
+        pr_numbers: &[u64],
+    ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send;
+
+    /// Remove all unmerged PRs from a stack, dissolving it if it empties.
+    fn unstack(
+        &self,
+        stack_number: u64,
+    ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
+
+    /// Probe whether the forge offers native server-side stacks on this
+    /// repository. `Ok(true)`/`Ok(false)` are definitive answers; `Err`
+    /// means the answer could not be determined (e.g. a transient network
+    /// failure) and callers should avoid destructive decisions based on it.
+    fn supports_native_stacks(
+        &self,
+    ) -> impl std::future::Future<Output = Result<bool, ForgeError>> + Send;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,9 +259,16 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
 
     // Load template. In `none`/`ignore` placement no stack content is ever
     // rendered, so a custom template is neither read nor compiled — a broken
-    // or missing one must not fail a submission that will not use it.
+    // or missing one must not fail a submission that will not use it. Auto
+    // placements may render, so their template is always loaded.
     let template_source = match (&args.template, args.stack_placement) {
-        (Some(path), StackPlacement::Comment | StackPlacement::Body) => Some(
+        (
+            Some(path),
+            StackPlacement::Comment
+            | StackPlacement::Body
+            | StackPlacement::AutoComment
+            | StackPlacement::AutoBody,
+        ) => Some(
             std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
                 path: path.clone(),
                 reason: e.to_string(),
@@ -274,9 +281,15 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
     // Phase 3: Execute. The header separates the plan from the result lines
     // printed during execution.
     println!("\nExecuting:");
-    let result =
-        submit::execute_submission_plan(&plan, &jj, &forge, &comment_env, args.stack_placement)
-            .await?;
+    let result = submit::execute_submission_plan(
+        &plan,
+        &jj,
+        &forge,
+        &comment_env,
+        args.stack_placement,
+        args.native_stacks,
+    )
+    .await?;
 
     println!("\nSubmitted {} bookmark(s).", result.stack_entries.len());
 

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -12,12 +12,14 @@ use std::fmt;
 use miette::Diagnostic;
 use thiserror::Error;
 
+use crate::cli::submit::NativeStacks;
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
 use crate::cli::submit::TrailerHandling;
 use crate::forge::CreatePrParams;
 use crate::forge::Forge;
 use crate::forge::ForgeError;
+use crate::forge::ForgeStack;
 use crate::forge::PullRequest;
 use crate::forge::comment::STAKK_REPO_URL;
 use crate::forge::comment::StackCommentContext;
@@ -193,6 +195,46 @@ pub enum SubmitError {
         #[source]
         source: ForgeError,
     },
+
+    /// Native stacks were requested but the forge does not offer them here.
+    #[error("native stacked pull requests are not enabled for this repository")]
+    #[diagnostic(
+        code(stakk::submit::stacks_unavailable),
+        help(
+            "your branches were pushed and PRs were created/updated normally — only the \
+             server-side stack linkage was skipped. GitHub's stacked pull requests are a preview \
+             feature that must be enabled per repository; set `--native-stacks auto` to use the \
+             feature only where available, or `off` (env: STAKK_NATIVE_STACKS)"
+        )
+    )]
+    StacksUnavailable {
+        #[source]
+        source: ForgeError,
+    },
+
+    /// Failed to reconcile the server-side stack after PRs were submitted.
+    #[error("failed to reconcile the server-side stack")]
+    #[diagnostic(
+        code(stakk::submit::stack_reconcile_failed),
+        help(
+            "your branches were pushed and PRs were created/updated normally — only the \
+             server-side stack linkage failed. Re-running `stakk submit` retries the \
+             reconciliation from scratch"
+        )
+    )]
+    StackReconcileFailed {
+        #[source]
+        source: ForgeError,
+    },
+}
+
+/// Wrap a stack-API error, routing the not-enabled case to its dedicated
+/// variant so miette renders the switch-placement guidance.
+fn wrap_stack_err(source: ForgeError) -> SubmitError {
+    match source {
+        ForgeError::StacksUnavailable { .. } => SubmitError::StacksUnavailable { source },
+        _ => SubmitError::StackReconcileFailed { source },
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -590,11 +632,42 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     forge: &F,
     comment_env: &minijinja::Environment<'_>,
     placement: StackPlacement,
+    native: NativeStacks,
 ) -> Result<SubmissionResult, SubmitError> {
     let pb = indicatif::ProgressBar::new_spinner();
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
 
-    let effective = resolve_placement(placement);
+    // Resolve whether a native server-side stack is in effect for this run.
+    // The probe only runs for `auto`, and only when its answer is actually
+    // consulted: by an auto placement, or by the reconcile step (which needs
+    // more than one bookmark to form a stack).
+    let native_state = match native {
+        NativeStacks::Off => NativeState::Inactive,
+        NativeStacks::On => NativeState::Active,
+        NativeStacks::Auto => {
+            let consulted = matches!(
+                placement,
+                StackPlacement::AutoComment | StackPlacement::AutoBody
+            ) || plan.bookmark_plans.len() > 1;
+            if consulted {
+                match forge.supports_native_stacks().await {
+                    Ok(true) => NativeState::Active,
+                    Ok(false) => NativeState::Inactive,
+                    Err(e) => {
+                        pb.println(format!(
+                            "  Warning: could not determine whether native stacked PRs are \
+                             available: {e}. Stack reconciliation is skipped and auto placements \
+                             behave like `ignore` this run."
+                        ));
+                        NativeState::Unknown
+                    }
+                }
+            } else {
+                NativeState::Unknown
+            }
+        }
+    };
+    let effective = resolve_placement(placement, native_state);
 
     let mut stack_entries = Vec::new();
 
@@ -903,9 +976,30 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
         }
     }
 
+    // Step 4: When native stacks are in effect, converge the forge's
+    // server-side stack with the submitted PRs. A single PR is not a stack,
+    // so single-bookmark submissions skip the stack API entirely (a stale
+    // server-side stack containing that PR is left alone).
+    if native_state == NativeState::Active && stack_entries.len() > 1 {
+        pb.set_message("Reconciling server-side stack...");
+        let desired: Vec<u64> = stack_entries.iter().map(|e| e.pr_number).collect();
+        reconcile_native_stack(forge, &desired, &pb).await?;
+    }
+
     pb.finish_and_clear();
 
     Ok(SubmissionResult { stack_entries })
+}
+
+/// Whether a native server-side stack is in effect for one run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeState {
+    /// The server-side stack will be reconciled.
+    Active,
+    /// Native stacks are off or definitively unavailable.
+    Inactive,
+    /// Availability could not be determined; avoid destructive decisions.
+    Unknown,
 }
 
 /// The artifact behavior a `StackPlacement` resolves to for one run.
@@ -921,13 +1015,108 @@ enum EffectivePlacement {
     Ignore,
 }
 
-fn resolve_placement(placement: StackPlacement) -> EffectivePlacement {
+fn resolve_placement(placement: StackPlacement, native: NativeState) -> EffectivePlacement {
     match placement {
         StackPlacement::Comment => EffectivePlacement::Comment,
         StackPlacement::Body => EffectivePlacement::Body,
         StackPlacement::None => EffectivePlacement::Cleanup,
         StackPlacement::Ignore => EffectivePlacement::Ignore,
+        StackPlacement::AutoComment => match native {
+            NativeState::Active => EffectivePlacement::Cleanup,
+            NativeState::Inactive => EffectivePlacement::Comment,
+            NativeState::Unknown => EffectivePlacement::Ignore,
+        },
+        StackPlacement::AutoBody => match native {
+            NativeState::Active => EffectivePlacement::Cleanup,
+            NativeState::Inactive => EffectivePlacement::Body,
+            NativeState::Unknown => EffectivePlacement::Ignore,
+        },
     }
+}
+
+/// Converge the forge's server-side stack with the submitted PRs.
+///
+/// `desired` holds the PR numbers bottom-to-top; the caller guarantees at
+/// least two entries. Idempotent: every failure point leaves the server in
+/// a state from which a re-run converges.
+async fn reconcile_native_stack<F: Forge>(
+    forge: &F,
+    desired: &[u64],
+    pb: &indicatif::ProgressBar,
+) -> Result<(), SubmitError> {
+    // Query every desired PR, not just the bottom one — an upper PR held by
+    // a foreign stack would otherwise make create/add fail opaquely.
+    let lookups = futures::future::join_all(desired.iter().map(|&n| forge.get_stacks_for_pr(n)));
+    let mut stacks: Vec<ForgeStack> = Vec::new();
+    for result in lookups.await {
+        for stack in result.map_err(wrap_stack_err)? {
+            if !stacks.iter().any(|s| s.number == stack.number) {
+                stacks.push(stack);
+            }
+        }
+    }
+
+    match stacks.as_slice() {
+        [] => {
+            let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+            pb.println(format!(
+                "  Created server-side stack #{} ({} PRs).",
+                created.number,
+                desired.len()
+            ));
+        }
+        [stack] if stack.open_pr_numbers == desired => {
+            pb.println(format!(
+                "  Server-side stack #{} is up to date.",
+                stack.number
+            ));
+        }
+        [stack]
+            if !stack.open_pr_numbers.is_empty() && desired.starts_with(&stack.open_pr_numbers) =>
+        {
+            let suffix = &desired[stack.open_pr_numbers.len()..];
+            match forge.add_to_stack(stack.number, suffix).await {
+                Ok(_) => {
+                    pb.println(format!(
+                        "  Added {} PR(s) to server-side stack #{}.",
+                        suffix.len(),
+                        stack.number
+                    ));
+                }
+                // The preview API's add semantics are not fully specified;
+                // if the server rejects the append, converge via the
+                // universal dissolve-and-recreate path instead.
+                Err(ForgeError::StackConflict { .. }) => {
+                    forge.unstack(stack.number).await.map_err(wrap_stack_err)?;
+                    let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+                    pb.println(format!(
+                        "  Recreated server-side stack #{} ({} PRs).",
+                        created.number,
+                        desired.len()
+                    ));
+                }
+                Err(e) => return Err(wrap_stack_err(e)),
+            }
+        }
+        _ => {
+            // Reorder, foreign members, multiple stacks, or a stack whose
+            // open PRs all merged away: dissolve everything and rebuild.
+            // `unstack` removes unmerged PRs wholesale (the preview API has
+            // no per-PR removal); merged leftovers cannot conflict with the
+            // new stack.
+            for stack in &stacks {
+                forge.unstack(stack.number).await.map_err(wrap_stack_err)?;
+            }
+            let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+            pb.println(format!(
+                "  Recreated server-side stack #{} ({} PRs).",
+                created.number,
+                desired.len()
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Remove any stack artifacts (stack comment and body fence) from a single PR.
@@ -984,6 +1173,7 @@ mod tests {
     use super::*;
     use crate::forge::Comment;
     use crate::forge::ForgeError;
+    use crate::forge::ForgeStack;
     use crate::forge::PrState;
     use crate::forge::comment::build_comment_env;
     use crate::graph::types::BranchStack;
@@ -1086,6 +1276,22 @@ mod tests {
         listed_comments: Mutex<Vec<u64>>,
         next_pr_number: Mutex<u64>,
         ops: Option<OpLog>,
+        existing_stacks: Vec<ForgeStack>,
+        /// When set, `get_stacks_for_pr` fails with `StacksUnavailable`.
+        stacks_unavailable: bool,
+        /// When set, `add_to_stack` fails with `StackConflict`.
+        add_conflicts: bool,
+        /// What `supports_native_stacks` reports: `Some(bool)` is a
+        /// definitive answer, `None` a transient failure.
+        probe_supported: Option<bool>,
+        /// Number of `supports_native_stacks` calls.
+        probe_calls: Mutex<usize>,
+        /// PR numbers `get_stacks_for_pr` was called for.
+        stack_lookups: Mutex<Vec<u64>>,
+        created_stacks: Mutex<Vec<Vec<u64>>>,
+        added_to_stacks: Mutex<Vec<(u64, Vec<u64>)>>,
+        unstacked: Mutex<Vec<u64>>,
+        next_stack_number: Mutex<u64>,
     }
 
     impl MockForge {
@@ -1103,6 +1309,16 @@ mod tests {
                 listed_comments: Mutex::new(Vec::new()),
                 next_pr_number: Mutex::new(100),
                 ops: None,
+                existing_stacks: Vec::new(),
+                stacks_unavailable: false,
+                add_conflicts: false,
+                probe_supported: Some(true),
+                probe_calls: Mutex::new(0),
+                stack_lookups: Mutex::new(Vec::new()),
+                created_stacks: Mutex::new(Vec::new()),
+                added_to_stacks: Mutex::new(Vec::new()),
+                unstacked: Mutex::new(Vec::new()),
+                next_stack_number: Mutex::new(500),
             }
         }
 
@@ -1118,6 +1334,34 @@ mod tests {
 
         fn with_existing_comments(mut self, pr_number: u64, comments: Vec<Comment>) -> Self {
             self.existing_comments.insert(pr_number, comments);
+            self
+        }
+
+        fn with_existing_stack(mut self, number: u64, open_prs: &[u64]) -> Self {
+            self.existing_stacks.push(ForgeStack {
+                number,
+                open_pr_numbers: open_prs.to_vec(),
+            });
+            self
+        }
+
+        fn with_stacks_unavailable(mut self) -> Self {
+            self.stacks_unavailable = true;
+            self
+        }
+
+        fn with_add_conflict(mut self) -> Self {
+            self.add_conflicts = true;
+            self
+        }
+
+        fn with_probe_unsupported(mut self) -> Self {
+            self.probe_supported = Some(false);
+            self
+        }
+
+        fn with_probe_error(mut self) -> Self {
+            self.probe_supported = None;
             self
         }
     }
@@ -1245,6 +1489,93 @@ mod tests {
         ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send {
             self.deleted_comments.lock().unwrap().push(comment_id);
             async { Ok(()) }
+        }
+
+        fn get_stacks_for_pr(
+            &self,
+            pr_number: u64,
+        ) -> impl std::future::Future<Output = Result<Vec<ForgeStack>, ForgeError>> + Send {
+            self.stack_lookups.lock().unwrap().push(pr_number);
+            let result = if self.stacks_unavailable {
+                Err(ForgeError::StacksUnavailable {
+                    message: "not enabled".to_string(),
+                    source: "test".to_string().into(),
+                })
+            } else {
+                // Snapshot semantics: the reconcile queries before mutating,
+                // so fixture stacks need not reflect later mutations.
+                Ok(self
+                    .existing_stacks
+                    .iter()
+                    .filter(|s| s.open_pr_numbers.contains(&pr_number))
+                    .cloned()
+                    .collect())
+            };
+            async move { result }
+        }
+
+        fn create_stack(
+            &self,
+            pr_numbers: &[u64],
+        ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send {
+            let mut counter = self.next_stack_number.lock().unwrap();
+            let number = *counter;
+            *counter += 1;
+            drop(counter);
+            let stack = ForgeStack {
+                number,
+                open_pr_numbers: pr_numbers.to_vec(),
+            };
+            self.created_stacks
+                .lock()
+                .unwrap()
+                .push(pr_numbers.to_vec());
+            async move { Ok(stack) }
+        }
+
+        fn add_to_stack(
+            &self,
+            stack_number: u64,
+            pr_numbers: &[u64],
+        ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send {
+            let result = if self.add_conflicts {
+                Err(ForgeError::StackConflict {
+                    message: "conflict".to_string(),
+                    source: "test".to_string().into(),
+                })
+            } else {
+                self.added_to_stacks
+                    .lock()
+                    .unwrap()
+                    .push((stack_number, pr_numbers.to_vec()));
+                Ok(ForgeStack {
+                    number: stack_number,
+                    open_pr_numbers: pr_numbers.to_vec(),
+                })
+            };
+            async move { result }
+        }
+
+        fn unstack(
+            &self,
+            stack_number: u64,
+        ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send {
+            self.unstacked.lock().unwrap().push(stack_number);
+            async { Ok(()) }
+        }
+
+        fn supports_native_stacks(
+            &self,
+        ) -> impl std::future::Future<Output = Result<bool, ForgeError>> + Send {
+            *self.probe_calls.lock().unwrap() += 1;
+            let result = match self.probe_supported {
+                Some(supported) => Ok(supported),
+                None => Err(ForgeError::Api {
+                    message: "probe failed".to_string(),
+                    source: "test".to_string().into(),
+                }),
+            };
+            async move { result }
         }
     }
 
@@ -1946,9 +2277,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 2);
 
@@ -1985,9 +2323,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated = forge.updated_bases.lock().unwrap();
         assert_eq!(updated.len(), 1);
@@ -2033,9 +2378,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let comments = forge.created_comments.lock().unwrap();
         // One stack comment per PR.
@@ -2120,9 +2472,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Should have updated the existing comment on PR #50, not created a
         // new one. A new comment is created for the second PR.
@@ -2173,9 +2532,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let calls = push_calls.lock().unwrap();
         assert_eq!(calls.len(), 2);
@@ -2235,9 +2601,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let created = forge.created_prs.lock().unwrap();
         assert_eq!(created.len(), 1);
@@ -2269,9 +2642,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert_eq!(updated_titles.len(), 1);
@@ -2307,9 +2687,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert_eq!(updated_titles[0], (42, "title only".to_string()));
@@ -2344,9 +2731,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert!(updated_titles.is_empty());
@@ -2391,9 +2785,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Body sync is skipped in the per-bookmark loop when body-mode is
         // active — the fence-splicing phase handles it in a single API call.
@@ -2779,9 +3180,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 2);
@@ -2843,9 +3251,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 2);
@@ -2940,9 +3355,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Should have written body for both PRs.
         let updated_bodies = forge.updated_bodies.lock().unwrap();
@@ -3000,9 +3422,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Should have created comments for both PRs.
         let created_comments = forge.created_comments.lock().unwrap();
@@ -3049,9 +3478,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 1);
 
@@ -3129,9 +3565,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Old stack comment should be deleted.
         let deleted = forge.deleted_comments.lock().unwrap();
@@ -3171,9 +3614,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Body fence should be stripped.
         let updated_bodies = forge.updated_bodies.lock().unwrap();
@@ -3233,9 +3683,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 2);
 
@@ -3336,9 +3793,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // Old stack comment on PR #50 should be deleted.
         let deleted = forge.deleted_comments.lock().unwrap();
@@ -3417,9 +3881,16 @@ mod tests {
         );
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Ignore)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Ignore,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         // The submission itself runs normally...
         assert_eq!(result.stack_entries.len(), 2);
@@ -3466,12 +3937,592 @@ mod tests {
         );
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Ignore)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Ignore,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         assert!(forge.deleted_comments.lock().unwrap().is_empty());
         assert!(forge.listed_comments.lock().unwrap().is_empty());
+    }
+
+    // -- auto placements & native_stacks auto --
+
+    async fn run_with(
+        plan: &SubmissionPlan,
+        forge: &MockForge,
+        placement: StackPlacement,
+        native: NativeStacks,
+    ) -> SubmissionResult {
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let env = test_comment_env();
+        execute_submission_plan(plan, &jj, forge, &env, placement, native)
+            .await
+            .unwrap()
+    }
+
+    /// Two-bookmark all-create plan shared by the auto tests.
+    fn two_create_plan() -> SubmissionPlan {
+        SubmissionPlan {
+            bookmark_plans: vec![
+                BookmarkPlan {
+                    bookmark_name: "feat-a".to_string(),
+                    base: "main".to_string(),
+                    title: "feature a".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+                BookmarkPlan {
+                    bookmark_name: "feat-b".to_string(),
+                    base: "feat-a".to_string(),
+                    title: "feature b".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+            ],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_auto_comment_native_off_writes_comments_without_probe() {
+        let plan = two_create_plan();
+        let forge = MockForge::new();
+
+        run_with(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Off,
+        )
+        .await;
+
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert_eq!(*forge.probe_calls.lock().unwrap(), 0);
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_auto_comment_native_auto_supported_cleans_up_and_reconciles() {
+        let plan = two_create_plan();
+        let forge = MockForge::new(); // probe: supported by default
+
+        run_with(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Auto,
+        )
+        .await;
+
+        // Native in effect: no comments, stack reconciled.
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![100, 101]]);
+        assert_eq!(*forge.probe_calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_auto_comment_native_auto_unsupported_writes_comments() {
+        let plan = two_create_plan();
+        let forge = MockForge::new().with_probe_unsupported();
+
+        run_with(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Auto,
+        )
+        .await;
+
+        // Fallback rendering: comments written, no stack API traffic beyond
+        // the probe.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert_eq!(*forge.probe_calls.lock().unwrap(), 1);
+        assert!(forge.stack_lookups.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_auto_comment_probe_error_behaves_like_ignore() {
+        // PR #50 carries a stale stack comment; an indeterminate probe must
+        // neither write nor remove anything, and must not fail the submit.
+        let plan = SubmissionPlan {
+            bookmark_plans: vec![
+                BookmarkPlan {
+                    bookmark_name: "feat-a".to_string(),
+                    base: "main".to_string(),
+                    title: "feature a".to_string(),
+                    body: None,
+                    existing_pr: Some(make_pr(50, "feat-a", "main")),
+                    needs_push: true,
+                    needs_create: false,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+                BookmarkPlan {
+                    bookmark_name: "feat-b".to_string(),
+                    base: "feat-a".to_string(),
+                    title: "feature b".to_string(),
+                    body: None,
+                    existing_pr: None,
+                    needs_push: true,
+                    needs_create: true,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+            ],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+        let forge = MockForge::new().with_probe_error().with_existing_comments(
+            50,
+            vec![Comment {
+                id: 999,
+                body: "<!--- STAKK_STACK: e30= --->\nold stack comment".to_string(),
+            }],
+        );
+
+        let result = run_with(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Auto,
+        )
+        .await;
+
+        assert_eq!(result.stack_entries.len(), 2);
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+        assert!(forge.deleted_comments.lock().unwrap().is_empty());
+        assert!(forge.updated_bodies.lock().unwrap().is_empty());
+        assert!(forge.listed_comments.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_auto_body_native_off_splices_fence() {
+        let plan = two_create_plan();
+        let forge = MockForge::new();
+
+        run_with(&plan, &forge, StackPlacement::AutoBody, NativeStacks::Off).await;
+
+        // Resolves to body mode: fences spliced into both PR bodies.
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(updated_bodies.len(), 2);
+        assert!(updated_bodies[0].1.contains("STAKK_BODY_START"));
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_auto_body_native_on_syncs_body_in_loop() {
+        // Native in effect resolves auto-body to cleanup, so a pending body
+        // sync must not be deferred to the (never-running) splice phase.
+        let mut plan = two_create_plan();
+        plan.bookmark_plans[0].existing_pr = Some(make_pr(50, "feat-a", "main"));
+        plan.bookmark_plans[0].needs_create = false;
+        plan.bookmark_plans[0].needs_body_sync = true;
+        plan.bookmark_plans[0].body = Some("new body".to_string());
+        let forge = MockForge::new();
+
+        run_with(&plan, &forge, StackPlacement::AutoBody, NativeStacks::On).await;
+
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(*updated_bodies, vec![(50, "new body".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_auto_unsupported_skips_reconcile() {
+        let plan = two_create_plan();
+        let forge = MockForge::new().with_probe_unsupported();
+
+        run_with(&plan, &forge, StackPlacement::Comment, NativeStacks::Auto).await;
+
+        // Fixed placement unaffected; reconcile silently skipped.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert!(forge.stack_lookups.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_auto_supported_reconciles() {
+        let plan = two_create_plan();
+        let forge = MockForge::new();
+
+        run_with(&plan, &forge, StackPlacement::Comment, NativeStacks::Auto).await;
+
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![100, 101]]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_auto_single_bookmark_fixed_placement_skips_probe() {
+        let plan = SubmissionPlan {
+            bookmark_plans: vec![BookmarkPlan {
+                bookmark_name: "feat-a".to_string(),
+                base: "main".to_string(),
+                title: "feature a".to_string(),
+                body: None,
+                existing_pr: None,
+                needs_push: true,
+                needs_create: true,
+                needs_base_update: false,
+                needs_title_sync: false,
+                needs_body_sync: false,
+            }],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+        let forge = MockForge::new();
+
+        run_with(&plan, &forge, StackPlacement::Comment, NativeStacks::Auto).await;
+
+        // The probe's answer would never be consulted — no wasted API call.
+        assert_eq!(*forge.probe_calls.lock().unwrap(), 0);
+    }
+
+    // -- native stacks --
+
+    /// A bookmark plan that pushes and either reuses `existing` or creates.
+    fn make_native_bookmark_plan(
+        name: &str,
+        base: &str,
+        existing: Option<PullRequest>,
+    ) -> BookmarkPlan {
+        BookmarkPlan {
+            bookmark_name: name.to_string(),
+            base: base.to_string(),
+            title: format!("title {name}"),
+            body: None,
+            needs_create: existing.is_none(),
+            existing_pr: existing,
+            needs_push: true,
+            needs_base_update: false,
+            needs_title_sync: false,
+            needs_body_sync: false,
+        }
+    }
+
+    fn make_native_plan(bookmark_plans: Vec<BookmarkPlan>) -> SubmissionPlan {
+        SubmissionPlan {
+            bookmark_plans,
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        }
+    }
+
+    /// Run with native stacks on and `none` placement (the closest analog
+    /// to the typical native configuration).
+    async fn run_native(plan: &SubmissionPlan, forge: &MockForge) -> SubmissionResult {
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let env = test_comment_env();
+        execute_submission_plan(
+            plan,
+            &jj,
+            forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::On,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn execute_native_on_is_independent_of_comment_placement() {
+        // native_stacks is orthogonal to stack placement: with comment
+        // placement, both the stack comments and the server-side stack are
+        // written.
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", None),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new();
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let env = test_comment_env();
+
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::On,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![100, 101]]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_creates_stack_when_none_exists() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", None),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+            make_native_bookmark_plan("feat-c", "feat-b", None),
+        ]);
+        let forge = MockForge::new();
+
+        let result = run_native(&plan, &forge).await;
+
+        assert_eq!(result.stack_entries.len(), 3);
+        // Mock-created PRs number from 100; the stack is created from the
+        // submitted PRs bottom-to-top.
+        let created_stacks = forge.created_stacks.lock().unwrap();
+        assert_eq!(*created_stacks, vec![vec![100, 101, 102]]);
+        // Every desired PR is queried for existing stack membership.
+        let lookups = forge.stack_lookups.lock().unwrap();
+        assert_eq!(*lookups, vec![100, 101, 102]);
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_noop_when_stack_matches() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main"))),
+            make_native_bookmark_plan("feat-b", "feat-a", Some(make_pr(51, "feat-b", "feat-a"))),
+        ]);
+        let forge = MockForge::new().with_existing_stack(500, &[50, 51]);
+
+        run_native(&plan, &forge).await;
+
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_adds_suffix_when_existing_stack_is_prefix() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main"))),
+            make_native_bookmark_plan("feat-b", "feat-a", Some(make_pr(51, "feat-b", "feat-a"))),
+            make_native_bookmark_plan("feat-c", "feat-b", None),
+        ]);
+        let forge = MockForge::new().with_existing_stack(500, &[50, 51]);
+
+        run_native(&plan, &forge).await;
+
+        // The new PR (100) is appended on top of the existing stack.
+        let added = forge.added_to_stacks.lock().unwrap();
+        assert_eq!(*added, vec![(500, vec![100])]);
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_recreates_stack_on_membership_mismatch() {
+        // Server has the same PRs in the opposite order (a stack reorder).
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main"))),
+            make_native_bookmark_plan("feat-b", "feat-a", Some(make_pr(51, "feat-b", "feat-a"))),
+        ]);
+        let forge = MockForge::new().with_existing_stack(500, &[51, 50]);
+
+        run_native(&plan, &forge).await;
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![500]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![50, 51]]);
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_recreates_stack_when_multiple_stacks_found() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main"))),
+            make_native_bookmark_plan("feat-b", "feat-a", Some(make_pr(51, "feat-b", "feat-a"))),
+        ]);
+        let forge = MockForge::new()
+            .with_existing_stack(500, &[50])
+            .with_existing_stack(501, &[51]);
+
+        run_native(&plan, &forge).await;
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![500, 501]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![50, 51]]);
+    }
+
+    #[tokio::test]
+    async fn reconcile_recreates_stack_with_foreign_member() {
+        // The existing stack holds a PR that is not part of the submission;
+        // desired is not a prefix-extension of it, so it is rebuilt.
+        let forge = MockForge::new().with_existing_stack(500, &[999, 50, 51]);
+        let pb = indicatif::ProgressBar::hidden();
+
+        reconcile_native_stack(&forge, &[50, 51], &pb)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![500]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![50, 51]]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_add_conflict_falls_back_to_recreate() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main"))),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new()
+            .with_existing_stack(500, &[50])
+            .with_add_conflict();
+
+        run_native(&plan, &forge).await;
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![500]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![50, 100]]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_cleans_up_existing_artifacts() {
+        use crate::forge::comment::splice_stack_into_body;
+
+        // PR #50 carries both an old stack comment and a body fence from a
+        // previous comment/body-mode submit.
+        let body_with_fence = splice_stack_into_body("Original PR body", "old stack content");
+        let old_comment_body = "<!--- STAKK_STACK: e30= --->\nold stack comment".to_string();
+
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan(
+                "feat-a",
+                "main",
+                Some(make_pr_with_body(50, "feat-a", "main", &body_with_fence)),
+            ),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new()
+            .with_existing_comments(
+                50,
+                vec![Comment {
+                    id: 999,
+                    body: old_comment_body,
+                }],
+            )
+            .with_existing_stack(500, &[50, 100]);
+
+        run_native(&plan, &forge).await;
+
+        // Old stack comment deleted and body fence stripped, like `none`.
+        assert_eq!(*forge.deleted_comments.lock().unwrap(), vec![999]);
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(updated_bodies.len(), 1);
+        assert!(!updated_bodies[0].1.contains("STAKK_BODY_START"));
+        // The server-side stack already matches — no mutation.
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_native_writes_no_comments_or_bodies() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", None),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new();
+
+        run_native(&plan, &forge).await;
+
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+        assert!(forge.updated_comments.lock().unwrap().is_empty());
+        assert!(forge.updated_bodies.lock().unwrap().is_empty());
+        // Freshly created PRs carry no artifacts — no lookups either.
+        assert!(forge.listed_comments.lock().unwrap().is_empty());
+        // But the stack is reconciled.
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![100, 101]]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_single_bookmark_skips_stack_api() {
+        let plan = make_native_plan(vec![make_native_bookmark_plan(
+            "feat-a",
+            "main",
+            Some(make_pr(50, "feat-a", "main")),
+        )]);
+        let forge = MockForge::new().with_existing_stack(500, &[50, 51]);
+
+        run_native(&plan, &forge).await;
+
+        // A single PR is not a stack: no stack API traffic at all, even
+        // though the server holds a stale stack containing the PR.
+        assert!(forge.stack_lookups.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+        // Artifact cleanup still runs on the pre-existing PR.
+        assert_eq!(*forge.listed_comments.lock().unwrap(), vec![50]);
+    }
+
+    #[tokio::test]
+    async fn execute_native_stacks_unavailable_surfaces_diagnostic() {
+        let plan = make_native_plan(vec![
+            make_native_bookmark_plan("feat-a", "main", None),
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new().with_stacks_unavailable();
+        let (runner, push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let env = test_comment_env();
+
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::On,
+        )
+        .await;
+
+        assert!(matches!(result, Err(SubmitError::StacksUnavailable { .. })));
+        // The submission itself completed before the reconcile failed.
+        assert_eq!(forge.created_prs.lock().unwrap().len(), 2);
+        assert_eq!(push_calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn execute_native_body_sync_not_deferred() {
+        // Unlike body mode, native placement has no fence-splicing phase to
+        // fold the body sync into — it must happen in the per-bookmark loop.
+        let mut bp =
+            make_native_bookmark_plan("feat-a", "main", Some(make_pr(50, "feat-a", "main")));
+        bp.needs_body_sync = true;
+        bp.body = Some("new body".to_string());
+        let plan = make_native_plan(vec![
+            bp,
+            make_native_bookmark_plan("feat-b", "feat-a", None),
+        ]);
+        let forge = MockForge::new().with_existing_stack(500, &[50, 100]);
+
+        run_native(&plan, &forge).await;
+
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(*updated_bodies, vec![(50, "new body".to_string())]);
     }
 
     #[tokio::test]
@@ -3519,9 +4570,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -3595,9 +4653,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -3658,9 +4723,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Off,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(


### PR DESCRIPTION
feat(cli): default `--stack-placement` to `auto-comment`

`auto-comment` is behaviorally identical to `comment` while `--native-stacks` is `off` (the default): no probe fires and stack comments are written as before, so this changes nothing for existing configurations. It positions the defaults so that enabling native stacks — per invocation today, or via a future `--native-stacks` default flip to `auto` at GA — automatically retires the now-redundant stack comments without a coordinated placement change. An explicit `comment`/`body` choice is never overridden.

The `--native-stacks` docs now note that its default may change to `auto` once GitHub's stacked pull requests reach general availability.

---

feat(forge): integrate GitHub's native stacked pull requests (`--native-stacks`)

Adds `--native-stacks <off|on|auto>` (env: STAKK_NATIVE_STACKS, config: `native_stacks`, default `off`), which registers submitted stacks with GitHub's server-side stacked-pull-requests feature (public preview) after the execute phase — orthogonal to `--stack-placement`, since registering the stack and placing stakk's stack-info text are independent decisions.

The reconcile converges idempotently via new `Forge` primitives (`get_stacks_for_pr`, `create_stack`, `add_to_stack`, `unstack`): it queries every submitted PR for existing stack membership, then no-ops on exact match, appends via `/add` when the server stack is a bottom-prefix, and dissolves-and-recreates on anything else (reorders, foreign members, multiple stacks). Comparison uses open PRs only, so merged bottoms drop out naturally. Single-bookmark submissions skip the stack API entirely. With `on`, reconcile failures fail the submit with diagnostics stating that branches and PRs were submitted normally and re-running is safe; a repository without the feature gets a dedicated `stacks_unavailable` diagnostic.

With `auto`, the repository is probed once per submit (`Forge::supports_native_stacks`, `GET /stacks?per_page=1` — 200 means supported, 404 means not enabled, other errors are indeterminate) and repositories without the feature are skipped silently. The probe is skipped when its answer would never be consulted (single bookmark with a fixed placement).

New placements `auto-comment`/`auto-body` defer to native stacks: when a native stack is in effect they behave like `none` (retiring stakk's artifacts), otherwise like `comment`/`body`. An indeterminate probe resolves them to `ignore` for the run — only a definitive answer may trigger the destructive direction. `native_stacks = auto` + `stack_placement = auto-comment` is the intended zero-config end state once the feature reaches GA: native rendering where enabled, stack comments everywhere else, never both.

`GitHubForge` carries a second octocrab client solely to send the `x-github-api-version: 2026-03-10` header the stack routes require (octocrab sends no version header by default). The endpoints have no typed octocrab support yet, so calls go through octocrab's generic typed `get`/`post` with stakk-defined serde DTOs; `unstack` alone uses the raw `_post` (204 has no body) and reinstates `octocrab::map_github_error` manually.

Documents the new surface in the README (feature bullets, `stakk.toml` example, environment-variable and flag tables, submit prose) and in the CLAUDE.md gotchas and Key Decisions.