### PR TITLE
fix: submit all bookmarked ancestors when a bookmark is passed explicitly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,11 @@ following, update `scripts/record-demo.py` in the same change:
   bookmark names from jj log — unlike `BookmarkSegment::bookmark_names`,
   it includes bookmarks the bookmarks revset excluded (e.g. on immutable
   commits). Used to diagnose excluded selections and label locked TUI rows.
+- `analyze_submission` takes `Option<&HashSet<String>>` for the selection.
+  `None` is the explicit `stakk submit <bookmark>` path: every boundary from
+  trunk through the target is submitted as its own stacked PR — no folding
+  (issue #184). Only the interactive TUI passes `Some(...)`, where unselected
+  segments fold into the next selected one.
 - `analyze_submission` errors (`stakk::submit::selected_bookmarks_excluded`)
   when a selected bookmark is a boundary in no segment of the target stack,
   instead of silently folding it away. The intentional fold for

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,11 +158,12 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
     // Resolve bookmark: explicit argument or interactive selection.
     pb.finish_and_clear();
 
+    // `selected_bookmarks` is `None` for an explicit bookmark argument: the
+    // target and all its bookmarked ancestors are submitted as stacked PRs.
+    // The interactive TUI yields an explicit set so deliberately unchecked
+    // bookmarks fold into the next selected segment.
     let (bookmark, change_graph, selected_bookmarks) = match &args.bookmark {
-        Some(name) => {
-            let selected = HashSet::from([name.clone()]);
-            (name.clone(), change_graph, selected)
-        }
+        Some(name) => (name.clone(), change_graph, None),
         None => match select::resolve_bookmark_interactively(
             &change_graph,
             args.bookmark_command.as_deref(),
@@ -216,7 +217,7 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
                     change_graph
                 };
 
-                (leaf_bookmark, graph, selected)
+                (leaf_bookmark, graph, Some(selected))
             }
             None => return Ok(()),
         },
@@ -230,7 +231,7 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
         &bookmark,
         &change_graph,
         &default_branch,
-        &selected_bookmarks,
+        selected_bookmarks.as_ref(),
     )?;
 
     // Phase 2: Plan.

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -266,11 +266,17 @@ pub struct SubmissionResult {
 ///
 /// Locates the stack containing `target_bookmark` in the change graph and
 /// returns all segments from trunk to the target (inclusive).
+///
+/// `selected_bookmarks` controls which segment boundaries survive as their
+/// own PR: segments whose bookmarks are all unselected fold their commits
+/// into the next selected segment. `None` selects every boundary — the
+/// explicit `stakk submit <bookmark>` path, where the whole ancestor chain
+/// is submitted as stacked PRs.
 pub fn analyze_submission(
     target_bookmark: &str,
     change_graph: &ChangeGraph,
     default_branch: &str,
-    selected_bookmarks: &HashSet<String>,
+    selected_bookmarks: Option<&HashSet<String>>,
 ) -> Result<SubmissionAnalysis, SubmitError> {
     let stack = change_graph
         .stacks
@@ -294,10 +300,11 @@ pub fn analyze_submission(
     let mut accumulated_commits: Vec<SegmentCommit> = Vec::new();
 
     for seg in &stack.segments[..=target_index] {
-        let is_selected = seg
-            .bookmark_names
-            .iter()
-            .any(|name| selected_bookmarks.contains(name));
+        let is_selected = selected_bookmarks.is_none_or(|selected| {
+            seg.bookmark_names
+                .iter()
+                .any(|name| selected.contains(name))
+        });
 
         if is_selected {
             let mut commits = seg.commits.clone();
@@ -319,31 +326,33 @@ pub fn analyze_submission(
     // it away would submit fewer PRs than the user selected. Selected names
     // above the target are fine: they're boundaries, just not part of this
     // submission.
-    let known: HashSet<&str> = stack
-        .segments
-        .iter()
-        .flat_map(|s| &s.bookmark_names)
-        .map(String::as_str)
-        .collect();
-    let mut missing: Vec<String> = selected_bookmarks
-        .iter()
-        .filter(|name| !known.contains(name.as_str()))
-        .cloned()
-        .collect();
-    if !missing.is_empty() {
-        missing.sort_unstable();
-        let immutable: Vec<String> = missing
+    if let Some(selected) = selected_bookmarks {
+        let known: HashSet<&str> = stack
+            .segments
             .iter()
-            .filter(|name| {
-                stack
-                    .segments
-                    .iter()
-                    .flat_map(|s| &s.commits)
-                    .any(|c| c.is_immutable && c.local_bookmark_names.contains(name))
-            })
+            .flat_map(|s| &s.bookmark_names)
+            .map(String::as_str)
+            .collect();
+        let mut missing: Vec<String> = selected
+            .iter()
+            .filter(|name| !known.contains(name.as_str()))
             .cloned()
             .collect();
-        return Err(SubmitError::SelectedBookmarksExcluded { missing, immutable });
+        if !missing.is_empty() {
+            missing.sort_unstable();
+            let immutable: Vec<String> = missing
+                .iter()
+                .filter(|name| {
+                    stack
+                        .segments
+                        .iter()
+                        .flat_map(|s| &s.commits)
+                        .any(|c| c.is_immutable && c.local_bookmark_names.contains(name))
+                })
+                .cloned()
+                .collect();
+            return Err(SubmitError::SelectedBookmarksExcluded { missing, immutable });
+        }
     }
 
     Ok(SubmissionAnalysis {
@@ -1291,8 +1300,7 @@ mod tests {
             segments: vec![seg],
         }]);
 
-        let all = HashSet::from(["feat-a".to_string()]);
-        let result = analyze_submission("feat-a", &graph, "main", &all).unwrap();
+        let result = analyze_submission("feat-a", &graph, "main", None).unwrap();
         assert_eq!(result.segments.len(), 1);
         assert_eq!(result.segments[0].bookmark_names, vec!["feat-a"]);
 
@@ -1308,12 +1316,7 @@ mod tests {
             segments: vec![seg_a, seg_b, seg_c],
         }]);
 
-        let all = HashSet::from([
-            "feat-a".to_string(),
-            "feat-b".to_string(),
-            "feat-c".to_string(),
-        ]);
-        let result = analyze_submission("feat-b", &graph, "main", &all).unwrap();
+        let result = analyze_submission("feat-b", &graph, "main", None).unwrap();
         assert_eq!(result.segments.len(), 2);
         assert_eq!(result.segments[0].bookmark_names, vec!["feat-a"]);
         assert_eq!(result.segments[1].bookmark_names, vec!["feat-b"]);
@@ -1327,8 +1330,7 @@ mod tests {
             segments: vec![seg_a, seg_b],
         }]);
 
-        let all = HashSet::from(["feat-a".to_string(), "feat-b".to_string()]);
-        let result = analyze_submission("feat-b", &graph, "main", &all).unwrap();
+        let result = analyze_submission("feat-b", &graph, "main", None).unwrap();
         assert_eq!(result.segments.len(), 2);
     }
 
@@ -1339,8 +1341,7 @@ mod tests {
             segments: vec![seg],
         }]);
 
-        let all = HashSet::from(["nonexistent".to_string()]);
-        let result = analyze_submission("nonexistent", &graph, "main", &all);
+        let result = analyze_submission("nonexistent", &graph, "main", None);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -1362,8 +1363,7 @@ mod tests {
         };
         let graph = make_graph(vec![stack1, stack2]);
 
-        let all = HashSet::from(["beta".to_string(), "gamma".to_string()]);
-        let result = analyze_submission("gamma", &graph, "main", &all).unwrap();
+        let result = analyze_submission("gamma", &graph, "main", None).unwrap();
         assert_eq!(result.segments.len(), 2);
         assert_eq!(result.segments[0].bookmark_names, vec!["beta"]);
         assert_eq!(result.segments[1].bookmark_names, vec!["gamma"]);
@@ -1381,7 +1381,7 @@ mod tests {
         // Only select the leaf — intermediate bookmarks should be excluded,
         // but their commits fold into the next retained segment.
         let selected = HashSet::from(["feat-c".to_string()]);
-        let result = analyze_submission("feat-c", &graph, "main", &selected).unwrap();
+        let result = analyze_submission("feat-c", &graph, "main", Some(&selected)).unwrap();
         assert_eq!(result.segments.len(), 1);
         assert_eq!(result.segments[0].bookmark_names, vec!["feat-c"]);
         assert_eq!(result.segments[0].commits.len(), 3); // C's own + B's + A's
@@ -1399,7 +1399,7 @@ mod tests {
         // Select first and last — middle should be excluded,
         // and middle's commits fold into the next retained segment.
         let selected = HashSet::from(["feat-a".to_string(), "feat-c".to_string()]);
-        let result = analyze_submission("feat-c", &graph, "main", &selected).unwrap();
+        let result = analyze_submission("feat-c", &graph, "main", Some(&selected)).unwrap();
         assert_eq!(result.segments.len(), 2);
         assert_eq!(result.segments[0].bookmark_names, vec!["feat-a"]);
         assert_eq!(result.segments[0].commits.len(), 1); // A's own only
@@ -1422,7 +1422,7 @@ mod tests {
         }]);
 
         let selected = HashSet::from(["feat-b".to_string(), "ghost".to_string()]);
-        let result = analyze_submission("feat-b", &graph, "main", &selected);
+        let result = analyze_submission("feat-b", &graph, "main", Some(&selected));
         match result {
             Err(SubmitError::SelectedBookmarksExcluded { missing, immutable }) => {
                 assert_eq!(missing, vec!["ghost"]);
@@ -1442,7 +1442,7 @@ mod tests {
         }]);
 
         let selected = HashSet::from(["feat-a".to_string(), "vanished".to_string()]);
-        let result = analyze_submission("feat-a", &graph, "main", &selected);
+        let result = analyze_submission("feat-a", &graph, "main", Some(&selected));
         match result {
             Err(SubmitError::SelectedBookmarksExcluded { missing, immutable }) => {
                 assert_eq!(missing, vec!["vanished"]);
@@ -1452,10 +1452,10 @@ mod tests {
         }
     }
 
-    /// The explicit `--bookmark <name>` path (selected == {target}) can never
-    /// trigger the excluded-bookmarks guard.
+    /// An interactive selection of only the target (selected == {target})
+    /// can never trigger the excluded-bookmarks guard.
     #[test]
-    fn analyze_explicit_single_bookmark_never_triggers_guard() {
+    fn analyze_selected_single_bookmark_never_triggers_guard() {
         let seg_a = make_segment(&["feat-a"], "ch_a", "feature a");
         let seg_b = make_segment(&["feat-b"], "ch_b", "feature b");
         let graph = make_graph(vec![BranchStack {
@@ -1463,9 +1463,33 @@ mod tests {
         }]);
 
         let selected = HashSet::from(["feat-b".to_string()]);
-        let result = analyze_submission("feat-b", &graph, "main", &selected).unwrap();
+        let result = analyze_submission("feat-b", &graph, "main", Some(&selected)).unwrap();
         assert_eq!(result.segments.len(), 1);
         assert_eq!(result.segments[0].bookmark_names, vec!["feat-b"]);
+    }
+
+    /// Regression test for <https://github.com/glennib/stakk/issues/184>:
+    /// `stakk submit <leaf>` (no interactive selection) must submit the leaf
+    /// and every bookmarked ancestor as separate stacked segments, not fold
+    /// the ancestors into one cumulative leaf PR.
+    #[test]
+    fn analyze_explicit_target_submits_all_ancestors() {
+        let seg_a = make_segment(&["feat-a"], "ch_a", "feature a");
+        let seg_b = make_segment(&["feat-b"], "ch_b", "feature b");
+        let seg_c = make_segment(&["feat-c"], "ch_c", "feature c");
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![seg_a, seg_b, seg_c],
+        }]);
+
+        let result = analyze_submission("feat-c", &graph, "main", None).unwrap();
+        assert_eq!(result.segments.len(), 3);
+        assert_eq!(result.segments[0].bookmark_names, vec!["feat-a"]);
+        assert_eq!(result.segments[1].bookmark_names, vec!["feat-b"]);
+        assert_eq!(result.segments[2].bookmark_names, vec!["feat-c"]);
+        // No folding: each segment keeps exactly its own commit.
+        for seg in &result.segments {
+            assert_eq!(seg.commits.len(), 1);
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
`stakk submit <bookmark>` selected only the target bookmark, so every bookmarked ancestor segment folded into it and the plan produced one cumulative PR targeting the default branch — contradicting the documented behavior of submitting the bookmark *and its ancestors* as stacked PRs. Regressed in 50c700ff (v1.6.1), which introduced selection filtering for the interactive TUI and reused it for the explicit path with a singleton set.

`analyze_submission` now takes `Option<&HashSet<String>>`:

- `None` — the explicit-argument path: every segment boundary from trunk through the target survives as its own stacked PR, and the `SelectedBookmarksExcluded` guard is skipped (there is no user selection to lose).
- `Some(set)` — the interactive TUI path: unchanged fold semantics for deliberately unchecked rows.

Adds a regression test covering the explicit three-bookmark stack.

Fixes #184