### PR TITLE
feat(cli): non-interactive stack selection via --keep/--new flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ src/
 │   ├── app.rs       # App state machine, event loop, terminal init
 │   ├── graph_widget.rs  # Screen 1: jj-log-style graph widget (leaf selection, collapsing, scrolling)
 │   ├── bookmark_widget.rs # Screen 2: bookmark toggle/assignment widget
+│   ├── explicit.rs  # Non-interactive selection via --keep/--keep-all/--new/--new-auto/--new-command
 │   ├── bookmark_gen.rs # Bookmark validation and external command execution
 │   ├── tfidf.rs     # TF-IDF algorithm for auto-generated bookmark names
 │   └── event.rs     # crossterm key event mapping to app actions
@@ -337,10 +338,24 @@ following, update `scripts/record-demo.py` in the same change:
 - Two phase-1 constructors: the positional `stakk submit <bookmark>` path
   uses `analyze_submission(..., None)` — every boundary from trunk through
   the target is its own stacked PR, no folding (issue #184). Selection-based
-  paths (the TUI) use `analysis_from_selection(path, assignments, ...)`:
+  paths (the TUI and the explicit flags via `select::explicit`) use
+  `analysis_from_selection(path, assignments, ...)`:
   boundaries are matched by change ID on the selected trunk→tip path, so new
   bookmarks need not exist yet and no graph rebuild happens; commits between
   boundaries fold into the boundary above.
+- Explicit selection (`select/explicit.rs`): `--keep`/`--keep-all`/`--new
+  REV[=NAME]`/`--new-auto REV`/`--new-command REV` marks fully determine the
+  PR set — nothing implicit. Revs prefix-match change/commit ids on the
+  graph (deduped by commit_id: shared segments cloned into several stacks
+  are one commit, not ambiguous); colinearity is validated by intersecting
+  per-mark containing-stack sets; the topmost mark is the tip. Bare
+  `--keep-all` needs the stacks to agree on their bookmarks; anchored, it
+  expands on the marked path, skipping commits with explicit marks
+  (explicit beats bulk). Errors are `stakk::selection::*` diagnostics
+  pointing at `stakk show`. Known limitation: the `name_exists` pre-check
+  sees only bookmarks on submittable stacks — a collision with any other
+  bookmark (e.g. trunk's `main`) surfaces at execution as
+  `stakk::submit::bookmark_create_failed`.
 - `analyze_submission`'s `Option<&HashSet<String>>` folding arm and its
   `stakk::submit::selected_bookmarks_excluded` guard are exercised only by
   tests now — production selection flows go through
@@ -373,6 +388,11 @@ following, update `scripts/record-demo.py` in the same change:
   be turned off cleanly. Deletion is not previewed by `--dry-run`, which
   returns before the execute phase.
 - **`--dry-run` not in env vars** — one-off decision, surprising as a default.
+- **Selection flags not in env vars/config** — `--keep`, `--keep-all`,
+  `--new`, `--new-auto`, `--new-command` are per-invocation decisions like
+  `--dry-run`; a persisted default would silently change what gets
+  submitted. CLI + README touchpoints only (deliberate exception to the
+  four-touchpoint rule).
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
 - **Three-phase submission** — analyze (pure) → plan (queries forge) →
   execute. All repo mutations (bookmark creation, pushes) live in execute,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,8 +212,9 @@ bookmark; UseGenerated skipped if it matches an existing one).
 
 A row is **locked** when `is_immutable && existing_bookmarks.is_empty()`
 (`BookmarkRow::is_locked()`): its commit is jj-immutable and carries no
-bookmark known to the graph, so any name assigned there would be filtered out
-by the bookmarks revset on the post-creation graph rebuild. Locked rows are
+bookmark known to the graph, so a bookmark created there would be filtered
+out by the default bookmarks revset (`~ immutable()`) on every subsequent
+run — stakk would create a PR it can never see or manage again. Locked rows are
 permanently `[ ]` Unchecked (dark gray) and render a hint —
 `(immutable — bookmark <names> excluded by --bookmarks-revset)` when the
 commit carries filtered-out bookmarks (`excluded_bookmarks`), else
@@ -333,16 +334,26 @@ following, update `scripts/record-demo.py` in the same change:
   bookmark names from jj log — unlike `BookmarkSegment::bookmark_names`,
   it includes bookmarks the bookmarks revset excluded (e.g. on immutable
   commits). Used to diagnose excluded selections and label locked TUI rows.
-- `analyze_submission` takes `Option<&HashSet<String>>` for the selection.
-  `None` is the explicit `stakk submit <bookmark>` path: every boundary from
-  trunk through the target is submitted as its own stacked PR — no folding
-  (issue #184). Only the interactive TUI passes `Some(...)`, where unselected
-  segments fold into the next selected one.
-- `analyze_submission` errors (`stakk::submit::selected_bookmarks_excluded`)
-  when a selected bookmark is a boundary in no segment of the target stack,
-  instead of silently folding it away. The intentional fold for
-  deliberately-unchecked rows is unaffected (unchecked names are never in
-  `selected_bookmarks`).
+- Two phase-1 constructors: the positional `stakk submit <bookmark>` path
+  uses `analyze_submission(..., None)` — every boundary from trunk through
+  the target is its own stacked PR, no folding (issue #184). Selection-based
+  paths (the TUI) use `analysis_from_selection(path, assignments, ...)`:
+  boundaries are matched by change ID on the selected trunk→tip path, so new
+  bookmarks need not exist yet and no graph rebuild happens; commits between
+  boundaries fold into the boundary above.
+- `analyze_submission`'s `Option<&HashSet<String>>` folding arm and its
+  `stakk::submit::selected_bookmarks_excluded` guard are exercised only by
+  tests now — production selection flows go through
+  `analysis_from_selection` instead.
+- New bookmarks are created by `execute_submission_plan`
+  (`SubmissionPlan::bookmark_creations`, before the push loop), not at
+  selection time — so `--dry-run` never mutates the repo and the plan
+  prints `Create bookmark <name> at <short_change_id>` lines instead.
+  Accepted limitation: nothing checks a new bookmark's name against the
+  bookmarks revset anymore (the old post-creation rebuild + excluded-guard
+  did, erroring after the bookmark was already created). Under a custom
+  `--bookmarks-revset` that excludes the new name, the submission succeeds
+  but subsequent runs will not see or manage that bookmark's PR.
 - Stack reorder safety: bookmarks must be pushed one-at-a-time with immediate
   base/PR updates. If all bookmarks are pushed before bases are updated, a PR
   whose head moved down the stack will have an empty diff (head is ancestor of
@@ -363,7 +374,9 @@ following, update `scripts/record-demo.py` in the same change:
   returns before the execute phase.
 - **`--dry-run` not in env vars** — one-off decision, surprising as a default.
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
-- **Three-phase submission** — analyze (pure) → plan (queries forge) → execute.
+- **Three-phase submission** — analyze (pure) → plan (queries forge) →
+  execute. All repo mutations (bookmark creation, pushes) live in execute,
+  so `--dry-run` — which returns after printing the plan — is fully inert.
 - **ratatui over inquire** — visual graph rendering, bookmark assignment TUI.
 - **minijinja for stack comments** — customizable templates, metadata outside template.
 - **Interleaved push+update** — `execute_submission_plan` processes each bookmark

--- a/README.md
+++ b/README.md
@@ -327,6 +327,11 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | Flag | Env var | Description |
 |------|--------|-------------|
 | `--dry-run` | | Show the submission plan without executing |
+| `--keep <bookmark>` | | Non-interactive: keep an existing bookmark as a PR boundary (repeatable) |
+| `--keep-all` | | Non-interactive: keep every existing bookmark on the selected path |
+| `--new <rev>[=<name>]` | | Non-interactive: new bookmark at `rev` — `stakk-<change_id>` by default, or `name` (repeatable) |
+| `--new-auto <rev>` | | Non-interactive: new TF-IDF-named bookmark at `rev`, honoring `--auto-prefix`; falls back to `stakk-<change_id>` when nothing can be derived or the name is taken (repeatable) |
+| `--new-command <rev>` | | Non-interactive: new bookmark at `rev` named by `--bookmark-command` (repeatable) |
 | `--draft` | `STAKK_DRAFT` | Create new PRs as drafts |
 | `--remote <name>` | `STAKK_REMOTE` | Push to a specific remote (default: `origin`) |
 | `--template <path>` | `STAKK_TEMPLATE` | Use a custom minijinja template for stack comments |
@@ -334,6 +339,38 @@ graph view, then assign bookmarks to any unmarked commits before submitting.
 | `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
 | `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
 | `--trailers <mode>` | `STAKK_TRAILERS` | Keep or strip git commit trailers in PR bodies: `keep` (default), `strip` |
+
+The selection flags (`--keep`, `--keep-all`, `--new`, `--new-auto`,
+`--new-command`) replace the TUI with a fully explicit, scriptable
+selection; they conflict with the positional bookmark argument and are
+deliberately CLI-only (no env vars, no config keys — like `--dry-run`,
+per-invocation decisions make surprising defaults). The marks fully
+determine the PR set: nothing is implicit. All marks must lie on one
+trunk-to-tip path, the topmost mark is the tip of the submission, and
+bookmarks on the path that are not kept fold into the PR above them.
+`rev` is a change id or commit id prefix as printed by `stakk show`.
+Bare `--keep-all` requires the choice of stack to be unambiguous — a
+single stack, or several that agree on their bookmarks (e.g. differing
+only in unbookmarked heads such as the working copy); anchor it with
+`--keep`/`--new` otherwise. Commits already carrying an explicit mark
+are skipped by `--keep-all` (explicit beats bulk).
+
+#### Agent / scripting usage
+
+Non-interactive submission is a two-command loop — discover, then submit.
+Everything `stakk submit` needs (change id prefixes, bookmark names) is in
+`stakk show`'s output:
+
+```console
+$ stakk show --format=json | jq '.stacks[0].segments[].commits[] | {short_change_id, description, local_bookmark_names}'
+$ stakk submit --keep base --new qzvs=my-feature --new-auto wmtk --dry-run
+$ stakk submit --keep base --new qzvs=my-feature --new-auto wmtk
+```
+
+`--dry-run` is fully inert: it prints the planned bookmark creations and
+PR actions without creating, pushing, or changing anything — safe for
+validation before the real run. Selection errors carry machine-readable
+diagnostic codes (`stakk::selection::*`) and point back at `stakk show`.
 
 PR titles come from the first line of the jj change description. PR bodies
 are populated from the full description (everything after the title line).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -43,7 +43,9 @@ pub struct Cli {
 pub enum Commands {
     /// Submit bookmarks as GitHub pull requests (default when no command
     /// given).
-    Submit(SubmitArgs),
+    // Boxed: SubmitArgs is by far the largest payload (clippy
+    // large_enum_variant).
+    Submit(Box<SubmitArgs>),
     /// Manage authentication.
     Auth(AuthArgs),
     /// Show repository status and bookmark stacks.
@@ -495,6 +497,85 @@ mod tests {
             }
             other => panic!("expected Show, got {other:?}"),
         }
+    }
+
+    // -- explicit selection flags --
+
+    #[test]
+    fn selection_flags_parse_and_accumulate() {
+        let cli = parse_with_config(
+            Config::default(),
+            &[
+                "stakk",
+                "submit",
+                "--keep",
+                "a",
+                "--keep",
+                "b",
+                "--keep-all",
+                "--new",
+                "r1=name1",
+                "--new",
+                "r2",
+                "--new-auto",
+                "r3",
+                "--new-command",
+                "r4",
+            ],
+        );
+        let args = submit_args(&cli);
+        assert_eq!(args.keep, vec!["a", "b"]);
+        assert!(args.keep_all);
+        assert_eq!(args.new, vec!["r1=name1", "r2"]);
+        assert_eq!(args.new_auto, vec!["r3"]);
+        assert_eq!(args.new_command, vec!["r4"]);
+    }
+
+    #[test]
+    fn selection_flags_conflict_with_positional_bookmark() {
+        use clap::error::ErrorKind;
+
+        for flag_args in [
+            vec!["--keep", "a"],
+            vec!["--keep-all"],
+            vec!["--new", "r"],
+            vec!["--new-auto", "r"],
+            vec!["--new-command", "r"],
+        ] {
+            let mut argv = vec!["stakk", "submit", "my-bookmark"];
+            argv.extend(&flag_args);
+            let cmd = apply_config_defaults(Config::default(), Cli::command());
+            let err = cmd.try_get_matches_from(argv).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                ErrorKind::ArgumentConflict,
+                "flags {flag_args:?} must conflict with the positional bookmark",
+            );
+        }
+    }
+
+    #[test]
+    fn selection_flags_parse_at_top_level() {
+        // The flattened no-subcommand form must accept the flags too.
+        let cli = parse_with_config(
+            Config::default(),
+            &["stakk", "--keep", "a", "--new", "r=n", "--keep-all"],
+        );
+        assert!(cli.command.is_none());
+        assert_eq!(cli.submit_args.keep, vec!["a"]);
+        assert_eq!(cli.submit_args.new, vec!["r=n"]);
+        assert!(cli.submit_args.keep_all);
+    }
+
+    #[test]
+    fn selection_flags_conflict_at_top_level() {
+        use clap::error::ErrorKind;
+
+        let cmd = apply_config_defaults(Config::default(), Cli::command());
+        let err = cmd
+            .try_get_matches_from(["stakk", "my-bookmark", "--keep", "a"])
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     // -- env var interaction --

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -75,14 +75,85 @@ impl std::fmt::Display for TrailerHandling {
 
 /// Arguments for the submit subcommand.
 #[derive(Debug, Args)]
+#[command(group = clap::ArgGroup::new("explicit_marks").multiple(true))]
 pub struct SubmitArgs {
     /// The bookmark to submit as a pull request. If omitted, shows an
-    /// interactive selection.
+    /// interactive selection (or uses the explicit selection flags
+    /// --keep/--keep-all/--new/--new-auto/--new-command, which conflict
+    /// with this argument).
+    #[arg(conflicts_with = "explicit_marks")]
     pub bookmark: Option<String>,
 
     /// Show what would be done without actually doing it.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Keep an existing bookmark as a PR boundary (repeatable).
+    ///
+    /// Non-interactive selection: the --keep/--keep-all/--new/--new-auto/
+    /// --new-command marks fully determine the PR set — nothing is
+    /// implicit. All marks must lie on one trunk-to-tip path; the topmost
+    /// mark is the tip of the submission. Bookmarks on the path that are
+    /// not kept fold into the PR above them.
+    ///
+    /// Run `stakk show` (or `stakk show --format=json`) to list stacks,
+    /// bookmarks, and change ids.
+    #[arg(
+        long,
+        value_name = "BOOKMARK",
+        group = "explicit_marks",
+        verbatim_doc_comment
+    )]
+    pub keep: Vec<String>,
+
+    /// Keep every existing bookmark on the selected path.
+    ///
+    /// With other marks, expands on the path they anchor; commits that
+    /// carry an explicit mark are skipped (explicit beats bulk). Alone,
+    /// it requires the choice of stack to be unambiguous: a single stack,
+    /// or several that agree on their bookmarks (e.g. differing only in
+    /// unbookmarked heads such as the working copy).
+    #[arg(long, group = "explicit_marks", verbatim_doc_comment)]
+    pub keep_all: bool,
+
+    /// Create a new bookmark at REV as a PR boundary (repeatable).
+    ///
+    /// REV is a change id or commit id prefix (as shown by `stakk show`).
+    /// Without =NAME the bookmark is named stakk-<change_id>; with =NAME
+    /// the given name is used.
+    #[arg(
+        long,
+        value_name = "REV[=NAME]",
+        group = "explicit_marks",
+        verbatim_doc_comment
+    )]
+    pub new: Vec<String>,
+
+    /// Create a new auto-named bookmark at REV (repeatable).
+    ///
+    /// The name is generated with TF-IDF from the descriptions and files
+    /// of the commits folded into the boundary, honoring --auto-prefix;
+    /// falls back to stakk-<change_id> when no name can be derived or
+    /// the derived name is already taken.
+    #[arg(
+        long,
+        value_name = "REV",
+        group = "explicit_marks",
+        verbatim_doc_comment
+    )]
+    pub new_auto: Vec<String>,
+
+    /// Create a new bookmark at REV named by --bookmark-command (repeatable).
+    ///
+    /// Errors if no bookmark command is configured. The command receives
+    /// the same JSON segment description as in the TUI.
+    #[arg(
+        long,
+        value_name = "REV",
+        group = "explicit_marks",
+        verbatim_doc_comment
+    )]
+    pub new_command: Vec<String>,
 
     #[command(flatten)]
     pub graph: GraphArgs,

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,11 @@ pub enum StakkError {
     #[diagnostic(transparent)]
     BookmarkGen(#[from] BookmarkGenError),
 
+    /// An error from the non-interactive selection flags.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ExplicitSelection(#[from] crate::select::explicit::ExplicitSelectionError),
+
     /// A configuration error.
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -7,7 +7,7 @@ use crate::jj::types::Signature;
 
 /// A commit within a bookmark segment, carrying metadata needed for display
 /// and later PR creation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentCommit {
     pub commit_id: String,
     pub change_id: String,
@@ -30,7 +30,7 @@ pub struct SegmentCommit {
 ///
 /// When multiple bookmarks point at the same change, they share one segment.
 /// Commits are ordered newest-first (the bookmarked commit is first).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BookmarkSegment {
     /// Bookmark names pointing at this segment's change.
     pub bookmark_names: Vec<String>,
@@ -48,6 +48,23 @@ pub struct BookmarkSegment {
 #[derive(Debug, Clone)]
 pub struct BranchStack {
     pub segments: Vec<BookmarkSegment>,
+}
+
+impl BranchStack {
+    /// All commits of the stack in trunk-to-tip order (oldest first).
+    ///
+    /// Segments are stored trunk-to-leaf but each segment's commits are
+    /// newest-first, so commits are reversed per segment.
+    pub fn commits_trunk_to_tip(&self) -> impl Iterator<Item = &SegmentCommit> {
+        self.segments
+            .iter()
+            .flat_map(|seg| seg.commits.iter().rev())
+    }
+
+    /// The newest commit of the stack (the leaf segment's boundary commit).
+    pub fn tip_commit(&self) -> Option<&SegmentCommit> {
+        self.segments.last().and_then(|seg| seg.commits.first())
+    }
 }
 
 /// The complete change graph: all bookmarked segments, their relationships,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,6 @@ mod select;
 mod show;
 mod submit;
 
-use std::collections::HashSet;
-
 use clap::CommandFactory;
 use clap::FromArgMatches;
 
@@ -160,86 +158,51 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
     // Resolve bookmark: explicit argument or interactive selection.
     pb.finish_and_clear();
 
-    // `selected_bookmarks` is `None` for an explicit bookmark argument: the
-    // target and all its bookmarked ancestors are submitted as stacked PRs.
-    // The interactive TUI yields an explicit set so deliberately unchecked
-    // bookmarks fold into the next selected segment.
-    let (bookmark, change_graph, selected_bookmarks) = match &args.bookmark {
-        Some(name) => (name.clone(), change_graph, None),
+    // Phase 1: Analyze. A positional bookmark argument submits the target
+    // and all its bookmarked ancestors as stacked PRs (no folding). The
+    // interactive TUI instead yields explicit assignments on a selected
+    // path; the analysis is built directly from those, so new bookmarks
+    // need not exist yet — they are created in the execute phase, which
+    // keeps --dry-run free of side effects.
+    let (analysis, bookmark_creations) = match &args.bookmark {
+        Some(name) => {
+            let analysis = submit::analyze_submission(name, &change_graph, &default_branch, None)?;
+            (analysis, Vec::new())
+        }
         None => match select::resolve_bookmark_interactively(
             &change_graph,
             args.bookmark_command.as_deref(),
             args.auto_prefix.as_deref(),
         )? {
             Some(result) => {
-                // Create any new bookmarks that were assigned.
-                let has_new = result.assignments.iter().any(|a| a.is_new);
-                for assignment in &result.assignments {
-                    if assignment.is_new {
-                        let pb = indicatif::ProgressBar::new_spinner();
-                        pb.enable_steady_tick(std::time::Duration::from_millis(120));
-                        pb.set_message(format!(
-                            "Creating bookmark {}...",
-                            assignment.bookmark_name
-                        ));
-                        jj.create_bookmark(&assignment.bookmark_name, &assignment.change_id)
-                            .await?;
-                        pb.finish_and_clear();
-                    }
-                }
-
-                // Collect selected bookmark names for filtering.
-                let selected: HashSet<String> = result
+                let analysis = submit::analysis_from_selection(
+                    &result.path,
+                    &result.assignments,
+                    &default_branch,
+                )?;
+                let creations: Vec<submit::BookmarkCreation> = result
                     .assignments
                     .iter()
-                    .map(|a| a.bookmark_name.clone())
+                    .filter(|a| a.is_new)
+                    .map(|a| submit::BookmarkCreation {
+                        bookmark_name: a.bookmark_name.clone(),
+                        change_id: a.change_id.clone(),
+                        short_change_id: a.short_change_id.clone(),
+                    })
                     .collect();
-
-                // Use the leaf-most assignment's bookmark name.
-                let leaf_bookmark = result
-                    .assignments
-                    .last()
-                    .map(|a| a.bookmark_name.clone())
-                    .unwrap_or_default();
-
-                // Rebuild graph if we created new bookmarks.
-                let graph = if has_new {
-                    let pb = indicatif::ProgressBar::new_spinner();
-                    pb.enable_steady_tick(std::time::Duration::from_millis(120));
-                    pb.set_message("Rebuilding change graph...");
-                    let g = graph::build_change_graph(
-                        &jj,
-                        &args.graph.bookmarks_revset,
-                        &args.graph.heads_revset,
-                    )
-                    .await?;
-                    pb.finish_and_clear();
-                    g
-                } else {
-                    change_graph
-                };
-
-                (leaf_bookmark, graph, Some(selected))
+                (analysis, creations)
             }
             None => return Ok(()),
         },
     };
 
-    // Phase 1: Analyze.
+    // Phase 2: Plan.
     let pb = indicatif::ProgressBar::new_spinner();
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
-    pb.set_message("Analyzing submission...");
-    let analysis = submit::analyze_submission(
-        &bookmark,
-        &change_graph,
-        &default_branch,
-        selected_bookmarks.as_ref(),
-    )?;
-
-    // Phase 2: Plan.
     pb.set_message("Checking for existing pull requests...");
     let plan = submit::create_submission_plan(
         &analysis,
+        bookmark_creations,
         &forge,
         &remote_name,
         args.pr_mode(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,20 +160,34 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
 
     // Phase 1: Analyze. A positional bookmark argument submits the target
     // and all its bookmarked ancestors as stacked PRs (no folding). The
-    // interactive TUI instead yields explicit assignments on a selected
-    // path; the analysis is built directly from those, so new bookmarks
-    // need not exist yet — they are created in the execute phase, which
-    // keeps --dry-run free of side effects.
-    let (analysis, bookmark_creations) = match &args.bookmark {
-        Some(name) => {
-            let analysis = submit::analyze_submission(name, &change_graph, &default_branch, None)?;
-            (analysis, Vec::new())
-        }
-        None => match select::resolve_bookmark_interactively(
-            &change_graph,
-            args.bookmark_command.as_deref(),
-            args.auto_prefix.as_deref(),
-        )? {
+    // selection flags (--keep/--new/...) and the interactive TUI instead
+    // yield explicit assignments on a selected path; the analysis is built
+    // directly from those, so new bookmarks need not exist yet — they are
+    // created in the execute phase, which keeps --dry-run free of side
+    // effects.
+    let (analysis, bookmark_creations) = if let Some(name) = &args.bookmark {
+        let analysis = submit::analyze_submission(name, &change_graph, &default_branch, None)?;
+        (analysis, Vec::new())
+    } else {
+        let spec = select::explicit::SelectionSpec::from_args(args)?;
+        let selection = if spec.is_empty() {
+            select::resolve_bookmark_interactively(
+                &change_graph,
+                args.bookmark_command.as_deref(),
+                args.auto_prefix.as_deref(),
+            )?
+        } else {
+            Some(
+                select::explicit::resolve_bookmarks_explicitly(
+                    &change_graph,
+                    &spec,
+                    args.auto_prefix.as_deref(),
+                    args.bookmark_command.as_deref(),
+                )
+                .await?,
+            )
+        };
+        match selection {
             Some(result) => {
                 let analysis = submit::analysis_from_selection(
                     &result.path,
@@ -193,7 +207,7 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
                 (analysis, creations)
             }
             None => return Ok(()),
-        },
+        }
     };
 
     // Phase 2: Plan.

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -48,6 +48,7 @@ use crate::error::StakkError::{self};
 use crate::graph::layout::GraphLayout;
 use crate::graph::layout::build_layout;
 use crate::graph::types::ChangeGraph;
+use crate::graph::types::SegmentCommit;
 
 /// Terminal type used by the TUI: inline viewport over stderr.
 type Tui = Terminal<CrosstermBackend<io::Stderr>>;
@@ -94,6 +95,7 @@ pub fn run_tui(
 
     let result = run_event_loop(
         &mut terminal,
+        graph,
         &layout,
         &mut graph_state,
         &mut bookmark_state,
@@ -131,6 +133,30 @@ pub fn run_tui(
     }
 
     result
+}
+
+/// The trunk-to-tip commit chain of the stack whose tip is the currently
+/// selected leaf.
+///
+/// Every layout leaf is the tip of a stack: layout nodes come from
+/// `graph.stacks`, and a node without children is by construction the last
+/// commit of at least one stack.
+fn selected_stack_path(
+    graph: &ChangeGraph,
+    layout: &GraphLayout,
+    graph_state: &GraphViewState,
+) -> Vec<SegmentCommit> {
+    let leaf = layout.leaves[graph_state.selected_leaf];
+    let leaf_commit_id = &layout.nodes[leaf].commit_id;
+    let stack = graph
+        .stacks
+        .iter()
+        .find(|s| {
+            s.tip_commit()
+                .is_some_and(|c| &c.commit_id == leaf_commit_id)
+        })
+        .expect("every layout leaf is the tip of a stack");
+    stack.commits_trunk_to_tip().cloned().collect()
 }
 
 /// Viewport height for a screen with `content_rows` content lines: content
@@ -185,6 +211,7 @@ fn replace_viewport(terminal: &mut Tui, viewport_height: u16) -> io::Result<()> 
 )]
 fn run_event_loop(
     terminal: &mut Tui,
+    graph: &ChangeGraph,
     layout: &GraphLayout,
     graph_state: &mut GraphViewState,
     bookmark_state: &mut Option<BookmarkAssignmentState>,
@@ -390,7 +417,8 @@ fn run_event_loop(
                             match state.build_result() {
                                 Ok(assignments) if assignments.is_empty() => {}
                                 Ok(assignments) => {
-                                    return Ok(Some(SelectionResult { assignments }));
+                                    let path = selected_stack_path(graph, layout, graph_state);
+                                    return Ok(Some(SelectionResult { assignments, path }));
                                 }
                                 Err(SelectionError::DuplicateName(name)) => {
                                     error_message =

--- a/src/select/bookmark_gen.rs
+++ b/src/select/bookmark_gen.rs
@@ -13,6 +13,8 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::bookmark_widget::BookmarkRow;
+use super::tfidf;
+use crate::graph::types::SegmentCommit;
 
 /// Errors from the bookmark name generation command.
 #[derive(Debug, Error, Diagnostic)]
@@ -248,28 +250,79 @@ pub async fn generate_custom_name(
 /// Build the JSON input struct from bookmark rows. Exposed for `app.rs` to
 /// serialize before spawning a background task.
 pub(super) fn build_segment_input(rows: &[&BookmarkRow]) -> SegmentInput {
+    segment_input(rows.iter().map(|r| CommitInput::from(*r)).collect())
+}
+
+/// Build the JSON input struct from graph commits, ordered trunk-to-tip
+/// (oldest first). Used by the non-interactive selection path
+/// (`select::explicit`), which works on `SegmentCommit`s instead of TUI
+/// rows. Same wire format as [`build_segment_input`].
+pub(super) fn build_segment_input_from_commits(commits: &[&SegmentCommit]) -> SegmentInput {
+    segment_input(commits.iter().map(|c| CommitInput::from(*c)).collect())
+}
+
+/// The single owner of the wire format's envelope: `schema_version` and the
+/// validation rules. Both segment-input builders go through here so the
+/// TUI and `--new-command` paths cannot drift apart.
+fn segment_input(commits: Vec<CommitInput>) -> SegmentInput {
     SegmentInput {
         schema_version: 1,
         rules: RulesInput {
             max_length: MAX_BOOKMARK_LENGTH,
             disallowed_chars: DISALLOWED_CHARS.to_string(),
         },
-        commits: rows
-            .iter()
-            .map(|row| CommitInput {
-                commit_id: row.commit_id.clone(),
-                change_id: row.change_id.clone(),
-                short_change_id: row.short_change_id.clone(),
-                description: row.description.clone(),
-                author: AuthorInput {
-                    name: row.author.name.clone(),
-                    email: row.author.email.clone(),
-                    timestamp: row.author.timestamp.clone(),
-                },
-                files: row.files.clone(),
-            })
-            .collect(),
+        commits,
     }
+}
+
+impl From<&BookmarkRow> for CommitInput {
+    fn from(row: &BookmarkRow) -> Self {
+        Self {
+            commit_id: row.commit_id.clone(),
+            change_id: row.change_id.clone(),
+            short_change_id: row.short_change_id.clone(),
+            description: row.description.clone(),
+            author: AuthorInput {
+                name: row.author.name.clone(),
+                email: row.author.email.clone(),
+                timestamp: row.author.timestamp.clone(),
+            },
+            files: row.files.clone(),
+        }
+    }
+}
+
+impl From<&SegmentCommit> for CommitInput {
+    fn from(c: &SegmentCommit) -> Self {
+        Self {
+            commit_id: c.commit_id.clone(),
+            change_id: c.change_id.clone(),
+            short_change_id: c.short_change_id.clone(),
+            description: c.description.clone(),
+            author: AuthorInput {
+                name: c.author.name.clone(),
+                email: c.author.email.clone(),
+                timestamp: c.author.timestamp.clone(),
+            },
+            files: c.files.clone(),
+        }
+    }
+}
+
+/// TF-IDF bookmark name for a segment's commits with the auto prefix
+/// applied and the length budget reserved for it. `None` when no name can
+/// be derived. The single owner of the naming policy (term count, length
+/// budget, disallowed characters) shared by the TUI's `[~]auto` state and
+/// `--new-auto`.
+pub(super) fn tfidf_prefixed_name(
+    data: &[tfidf::CommitData<'_>],
+    variation: usize,
+    auto_prefix: Option<&str>,
+) -> Option<String> {
+    let prefix = auto_prefix.unwrap_or("");
+    let max_length = MAX_BOOKMARK_LENGTH.saturating_sub(prefix.len());
+    tfidf::tfidf_bookmark_name(data, 3, variation, max_length, DISALLOWED_CHARS)
+        .map(|name| format!("{prefix}{name}"))
 }
 
 /// Run the shell command with the given JSON on stdin. Exposed for `app.rs`

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -186,22 +186,7 @@ fn compute_tfidf_for_segment(
         })
         .collect();
 
-    // Reserve space for the prefix in the max length budget.
-    let prefix_len = auto_prefix.map_or(0, str::len);
-    let max_length = bookmark_gen::MAX_BOOKMARK_LENGTH.saturating_sub(prefix_len);
-
-    let name = tfidf::tfidf_bookmark_name(
-        &commit_data,
-        3,
-        variation,
-        max_length,
-        bookmark_gen::DISALLOWED_CHARS,
-    )?;
-
-    match auto_prefix {
-        Some(prefix) => Some(format!("{prefix}{name}")),
-        None => Some(name),
-    }
+    bookmark_gen::tfidf_prefixed_name(&commit_data, variation, auto_prefix)
 }
 
 /// State for the bookmark assignment widget.

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -772,6 +772,7 @@ impl BookmarkAssignmentState {
 
             assignments.push(BookmarkAssignment {
                 change_id: r.change_id.clone(),
+                short_change_id: r.short_change_id.clone(),
                 bookmark_name,
                 is_new,
             });

--- a/src/select/explicit.rs
+++ b/src/select/explicit.rs
@@ -1,0 +1,1414 @@
+//! Non-interactive bookmark selection driven by CLI flags.
+//!
+//! `--keep`, `--keep-all`, `--new REV[=NAME]`, `--new-auto REV`, and
+//! `--new-command REV` fully determine the PR boundary set — nothing is
+//! implicit. The marks themselves define the stack: all must lie on one
+//! trunk-to-tip path (colinearity is validated), and the topmost mark is
+//! the tip of the submission. Bookmarks on the path that are not kept fold
+//! into the PR above them, exactly like unchecked rows in the TUI.
+//!
+//! The resolver is pure with respect to the repository: it reads the
+//! already-built [`ChangeGraph`] and produces a [`SelectionResult`]; all
+//! bookmark creation happens later, in the execute phase.
+
+use std::collections::BTreeSet;
+use std::collections::HashSet;
+
+use miette::Diagnostic;
+use thiserror::Error;
+
+use super::SelectionResult;
+use super::bookmark_gen;
+use super::bookmark_gen::BookmarkGenError;
+use super::tfidf;
+use crate::cli::submit::SubmitArgs;
+use crate::graph::types::ChangeGraph;
+use crate::graph::types::SegmentCommit;
+use crate::submit::BookmarkAssignment;
+
+/// Errors from resolving the explicit selection flags.
+#[derive(Debug, Error, Diagnostic)]
+pub enum ExplicitSelectionError {
+    /// A `--new` value that is neither `REV` nor `REV=NAME`.
+    #[error("invalid --new value {arg:?}: expected REV or REV=NAME")]
+    #[diagnostic(
+        code(stakk::selection::invalid_new_spec),
+        help(
+            "pass a change or commit id prefix, optionally followed by =NAME; run `stakk show` to \
+             list ids"
+        )
+    )]
+    InvalidNewSpec { arg: String },
+
+    /// A rev-taking flag received an empty value.
+    #[error("{flag} requires a non-empty REV")]
+    #[diagnostic(
+        code(stakk::selection::empty_rev),
+        help("pass a change or commit id prefix; run `stakk show` to list ids")
+    )]
+    EmptyRev { flag: String },
+
+    /// No submittable stacks exist at all.
+    #[error("no bookmark stacks found")]
+    #[diagnostic(
+        code(stakk::selection::no_stacks),
+        help(
+            "there is nothing to submit; check --bookmarks-revset / --heads-revset, or run `stakk \
+             show` to inspect the repository"
+        )
+    )]
+    NoStacks,
+
+    /// A rev matched no commit on any stack.
+    #[error("revision {rev:?} does not match any commit on a submittable stack")]
+    #[diagnostic(
+        code(stakk::selection::rev_not_found),
+        help(
+            "the rev must prefix-match a change or commit id on a stack; trunk, immutable, and \
+             revset-excluded commits are not submittable — run `stakk show` (or `stakk show \
+             --format=json`) to list candidates"
+        )
+    )]
+    RevNotFound { rev: String },
+
+    /// A rev matched more than one distinct commit.
+    #[error("revision {rev:?} is ambiguous: matches {}", candidates.join(", "))]
+    #[diagnostic(
+        code(stakk::selection::rev_ambiguous),
+        help("use a longer prefix; run `stakk show` to see short change ids")
+    )]
+    RevAmbiguous {
+        rev: String,
+        candidates: Vec<String>,
+    },
+
+    /// A rev resolved to an immutable commit.
+    #[error("revision {rev:?} resolves to an immutable commit")]
+    #[diagnostic(
+        code(stakk::selection::rev_immutable),
+        help(
+            "immutable commits cannot become PR boundaries; a bookmark there would be invisible \
+             to subsequent runs (see --bookmarks-revset)"
+        )
+    )]
+    RevImmutable { rev: String },
+
+    /// A `--keep` name matched no bookmark on any stack.
+    #[error("bookmark {name:?} not found on any stack")]
+    #[diagnostic(
+        code(stakk::selection::keep_not_found),
+        help(
+            "run `stakk show` to list bookmarks; only bookmarks matched by --bookmarks-revset \
+             appear"
+        )
+    )]
+    KeepNotFound { name: String },
+
+    /// The marks do not all lie on one trunk-to-tip path.
+    #[error("marks do not lie on a single trunk-to-tip path: {}", marks.join(", "))]
+    #[diagnostic(
+        code(stakk::selection::not_colinear),
+        help(
+            "all marks must be ancestors or descendants of one another — run `stakk show` to \
+             inspect the stacks"
+        )
+    )]
+    MarksNotColinear { marks: Vec<String> },
+
+    /// Bare `--keep-all` (or one anchored on a shared segment) cannot pick
+    /// a stack.
+    #[error("--keep-all is ambiguous between stacks: {}", candidates.join("; "))]
+    #[diagnostic(
+        code(stakk::selection::keep_all_ambiguous),
+        help("anchor the path with --keep or --new, or run `stakk show` to inspect the stacks")
+    )]
+    KeepAllAmbiguous { candidates: Vec<String> },
+
+    /// `--keep-all` alone found nothing to keep.
+    #[error("--keep-all found no bookmarks on the selected path")]
+    #[diagnostic(
+        code(stakk::selection::no_marks),
+        help("use --new to create a bookmark, or run `stakk show`")
+    )]
+    NoMarks,
+
+    /// Two marks target the same commit.
+    #[error("marks {a} and {b} target the same commit")]
+    #[diagnostic(
+        code(stakk::selection::duplicate_mark),
+        help("a commit can be at most one PR boundary; drop one of the marks")
+    )]
+    DuplicateMarkOnCommit { a: String, b: String },
+
+    /// The same bookmark name would be used by more than one mark.
+    #[error("bookmark name {name:?} is used by more than one mark")]
+    #[diagnostic(
+        code(stakk::selection::duplicate_name),
+        help("bookmark names must be unique; pass an explicit name with --new REV=NAME")
+    )]
+    DuplicateName { name: String },
+
+    /// A `--new` name collides with an existing bookmark.
+    #[error("bookmark {name:?} already exists")]
+    #[diagnostic(
+        code(stakk::selection::name_exists),
+        help("choose another name, or pass --keep with the existing name instead")
+    )]
+    NewNameExists { name: String },
+
+    /// `--new-command` was passed without a configured bookmark command.
+    #[error("--new-command requires a bookmark command")]
+    #[diagnostic(
+        code(stakk::selection::bookmark_command_not_configured),
+        help(
+            "pass --bookmark-command, set STAKK_BOOKMARK_COMMAND, or add bookmark_command to \
+             stakk.toml"
+        )
+    )]
+    BookmarkCommandNotConfigured,
+
+    /// The bookmark command failed or produced an invalid name.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Gen(#[from] BookmarkGenError),
+}
+
+/// A `--new REV[=NAME]` value, split.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewBookmarkSpec {
+    /// Change or commit id prefix.
+    pub rev: String,
+    /// Explicit name (`REV=NAME` form), or `None` for the
+    /// `stakk-<change_id>` default.
+    pub name: Option<String>,
+}
+
+/// The parsed selection flags of one `stakk submit` invocation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SelectionSpec {
+    pub keep: Vec<String>,
+    pub keep_all: bool,
+    pub new: Vec<NewBookmarkSpec>,
+    pub new_auto: Vec<String>,
+    pub new_command: Vec<String>,
+}
+
+impl SelectionSpec {
+    /// Parse the selection flags out of the CLI args.
+    ///
+    /// Splits `--new REV=NAME` values and validates explicit names, so
+    /// name errors surface as miette diagnostics rather than clap usage
+    /// errors.
+    pub fn from_args(args: &SubmitArgs) -> Result<Self, ExplicitSelectionError> {
+        let mut new = Vec::with_capacity(args.new.len());
+        for raw in &args.new {
+            let spec = if let Some((rev, name)) = raw.split_once('=') {
+                if rev.is_empty() || name.is_empty() {
+                    return Err(ExplicitSelectionError::InvalidNewSpec { arg: raw.clone() });
+                }
+                bookmark_gen::validate_bookmark_name(name)?;
+                NewBookmarkSpec {
+                    rev: rev.to_string(),
+                    name: Some(name.to_string()),
+                }
+            } else {
+                if raw.is_empty() {
+                    return Err(ExplicitSelectionError::InvalidNewSpec { arg: raw.clone() });
+                }
+                NewBookmarkSpec {
+                    rev: raw.clone(),
+                    name: None,
+                }
+            };
+            new.push(spec);
+        }
+        // An empty rev would prefix-match every commit; reject it here
+        // (clap accepts "" as a value).
+        for (revs, flag) in [
+            (&args.new_auto, "--new-auto"),
+            (&args.new_command, "--new-command"),
+        ] {
+            if revs.iter().any(String::is_empty) {
+                return Err(ExplicitSelectionError::EmptyRev {
+                    flag: flag.to_string(),
+                });
+            }
+        }
+        Ok(Self {
+            keep: args.keep.clone(),
+            keep_all: args.keep_all,
+            new,
+            new_auto: args.new_auto.clone(),
+            new_command: args.new_command.clone(),
+        })
+    }
+
+    /// Whether no selection flag was passed at all (→ interactive TUI).
+    pub fn is_empty(&self) -> bool {
+        self.keep.is_empty()
+            && !self.keep_all
+            && self.new.is_empty()
+            && self.new_auto.is_empty()
+            && self.new_command.is_empty()
+    }
+}
+
+/// How a mark produces its bookmark name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MarkKind {
+    /// Existing bookmark, kept as-is.
+    Keep { name: String },
+    /// New bookmark: explicit name, or the `stakk-<change_id>` default.
+    New { name: Option<String> },
+    /// New bookmark named by TF-IDF over the dynamic segment.
+    NewAuto,
+    /// New bookmark named by the external bookmark command.
+    NewCommand,
+}
+
+/// A mark resolved to a concrete commit, before path selection.
+#[derive(Debug)]
+struct Mark {
+    kind: MarkKind,
+    /// The flag occurrence, for error messages (e.g. `--new abc=foo`).
+    display: String,
+    commit_id: String,
+    /// Indices into `graph.stacks` of every stack containing the commit.
+    stacks: BTreeSet<usize>,
+}
+
+/// Resolve the explicit selection flags against the change graph.
+///
+/// Pure with respect to the repository: reads the graph, returns the
+/// assignments and the selected trunk-to-tip path. `async` only because
+/// `--new-command` awaits the external command.
+pub async fn resolve_bookmarks_explicitly(
+    graph: &ChangeGraph,
+    spec: &SelectionSpec,
+    auto_prefix: Option<&str>,
+    bookmark_command: Option<&str>,
+) -> Result<SelectionResult, ExplicitSelectionError> {
+    if !spec.new_command.is_empty() && bookmark_command.is_none() {
+        return Err(ExplicitSelectionError::BookmarkCommandNotConfigured);
+    }
+    if graph.stacks.is_empty() {
+        return Err(ExplicitSelectionError::NoStacks);
+    }
+
+    // Linearized trunk-to-tip commit chains, one per stack.
+    let linearized: Vec<Vec<&SegmentCommit>> = graph
+        .stacks
+        .iter()
+        .map(|s| s.commits_trunk_to_tip().collect())
+        .collect();
+
+    let mut marks: Vec<Mark> = Vec::new();
+
+    // Resolve rev marks (--new / --new-auto / --new-command).
+    let rev_marks = spec
+        .new
+        .iter()
+        .map(|n| {
+            let display = match &n.name {
+                Some(name) => format!("--new {}={name}", n.rev),
+                None => format!("--new {}", n.rev),
+            };
+            (
+                n.rev.clone(),
+                MarkKind::New {
+                    name: n.name.clone(),
+                },
+                display,
+            )
+        })
+        .chain(
+            spec.new_auto
+                .iter()
+                .map(|rev| (rev.clone(), MarkKind::NewAuto, format!("--new-auto {rev}"))),
+        )
+        .chain(spec.new_command.iter().map(|rev| {
+            (
+                rev.clone(),
+                MarkKind::NewCommand,
+                format!("--new-command {rev}"),
+            )
+        }));
+    for (rev, kind, display) in rev_marks {
+        let (commit, stacks) = resolve_rev(&linearized, &rev)?;
+        marks.push(Mark {
+            kind,
+            display,
+            commit_id: commit.commit_id.clone(),
+            stacks,
+        });
+    }
+
+    // Resolve --keep names; identical repeats dedupe silently.
+    let mut kept_names: HashSet<&str> = HashSet::new();
+    for name in &spec.keep {
+        if !kept_names.insert(name.as_str()) {
+            continue;
+        }
+        let (commit, stacks) = resolve_keep(&linearized, graph, name)?;
+        marks.push(Mark {
+            kind: MarkKind::Keep { name: name.clone() },
+            display: format!("--keep {name}"),
+            commit_id: commit.commit_id.clone(),
+            stacks,
+        });
+    }
+
+    // Colinearity: all marks must share at least one stack.
+    let candidate_stacks: BTreeSet<usize> =
+        match marks
+            .iter()
+            .map(|m| &m.stacks)
+            .fold(None::<BTreeSet<usize>>, |acc, s| match acc {
+                None => Some(s.clone()),
+                Some(acc) => Some(acc.intersection(s).copied().collect()),
+            }) {
+            Some(set) => {
+                if set.is_empty() {
+                    return Err(ExplicitSelectionError::MarksNotColinear {
+                        marks: marks.iter().map(|m| m.display.clone()).collect(),
+                    });
+                }
+                set
+            }
+            // No marks yet: bare --keep-all considers every stack.
+            None => (0..graph.stacks.len()).collect(),
+        };
+
+    // Expand --keep-all into Keep marks on the chosen path. Commits that
+    // already carry an explicit mark are skipped (explicit beats bulk).
+    if spec.keep_all {
+        let anchored = !marks.is_empty();
+        let expansion = keep_all_expansion(graph, &candidate_stacks, &marks)?;
+        if expansion.is_empty() && !anchored {
+            return Err(ExplicitSelectionError::NoMarks);
+        }
+        marks.extend(expansion);
+    }
+
+    // Per-commit duplicate check.
+    {
+        let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        for mark in &marks {
+            if let Some(first) = seen.insert(mark.commit_id.as_str(), mark.display.as_str()) {
+                return Err(ExplicitSelectionError::DuplicateMarkOnCommit {
+                    a: first.to_string(),
+                    b: mark.display.clone(),
+                });
+            }
+        }
+    }
+
+    // Name checks that don't need generation: duplicates among explicit
+    // names, and --new names colliding with any existing local bookmark.
+    let existing_names: HashSet<&str> = linearized
+        .iter()
+        .flatten()
+        .flat_map(|c| c.local_bookmark_names.iter())
+        .map(String::as_str)
+        .collect();
+    {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for mark in &marks {
+            let name = match &mark.kind {
+                MarkKind::Keep { name } => Some(name.as_str()),
+                MarkKind::New { name } => name.as_deref(),
+                MarkKind::NewAuto | MarkKind::NewCommand => None,
+            };
+            let Some(name) = name else { continue };
+            if !seen.insert(name) {
+                return Err(ExplicitSelectionError::DuplicateName {
+                    name: name.to_string(),
+                });
+            }
+            if matches!(mark.kind, MarkKind::New { .. }) && existing_names.contains(name) {
+                return Err(ExplicitSelectionError::NewNameExists {
+                    name: name.to_string(),
+                });
+            }
+        }
+    }
+
+    // Pick the path. Every candidate stack contains all marks; where they
+    // differ is only above the topmost mark, which the analysis drops, so
+    // the first candidate is as good as any.
+    let stack_idx = *candidate_stacks
+        .first()
+        .expect("candidate_stacks is non-empty: either checked above or built from marks");
+    let path: Vec<SegmentCommit> = graph.stacks[stack_idx]
+        .commits_trunk_to_tip()
+        .cloned()
+        .collect();
+
+    // Sort marks trunk-to-tip by position on the path.
+    let position = |commit_id: &str| {
+        path.iter()
+            .position(|c| c.commit_id == commit_id)
+            .expect("every mark is on a candidate stack by construction")
+    };
+    let mut marks: Vec<(usize, Mark)> = marks
+        .into_iter()
+        .map(|m| (position(&m.commit_id), m))
+        .collect();
+    marks.sort_by_key(|(pos, _)| *pos);
+
+    // Generate names trunk-to-tip. The dynamic segment of a mark is the
+    // path slice from the previous mark (exclusive) through the mark
+    // (inclusive) — the commits that fold into its PR.
+    let mut assignments = Vec::with_capacity(marks.len());
+    let mut used_names: HashSet<String> = HashSet::new();
+    let mut segment_start = 0usize;
+    for (pos, mark) in &marks {
+        let commit = &path[*pos];
+        let segment: Vec<&SegmentCommit> = path[segment_start..=*pos].iter().collect();
+        let (name, is_new) = match &mark.kind {
+            MarkKind::Keep { name } => (name.clone(), false),
+            MarkKind::New { name: Some(name) } => (name.clone(), true),
+            MarkKind::New { name: None } => {
+                (bookmark_gen::default_bookmark_name(&commit.change_id), true)
+            }
+            MarkKind::NewAuto => {
+                let taken = |n: &str| existing_names.contains(n) || used_names.contains(n);
+                (
+                    auto_name(&segment, &commit.change_id, auto_prefix, taken),
+                    true,
+                )
+            }
+            MarkKind::NewCommand => {
+                let command = bookmark_command
+                    .expect("--new-command without a configured command errors above");
+                let input = bookmark_gen::build_segment_input_from_commits(&segment);
+                let json =
+                    serde_json::to_string(&input).expect("SegmentInput is always serializable");
+                let name =
+                    bookmark_gen::run_command(command, &json, bookmark_gen::COMPUTING_TIMEOUT)
+                        .await?;
+                bookmark_gen::validate_bookmark_name(&name)?;
+                (name, true)
+            }
+        };
+        // Re-check duplicates now that generated names are known.
+        if !used_names.insert(name.clone()) {
+            return Err(ExplicitSelectionError::DuplicateName { name });
+        }
+        // No new name may shadow an existing bookmark. Explicit
+        // `--new REV=NAME` names were already checked before generation;
+        // re-checking them here is harmless and keeps the condition simple.
+        if is_new && existing_names.contains(name.as_str()) {
+            return Err(ExplicitSelectionError::NewNameExists { name });
+        }
+        assignments.push(BookmarkAssignment {
+            change_id: commit.change_id.clone(),
+            short_change_id: commit.short_change_id.clone(),
+            bookmark_name: name,
+            is_new,
+        });
+        segment_start = *pos + 1;
+    }
+
+    Ok(SelectionResult { assignments, path })
+}
+
+/// TF-IDF name for a dynamic segment, honoring the auto prefix; falls back
+/// to the `stakk-<change_id>` default when nothing can be derived or the
+/// derived name is already taken (mirroring the TUI, which skips states
+/// that would produce a duplicate).
+fn auto_name(
+    segment: &[&SegmentCommit],
+    change_id: &str,
+    auto_prefix: Option<&str>,
+    taken: impl Fn(&str) -> bool,
+) -> String {
+    let data: Vec<tfidf::CommitData<'_>> = segment
+        .iter()
+        .map(|c| tfidf::CommitData {
+            description: &c.description,
+            files: &c.files,
+        })
+        .collect();
+    match bookmark_gen::tfidf_prefixed_name(&data, 0, auto_prefix) {
+        Some(name) if !taken(&name) => name,
+        _ => bookmark_gen::default_bookmark_name(change_id),
+    }
+}
+
+/// Resolve a rev (change or commit id prefix) to a unique mutable commit
+/// and the set of stacks containing it.
+fn resolve_rev<'a>(
+    linearized: &[Vec<&'a SegmentCommit>],
+    rev: &str,
+) -> Result<(&'a SegmentCommit, BTreeSet<usize>), ExplicitSelectionError> {
+    // commit_id → (commit, stack set); shared segments are cloned into
+    // every containing stack, so one commit in N stacks is NOT ambiguous.
+    let mut matches: Vec<(&SegmentCommit, BTreeSet<usize>)> = Vec::new();
+    for (stack_idx, commits) in linearized.iter().enumerate() {
+        for commit in commits {
+            if commit.change_id.starts_with(rev) || commit.commit_id.starts_with(rev) {
+                match matches
+                    .iter_mut()
+                    .find(|(c, _)| c.commit_id == commit.commit_id)
+                {
+                    Some((_, stacks)) => {
+                        stacks.insert(stack_idx);
+                    }
+                    None => {
+                        matches.push((commit, BTreeSet::from([stack_idx])));
+                    }
+                }
+            }
+        }
+    }
+    // Immutable commits cannot become boundaries, so only mutable matches
+    // count toward uniqueness; immutable ones merely shape the error when
+    // nothing mutable matched.
+    let any_immutable = matches.iter().any(|(c, _)| c.is_immutable);
+    let mut mutable: Vec<(&SegmentCommit, BTreeSet<usize>)> = matches
+        .into_iter()
+        .filter(|(c, _)| !c.is_immutable)
+        .collect();
+    match mutable.len() {
+        0 if any_immutable => Err(ExplicitSelectionError::RevImmutable {
+            rev: rev.to_string(),
+        }),
+        0 => Err(ExplicitSelectionError::RevNotFound {
+            rev: rev.to_string(),
+        }),
+        1 => Ok(mutable.remove(0)),
+        _ => Err(ExplicitSelectionError::RevAmbiguous {
+            rev: rev.to_string(),
+            candidates: mutable
+                .iter()
+                .map(|(c, _)| {
+                    let summary = c.description.lines().next().unwrap_or("").trim();
+                    if summary.is_empty() {
+                        c.short_change_id.clone()
+                    } else {
+                        format!("{} {summary:?}", c.short_change_id)
+                    }
+                })
+                .collect(),
+        }),
+    }
+}
+
+/// Resolve a `--keep` name to its segment's boundary commit and the set of
+/// stacks containing it.
+fn resolve_keep<'a>(
+    linearized: &[Vec<&'a SegmentCommit>],
+    graph: &ChangeGraph,
+    name: &str,
+) -> Result<(&'a SegmentCommit, BTreeSet<usize>), ExplicitSelectionError> {
+    let mut found: Option<(&SegmentCommit, BTreeSet<usize>)> = None;
+    for (stack_idx, stack) in graph.stacks.iter().enumerate() {
+        for segment in &stack.segments {
+            if !segment.bookmark_names.iter().any(|n| n == name) {
+                continue;
+            }
+            let Some(boundary) = segment.commits.first() else {
+                continue;
+            };
+            match &mut found {
+                Some((commit, stacks)) if commit.commit_id == boundary.commit_id => {
+                    stacks.insert(stack_idx);
+                }
+                Some(_) => {
+                    // A bookmark points at exactly one commit; differing
+                    // commit ids for one name cannot come from the graph.
+                    unreachable!("bookmark {name} resolves to two different commits");
+                }
+                None => {
+                    // Borrow the commit from the linearized view so the
+                    // lifetime matches the return type.
+                    let commit = linearized[stack_idx]
+                        .iter()
+                        .find(|c| c.commit_id == boundary.commit_id)
+                        .expect("segment commits appear in the stack linearization");
+                    found = Some((commit, BTreeSet::from([stack_idx])));
+                }
+            }
+        }
+    }
+    found.ok_or_else(|| ExplicitSelectionError::KeepNotFound {
+        name: name.to_string(),
+    })
+}
+
+/// Expand `--keep-all` into Keep marks on the candidate stacks.
+///
+/// Commits already carrying an explicit mark are skipped (explicit beats
+/// bulk). All candidate stacks must agree on the resulting expansion;
+/// bare `--keep-all` therefore requires a single stack, and an anchored
+/// one errors if the candidates diverge in their bookmarks.
+fn keep_all_expansion(
+    graph: &ChangeGraph,
+    candidate_stacks: &BTreeSet<usize>,
+    marks: &[Mark],
+) -> Result<Vec<Mark>, ExplicitSelectionError> {
+    let marked_commits: HashSet<&str> = marks.iter().map(|m| m.commit_id.as_str()).collect();
+
+    // Per candidate stack: the (commit_id, name) list of unmarked
+    // bookmarked boundaries, trunk-to-leaf.
+    let mut expansions: Vec<Vec<(String, String)>> = Vec::new();
+    for &stack_idx in candidate_stacks {
+        let expansion: Vec<(String, String)> = graph.stacks[stack_idx]
+            .segments
+            .iter()
+            .filter_map(|segment| {
+                let name = segment.bookmark_names.first()?;
+                let boundary = segment.commits.first()?;
+                if marked_commits.contains(boundary.commit_id.as_str()) {
+                    return None;
+                }
+                Some((boundary.commit_id.clone(), name.clone()))
+            })
+            .collect();
+        expansions.push(expansion);
+    }
+
+    let first = &expansions[0];
+    if expansions.iter().any(|e| e != first) {
+        return Err(ExplicitSelectionError::KeepAllAmbiguous {
+            candidates: candidate_stacks
+                .iter()
+                .map(|&idx| describe_stack(&graph.stacks[idx]))
+                .collect(),
+        });
+    }
+
+    Ok(first
+        .iter()
+        .map(|(commit_id, name)| Mark {
+            kind: MarkKind::Keep { name: name.clone() },
+            display: format!("--keep-all ({name})"),
+            commit_id: commit_id.clone(),
+            // Identical expansions mean every expanded commit is shared by
+            // all candidate stacks. (Only the pre-expansion colinearity
+            // fold reads this, but keep the data truthful.)
+            stacks: candidate_stacks.clone(),
+        })
+        .collect())
+}
+
+/// One-line description of a stack for ambiguity errors: its tip's short
+/// change id plus the tip segment's bookmarks or description.
+fn describe_stack(stack: &crate::graph::types::BranchStack) -> String {
+    let Some(tip) = stack.tip_commit() else {
+        return "(empty stack)".to_string();
+    };
+    let names = stack
+        .segments
+        .last()
+        .map(|s| s.bookmark_names.join(", "))
+        .unwrap_or_default();
+    if names.is_empty() {
+        let summary = tip.description.lines().next().unwrap_or("").trim();
+        format!("{} {summary:?}", tip.short_change_id)
+    } else {
+        format!("{} ({names})", tip.short_change_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::graph::types::BookmarkSegment;
+    use crate::graph::types::BranchStack;
+    use crate::jj::types::Signature;
+
+    fn sig() -> Signature {
+        Signature {
+            name: "Test".to_string(),
+            email: "test@test.com".to_string(),
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_commit(change_id: &str, description: &str) -> SegmentCommit {
+        SegmentCommit {
+            commit_id: format!("c_{change_id}"),
+            change_id: change_id.to_string(),
+            description: description.to_string(),
+            author: sig(),
+            committer: sig(),
+            short_change_id: change_id[..4.min(change_id.len())].to_string(),
+            files: vec![format!("src/{change_id}.rs")],
+            is_immutable: false,
+            local_bookmark_names: vec![],
+        }
+    }
+
+    /// A one-commit segment; `names` also become the commit's local
+    /// bookmarks (like a real graph).
+    fn make_segment(names: &[&str], change_id: &str, description: &str) -> BookmarkSegment {
+        let mut commit = make_commit(change_id, description);
+        commit.local_bookmark_names = names.iter().map(ToString::to_string).collect();
+        BookmarkSegment {
+            bookmark_names: names.iter().map(ToString::to_string).collect(),
+            change_id: change_id.to_string(),
+            commits: vec![commit],
+        }
+    }
+
+    fn make_graph(stacks: Vec<BranchStack>) -> ChangeGraph {
+        ChangeGraph {
+            adjacency_list: HashMap::new(),
+            stack_leaves: std::collections::HashSet::new(),
+            stack_roots: std::collections::HashSet::new(),
+            segments: HashMap::new(),
+            tainted_change_ids: std::collections::HashSet::new(),
+            excluded_bookmark_count: 0,
+            stacks,
+        }
+    }
+
+    /// One stack: base <- mid <- leaf, all bookmarked.
+    fn single_stack_graph() -> ChangeGraph {
+        make_graph(vec![BranchStack {
+            segments: vec![
+                make_segment(&["base"], "aaaa1111", "base work"),
+                make_segment(&["mid"], "bbbb2222", "mid work"),
+                make_segment(&["leaf"], "cccc3333", "leaf work"),
+            ],
+        }])
+    }
+
+    /// Two stacks sharing a bookmarked base segment. The shared segment is
+    /// cloned into both stacks, like `group_segments_into_stacks` does.
+    fn forked_graph() -> ChangeGraph {
+        let base = make_segment(&["base"], "aaaa1111", "base work");
+        make_graph(vec![
+            BranchStack {
+                segments: vec![
+                    base.clone(),
+                    make_segment(&["feat-x"], "xxxx1111", "x work"),
+                ],
+            },
+            BranchStack {
+                segments: vec![base, make_segment(&["feat-y"], "yyyy1111", "y work")],
+            },
+        ])
+    }
+
+    fn spec(f: impl FnOnce(&mut SelectionSpec)) -> SelectionSpec {
+        let mut s = SelectionSpec::default();
+        f(&mut s);
+        s
+    }
+
+    async fn resolve(
+        graph: &ChangeGraph,
+        s: &SelectionSpec,
+    ) -> Result<SelectionResult, ExplicitSelectionError> {
+        resolve_bookmarks_explicitly(graph, s, None, None).await
+    }
+
+    fn names(result: &SelectionResult) -> Vec<(&str, bool)> {
+        result
+            .assignments
+            .iter()
+            .map(|a| (a.bookmark_name.as_str(), a.is_new))
+            .collect()
+    }
+
+    // -- keep --
+
+    #[tokio::test]
+    async fn keep_subset_orders_trunk_to_leaf() {
+        let graph = single_stack_graph();
+        // Marks given leaf-first; assignments must come back trunk-to-leaf.
+        let s = spec(|s| s.keep = vec!["leaf".into(), "base".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(names(&result), vec![("base", false), ("leaf", false)]);
+        assert_eq!(result.path.len(), 3);
+        assert_eq!(result.assignments.last().unwrap().bookmark_name, "leaf");
+    }
+
+    #[tokio::test]
+    async fn keep_repeated_name_dedupes_silently() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.keep = vec!["mid".into(), "mid".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(names(&result), vec![("mid", false)]);
+    }
+
+    #[tokio::test]
+    async fn keep_not_found() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.keep = vec!["nope".into()]);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::KeepNotFound { name } if name == "nope"));
+    }
+
+    // -- keep-all --
+
+    #[tokio::test]
+    async fn keep_all_bare_single_stack() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.keep_all = true);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            names(&result),
+            vec![("base", false), ("mid", false), ("leaf", false)]
+        );
+    }
+
+    #[tokio::test]
+    async fn keep_all_bare_multi_stack_errors() {
+        let graph = forked_graph();
+        let s = spec(|s| s.keep_all = true);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::KeepAllAmbiguous { candidates } if candidates.len() == 2
+        ));
+    }
+
+    #[tokio::test]
+    async fn keep_all_anchored_picks_the_marked_stack() {
+        let graph = forked_graph();
+        let s = spec(|s| {
+            s.keep_all = true;
+            s.keep = vec!["feat-y".into()];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(names(&result), vec![("base", false), ("feat-y", false)]);
+    }
+
+    #[tokio::test]
+    async fn keep_all_bare_no_bookmarks_errors_no_marks() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![{
+                let mut seg = make_segment(&[], "aaaa1111", "wip");
+                seg.bookmark_names = vec![];
+                seg
+            }],
+        }]);
+        let s = spec(|s| s.keep_all = true);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::NoMarks));
+    }
+
+    #[tokio::test]
+    async fn keep_all_skips_explicitly_marked_commits() {
+        let graph = single_stack_graph();
+        // mid's commit gets an explicit --new name; keep-all must not also
+        // keep `mid` there (explicit beats bulk).
+        let s = spec(|s| {
+            s.keep_all = true;
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: Some("renamed-mid".into()),
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            names(&result),
+            vec![("base", false), ("renamed-mid", true), ("leaf", false)]
+        );
+    }
+
+    // -- rev resolution --
+
+    #[tokio::test]
+    async fn rev_resolves_by_change_id_and_commit_id_prefix() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: Some("by-change".into()),
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(result.assignments[0].change_id, "bbbb2222");
+
+        // Commit ids are `c_<change_id>` in these fixtures.
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "c_bbbb".into(),
+                name: Some("by-commit".into()),
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(result.assignments[0].change_id, "bbbb2222");
+    }
+
+    #[tokio::test]
+    async fn rev_not_found() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "zzzz".into(),
+                name: None,
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::RevNotFound { rev } if rev == "zzzz"));
+    }
+
+    #[tokio::test]
+    async fn rev_ambiguous_across_distinct_commits() {
+        let graph = make_graph(vec![BranchStack {
+            segments: vec![
+                make_segment(&["a"], "dddd1111", "one"),
+                make_segment(&["b"], "dddd2222", "two"),
+            ],
+        }]);
+        let s = spec(|s| {
+            s.new_auto = vec!["dddd".into()];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::RevAmbiguous { candidates, .. } if candidates.len() == 2
+        ));
+    }
+
+    /// The shared base segment is cloned into both stacks; matching its
+    /// commit must NOT count as ambiguous (dedupe by commit id).
+    #[tokio::test]
+    async fn rev_shared_clone_is_not_ambiguous() {
+        let graph = forked_graph();
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "aaaa".into(),
+                name: Some("re-base".into()),
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(names(&result), vec![("re-base", true)]);
+        assert_eq!(result.assignments[0].change_id, "aaaa1111");
+    }
+
+    #[tokio::test]
+    async fn rev_immutable_errors() {
+        let mut graph = single_stack_graph();
+        graph.stacks[0].segments[0].commits[0].is_immutable = true;
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "aaaa".into(),
+                name: None,
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::RevImmutable { .. }));
+    }
+
+    // -- colinearity --
+
+    #[tokio::test]
+    async fn marks_on_diverging_stacks_error() {
+        let graph = forked_graph();
+        let s = spec(|s| s.keep = vec!["feat-x".into(), "feat-y".into()]);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::MarksNotColinear { marks } if marks.len() == 2
+        ));
+    }
+
+    #[tokio::test]
+    async fn marks_on_shared_prefix_are_colinear() {
+        let graph = forked_graph();
+        let s = spec(|s| s.keep = vec!["base".into(), "feat-x".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(names(&result), vec![("base", false), ("feat-x", false)]);
+    }
+
+    // -- duplicates --
+
+    #[tokio::test]
+    async fn two_marks_on_one_commit_error() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.keep = vec!["mid".into()];
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: Some("other".into()),
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::DuplicateMarkOnCommit { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn duplicate_explicit_names_error() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.new = vec![
+                NewBookmarkSpec {
+                    rev: "aaaa".into(),
+                    name: Some("same".into()),
+                },
+                NewBookmarkSpec {
+                    rev: "cccc".into(),
+                    name: Some("same".into()),
+                },
+            ];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::DuplicateName { name } if name == "same"
+        ));
+    }
+
+    #[tokio::test]
+    async fn new_name_matching_existing_bookmark_errors() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: Some("leaf".into()),
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::NewNameExists { name } if name == "leaf"
+        ));
+    }
+
+    // -- name generation --
+
+    #[tokio::test]
+    async fn new_without_name_uses_stakk_default() {
+        let graph = single_stack_graph();
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: None,
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            result.assignments[0].bookmark_name,
+            bookmark_gen::default_bookmark_name("bbbb2222"),
+        );
+        assert!(result.assignments[0].is_new);
+    }
+
+    #[tokio::test]
+    async fn new_auto_uses_dynamic_segment_and_prefix() {
+        let mut graph = single_stack_graph();
+        graph.stacks[0].segments[0].commits[0].description = "database caching layer".into();
+        graph.stacks[0].segments[1].commits[0].description = "login page styling".into();
+        // Mark only mid: its dynamic segment is base+mid (both folded in).
+        let s = spec(|s| s.new_auto = vec!["bbbb".into()]);
+        let result = resolve_bookmarks_explicitly(&graph, &s, Some("gb-"), None)
+            .await
+            .unwrap();
+        let name = &result.assignments[0].bookmark_name;
+        assert!(name.starts_with("gb-"), "prefix applied: {name}");
+        // Terms come from the folded commits, not just the boundary.
+        assert!(
+            name.contains("database") || name.contains("caching") || name.contains("login"),
+            "tf-idf terms from the dynamic segment: {name}",
+        );
+    }
+
+    #[tokio::test]
+    async fn new_auto_falls_back_to_default_name() {
+        let mut graph = single_stack_graph();
+        // No description, no files: TF-IDF has nothing to work with.
+        graph.stacks[0].segments[0].commits[0].description = String::new();
+        graph.stacks[0].segments[0].commits[0].files = vec![];
+        let s = spec(|s| s.new_auto = vec!["aaaa".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            result.assignments[0].bookmark_name,
+            bookmark_gen::default_bookmark_name("aaaa1111"),
+        );
+    }
+
+    /// Two auto marks deriving the same TF-IDF name do not collide: the
+    /// second falls back to its `stakk-<change_id>` default, mirroring the
+    /// TUI's skip-on-duplicate semantics.
+    #[tokio::test]
+    async fn second_auto_mark_with_identical_input_falls_back() {
+        let mut graph = single_stack_graph();
+        graph.stacks[0].segments[0].commits[0].description = "identical words here".into();
+        graph.stacks[0].segments[0].commits[0].files = vec![];
+        graph.stacks[0].segments[1].commits[0].description = "identical words here".into();
+        graph.stacks[0].segments[1].commits[0].files = vec![];
+        let s = spec(|s| s.new_auto = vec!["aaaa".into(), "bbbb".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            result.assignments[1].bookmark_name,
+            bookmark_gen::default_bookmark_name("bbbb2222"),
+        );
+        assert_ne!(
+            result.assignments[0].bookmark_name,
+            result.assignments[1].bookmark_name,
+        );
+    }
+
+    /// An empty rev must be rejected at parse time — `starts_with("")`
+    /// would otherwise match every commit.
+    #[test]
+    fn empty_rev_for_auto_and_command_flags_errors() {
+        for flag in ["--new-auto", "--new-command"] {
+            let args = parse_submit(&["stakk", "submit", flag, ""]);
+            let err = SelectionSpec::from_args(&args).unwrap_err();
+            assert!(
+                matches!(err, ExplicitSelectionError::EmptyRev { .. }),
+                "expected EmptyRev for {flag}",
+            );
+        }
+    }
+
+    /// A prefix matching one mutable and one immutable commit resolves to
+    /// the mutable one — immutable commits are not submittable candidates.
+    #[tokio::test]
+    async fn rev_prefix_shared_with_immutable_commit_is_not_ambiguous() {
+        let mut graph = single_stack_graph();
+        // Both commits share the "b" prefix; make the base one immutable.
+        graph.stacks[0].segments[0].commits[0].change_id = "baaa1111".into();
+        graph.stacks[0].segments[0].commits[0].is_immutable = true;
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "b".into(),
+                name: Some("picked".into()),
+            }];
+        });
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(result.assignments[0].change_id, "bbbb2222");
+
+        // A prefix matching ONLY the immutable commit reports immutability.
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "ba".into(),
+                name: Some("picked".into()),
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::RevImmutable { .. }));
+    }
+
+    /// A default-named `--new REV` whose `stakk-<change_id>` name already
+    /// exists as a bookmark errors at selection time, not at execution.
+    #[tokio::test]
+    async fn new_default_name_colliding_with_existing_bookmark_errors() {
+        let mut graph = single_stack_graph();
+        let taken = bookmark_gen::default_bookmark_name("bbbb2222");
+        graph.stacks[0].segments[0].bookmark_names = vec![taken.clone()];
+        graph.stacks[0].segments[0].commits[0].local_bookmark_names = vec![taken];
+        let s = spec(|s| {
+            s.new = vec![NewBookmarkSpec {
+                rev: "bbbb".into(),
+                name: None,
+            }];
+        });
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::NewNameExists { .. }));
+    }
+
+    /// An auto mark whose TF-IDF name collides with an existing bookmark
+    /// falls back to the default name instead of erroring.
+    #[tokio::test]
+    async fn auto_mark_colliding_with_existing_bookmark_falls_back() {
+        let mut graph = single_stack_graph();
+        graph.stacks[0].segments[1].commits[0].description = "database caching layer".into();
+        graph.stacks[0].segments[1].commits[0].files = vec![];
+        // Discover what TF-IDF derives for the segment, then plant an
+        // existing bookmark with exactly that name on the base segment.
+        let s = spec(|s| s.new_auto = vec!["bbbb".into()]);
+        let derived = resolve(&graph, &s)
+            .await
+            .unwrap()
+            .assignments
+            .swap_remove(0)
+            .bookmark_name;
+        graph.stacks[0].segments[0].bookmark_names = vec![derived.clone()];
+        graph.stacks[0].segments[0].commits[0].local_bookmark_names = vec![derived];
+        let result = resolve(&graph, &s).await.unwrap();
+        assert_eq!(
+            result.assignments[0].bookmark_name,
+            bookmark_gen::default_bookmark_name("bbbb2222"),
+        );
+    }
+
+    // -- bookmark command --
+
+    #[tokio::test]
+    async fn new_command_unconfigured_errors() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.new_command = vec!["bbbb".into()]);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::BookmarkCommandNotConfigured
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn new_command_runs_and_names() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.new_command = vec!["bbbb".into()]);
+        let result = resolve_bookmarks_explicitly(&graph, &s, None, Some("echo from-command"))
+            .await
+            .unwrap();
+        assert_eq!(names(&result), vec![("from-command", true)]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn new_command_failure_propagates() {
+        let graph = single_stack_graph();
+        let s = spec(|s| s.new_command = vec!["bbbb".into()]);
+        let err = resolve_bookmarks_explicitly(&graph, &s, None, Some("false"))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::Gen(BookmarkGenError::CommandFailed { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn new_command_receives_dynamic_segment_json() {
+        use std::io::Write;
+
+        let graph = single_stack_graph();
+        let tmpdir = std::env::temp_dir();
+        let script = tmpdir.join("stakk_explicit_stdin.sh");
+        let capture = tmpdir.join("stakk_explicit_stdin_capture.json");
+        {
+            let mut f = std::fs::File::create(&script).unwrap();
+            writeln!(f, "#!/bin/sh").unwrap();
+            writeln!(f, "cat > {}", capture.display()).unwrap();
+            writeln!(f, "echo captured-name").unwrap();
+        }
+
+        // Mark mid: the dynamic segment is base + mid, oldest first.
+        let s = spec(|s| s.new_command = vec!["bbbb".into()]);
+        let result = resolve_bookmarks_explicitly(
+            &graph,
+            &s,
+            None,
+            Some(&format!("sh {}", script.display())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(names(&result), vec![("captured-name", true)]);
+
+        let captured = std::fs::read_to_string(&capture).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&captured).unwrap();
+        assert_eq!(parsed["schema_version"], 1);
+        let commits = parsed["commits"].as_array().unwrap();
+        assert_eq!(commits.len(), 2, "base folds into mid's segment");
+        assert_eq!(commits[0]["change_id"], "aaaa1111");
+        assert_eq!(commits[1]["change_id"], "bbbb2222");
+
+        let _ = std::fs::remove_file(&script);
+        let _ = std::fs::remove_file(&capture);
+    }
+
+    // -- misc --
+
+    #[tokio::test]
+    async fn empty_graph_errors_no_stacks() {
+        let graph = make_graph(vec![]);
+        let s = spec(|s| s.keep_all = true);
+        let err = resolve(&graph, &s).await.unwrap_err();
+        assert!(matches!(err, ExplicitSelectionError::NoStacks));
+    }
+
+    /// End-to-end: resolve, then feed the result into
+    /// `analysis_from_selection` and check fold semantics.
+    #[tokio::test]
+    async fn resolves_into_folding_analysis() {
+        let graph = single_stack_graph();
+        // Keep base and leaf; mid folds into leaf.
+        let s = spec(|s| s.keep = vec!["base".into(), "leaf".into()]);
+        let result = resolve(&graph, &s).await.unwrap();
+
+        let analysis =
+            crate::submit::analysis_from_selection(&result.path, &result.assignments, "main")
+                .unwrap();
+        assert_eq!(analysis.segments.len(), 2);
+        assert_eq!(analysis.segments[0].bookmark_names, vec!["base"]);
+        assert_eq!(analysis.segments[1].bookmark_names, vec!["leaf"]);
+        // mid's commit folded into leaf's segment (newest first).
+        let leaf_ids: Vec<&str> = analysis.segments[1]
+            .commits
+            .iter()
+            .map(|c| c.change_id.as_str())
+            .collect();
+        assert_eq!(leaf_ids, vec!["cccc3333", "bbbb2222"]);
+    }
+
+    // -- SelectionSpec::from_args --
+
+    fn parse_submit(args: &[&str]) -> crate::cli::submit::SubmitArgs {
+        use clap::Parser;
+        let cli = crate::cli::Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(crate::cli::Commands::Submit(a)) => *a,
+            _ => cli.submit_args,
+        }
+    }
+
+    #[test]
+    fn from_args_splits_rev_name() {
+        let args = parse_submit(&["stakk", "submit", "--new", "abc=my-name", "--new", "def"]);
+        let spec = SelectionSpec::from_args(&args).unwrap();
+        assert_eq!(
+            spec.new,
+            vec![
+                NewBookmarkSpec {
+                    rev: "abc".into(),
+                    name: Some("my-name".into()),
+                },
+                NewBookmarkSpec {
+                    rev: "def".into(),
+                    name: None,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn from_args_rejects_empty_rev_or_name() {
+        for bad in ["=name", "rev=", ""] {
+            let args = parse_submit(&["stakk", "submit", "--new", bad]);
+            let err = SelectionSpec::from_args(&args).unwrap_err();
+            assert!(
+                matches!(err, ExplicitSelectionError::InvalidNewSpec { .. }),
+                "expected InvalidNewSpec for {bad:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn from_args_validates_explicit_names() {
+        let args = parse_submit(&["stakk", "submit", "--new", "abc=has space"]);
+        let err = SelectionSpec::from_args(&args).unwrap_err();
+        assert!(matches!(
+            err,
+            ExplicitSelectionError::Gen(BookmarkGenError::InvalidName { .. })
+        ));
+    }
+
+    #[test]
+    fn spec_is_empty() {
+        let args = parse_submit(&["stakk", "submit"]);
+        assert!(SelectionSpec::from_args(&args).unwrap().is_empty());
+        let args = parse_submit(&["stakk", "submit", "--keep-all"]);
+        assert!(!SelectionSpec::from_args(&args).unwrap().is_empty());
+    }
+}

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -7,6 +7,7 @@ mod app;
 pub(crate) mod bookmark_gen;
 mod bookmark_widget;
 mod event;
+pub(crate) mod explicit;
 mod graph_widget;
 mod tfidf;
 

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -14,23 +14,20 @@ use std::io::IsTerminal;
 
 use crate::error::StakkError;
 use crate::graph::types::ChangeGraph;
-
-/// A bookmark assignment for a commit in the submission stack.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BookmarkAssignment {
-    /// The jj change ID for this commit.
-    pub change_id: String,
-    /// The bookmark name (existing or newly generated).
-    pub bookmark_name: String,
-    /// `true` if stakk must run `jj bookmark create` for this bookmark.
-    pub is_new: bool,
-}
+// The assignment type lives in `submit` (the consumer); re-exported here so
+// selection code can construct it without importing across layers.
+pub use crate::submit::BookmarkAssignment;
 
 /// Result of the interactive selection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectionResult {
     /// Ordered trunk-to-leaf bookmark assignments.
     pub assignments: Vec<BookmarkAssignment>,
+    /// The full trunk-to-tip commit chain of the selected stack (oldest
+    /// first). Every assignment's `change_id` is on this path. Feeds
+    /// `submit::analysis_from_selection`, which needs the commits between
+    /// and above the boundaries.
+    pub path: Vec<crate::graph::types::SegmentCommit>,
 }
 
 /// Resolve bookmarks interactively from the change graph using a TUI.
@@ -92,6 +89,7 @@ mod tests {
     fn bookmark_assignment_new_flag() {
         let existing = BookmarkAssignment {
             change_id: "abc123".to_string(),
+            short_change_id: "abc".to_string(),
             bookmark_name: "my-feature".to_string(),
             is_new: false,
         };
@@ -99,6 +97,7 @@ mod tests {
 
         let generated = BookmarkAssignment {
             change_id: "def456".to_string(),
+            short_change_id: "def".to_string(),
             bookmark_name: "stakk-def456abcdef".to_string(),
             is_new: true,
         };
@@ -108,14 +107,17 @@ mod tests {
     #[test]
     fn selection_result_ordering() {
         let result = SelectionResult {
+            path: vec![],
             assignments: vec![
                 BookmarkAssignment {
                     change_id: "base".to_string(),
+                    short_change_id: "base".to_string(),
                     bookmark_name: "base-bm".to_string(),
                     is_new: false,
                 },
                 BookmarkAssignment {
                     change_id: "leaf".to_string(),
+                    short_change_id: "leaf".to_string(),
                     bookmark_name: "leaf-bm".to_string(),
                     is_new: true,
                 },

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -6,6 +6,7 @@
 mod trailers;
 mod unwrap;
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 
@@ -96,6 +97,45 @@ pub enum SubmitError {
         bookmark: String,
         #[source]
         source: ForgeError,
+    },
+
+    /// A selected assignment targets a commit that is not on the selected
+    /// path.
+    #[error(
+        "bookmark assignment '{bookmark}' targets change {change_id}, which is not on the \
+         selected path"
+    )]
+    #[diagnostic(
+        code(stakk::submit::assignment_off_path),
+        help("this indicates a bug in the selection layer — please report it")
+    )]
+    AssignmentOffPath { bookmark: String, change_id: String },
+
+    /// A change ID matches more than one commit on the selected path.
+    #[error(
+        "change {change_id} is divergent: it matches more than one commit on the selected path"
+    )]
+    #[diagnostic(
+        code(stakk::submit::divergent_change),
+        help(
+            "resolve the divergence first, e.g. `jj abandon` the copy you do not want, then re-run"
+        )
+    )]
+    DivergentChange { change_id: String },
+
+    /// Failed to create a local bookmark during execution.
+    #[error("failed to create bookmark '{bookmark}'")]
+    #[diagnostic(
+        code(stakk::submit::bookmark_create_failed),
+        help(
+            "check that the name is not already taken (`jj bookmark list`) and that the target \
+             commit still exists"
+        )
+    )]
+    BookmarkCreateFailed {
+        bookmark: String,
+        #[source]
+        source: JjError,
     },
 
     /// Failed to push a bookmark to the remote.
@@ -200,7 +240,7 @@ pub enum SubmitError {
 // ---------------------------------------------------------------------------
 
 /// Phase 1 output: the segments relevant to a submission.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionAnalysis {
     /// Segments from trunk to the target bookmark, inclusive.
     /// Ordered trunk-to-leaf (same as `BranchStack::segments`).
@@ -238,9 +278,44 @@ pub struct BookmarkPlan {
     pub needs_body_sync: bool,
 }
 
+/// A bookmark assignment for a commit in the submission stack.
+///
+/// Produced by the selection layer (the TUI, or future non-interactive
+/// selection sources) and consumed by `analysis_from_selection`; defined
+/// here so the submission engine does not depend on UI types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BookmarkAssignment {
+    /// The jj change ID for this commit.
+    pub change_id: String,
+    /// Shortest unique change ID prefix, for display.
+    pub short_change_id: String,
+    /// The bookmark name (existing or newly generated).
+    pub bookmark_name: String,
+    /// `true` if stakk must run `jj bookmark create` for this bookmark.
+    pub is_new: bool,
+}
+
+/// A local bookmark the execute phase must create before pushing.
+///
+/// Creation is deferred to execution so that `--dry-run` never mutates the
+/// repository; the plan lists pending creations instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BookmarkCreation {
+    /// The bookmark name to create.
+    pub bookmark_name: String,
+    /// The jj change the bookmark points at.
+    pub change_id: String,
+    /// Shortest unique change ID prefix, for display.
+    pub short_change_id: String,
+}
+
 /// Phase 2 output: the full submission plan.
 #[derive(Debug)]
 pub struct SubmissionPlan {
+    /// Local bookmarks to create before pushing. Derived from the
+    /// selection's `is_new` assignments; empty for the positional
+    /// `stakk submit <bookmark>` path where every bookmark already exists.
+    pub bookmark_creations: Vec<BookmarkCreation>,
     /// Per-bookmark plans, ordered trunk-to-leaf.
     pub bookmark_plans: Vec<BookmarkPlan>,
     /// The remote name to push to.
@@ -361,6 +436,82 @@ pub fn analyze_submission(
     })
 }
 
+/// Build a submission analysis directly from an explicit selection.
+///
+/// `path` is the full trunk-to-tip commit chain of the selected stack and
+/// `assignments` (trunk-to-leaf) name the commits that become segment
+/// boundaries. Commits between boundaries belong to the boundary above them
+/// — the same fold semantics as `analyze_submission` with a selected subset.
+/// Commits above the last boundary are not part of the submission.
+///
+/// Unlike `analyze_submission`, no bookmark lookup happens: boundaries are
+/// matched by change ID, so bookmarks that do not exist yet (`is_new`
+/// assignments) work without creating them first or rebuilding the graph.
+/// That keeps `--dry-run` free of side effects; the execute phase performs
+/// the actual `jj bookmark create` calls.
+///
+/// Contract: every assignment's `change_id` must be present on `path`
+/// (guaranteed by the TUI, whose rows come from the selected path). An
+/// assignment whose change ID is not on the path errors with
+/// `AssignmentOffPath`; a change ID matching more than one path commit (a
+/// divergent change) errors with `DivergentChange` — silently dropping or
+/// duplicating a boundary would otherwise desync the analysis from the
+/// bookmark creations scheduled for execution.
+///
+/// Where a segment carries several bookmark names, the resulting segment
+/// keeps only the assigned name — the name the user actually chose — rather
+/// than all names like `analyze_submission` does. With several consecutive
+/// folded segments the folded commits are ordered strictly newest-first,
+/// per `BookmarkSegment::commits`' convention.
+pub fn analysis_from_selection(
+    path: &[SegmentCommit],
+    assignments: &[BookmarkAssignment],
+    default_branch: &str,
+) -> Result<SubmissionAnalysis, SubmitError> {
+    let boundaries: HashMap<&str, &BookmarkAssignment> = assignments
+        .iter()
+        .map(|a| (a.change_id.as_str(), a))
+        .collect();
+
+    let mut segments = Vec::new();
+    let mut consumed: HashSet<&str> = HashSet::new();
+    // Oldest-first buffer of commits belonging to the next boundary above.
+    let mut pending: Vec<SegmentCommit> = Vec::new();
+
+    for commit in path {
+        pending.push(commit.clone());
+        if let Some(assignment) = boundaries.get(commit.change_id.as_str()) {
+            if !consumed.insert(assignment.change_id.as_str()) {
+                return Err(SubmitError::DivergentChange {
+                    change_id: assignment.change_id.clone(),
+                });
+            }
+            // Newest-first within the segment (internal convention).
+            pending.reverse();
+            segments.push(BookmarkSegment {
+                bookmark_names: vec![assignment.bookmark_name.clone()],
+                change_id: assignment.change_id.clone(),
+                commits: std::mem::take(&mut pending),
+            });
+        }
+    }
+
+    if let Some(missed) = assignments
+        .iter()
+        .find(|a| !consumed.contains(a.change_id.as_str()))
+    {
+        return Err(SubmitError::AssignmentOffPath {
+            bookmark: missed.bookmark_name.clone(),
+            change_id: missed.change_id.clone(),
+        });
+    }
+
+    Ok(SubmissionAnalysis {
+        segments,
+        default_branch: default_branch.to_string(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -420,9 +571,13 @@ fn build_pr_body(commits: &[SegmentCommit], trailers: TrailerHandling) -> Option
 /// Query the forge to determine what actions are needed for each bookmark.
 ///
 /// For each segment in the analysis, checks the forge for existing PRs and
-/// determines whether to push, create, or update.
+/// determines whether to push, create, or update. `bookmark_creations` are
+/// the local bookmarks the execute phase must create first (empty for the
+/// positional path, where every bookmark already exists); taking them here
+/// keeps the returned plan complete at construction.
 pub async fn create_submission_plan<F: Forge>(
     analysis: &SubmissionAnalysis,
+    bookmark_creations: Vec<BookmarkCreation>,
     forge: &F,
     remote: &str,
     pr_mode: PrMode,
@@ -520,6 +675,7 @@ pub async fn create_submission_plan<F: Forge>(
     }
 
     Ok(SubmissionPlan {
+        bookmark_creations,
         bookmark_plans,
         remote: remote.to_string(),
         pr_mode,
@@ -545,6 +701,14 @@ impl fmt::Display for SubmissionPlan {
             self.bookmark_plans.len(),
             self.remote,
         )?;
+
+        for creation in &self.bookmark_creations {
+            write!(
+                f,
+                "\n  Create bookmark {} at {}",
+                creation.bookmark_name, creation.short_change_id,
+            )?;
+        }
 
         for bp in &self.bookmark_plans {
             write!(f, "\n  {} (base: {})", bp.bookmark_name, bp.base)?;
@@ -604,6 +768,19 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
 
     let effective = resolve_placement(placement);
+
+    // Create pending local bookmarks first — pushes below require them to
+    // exist. Creation is local-only, so the one-at-a-time interleaving rule
+    // (which concerns pushes and base updates, #35) does not apply here.
+    for creation in &plan.bookmark_creations {
+        pb.set_message(format!("Creating bookmark: {}", creation.bookmark_name));
+        jj.create_bookmark(&creation.bookmark_name, &creation.change_id)
+            .await
+            .map_err(|source| SubmitError::BookmarkCreateFailed {
+                bookmark: creation.bookmark_name.clone(),
+                source,
+            })?;
+    }
 
     let mut stack_entries = Vec::new();
 
@@ -1005,6 +1182,7 @@ mod tests {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum Op {
+        CreateBookmark(String),
         Push(String),
         BaseUpdate(u64),
         CreatePr(String),
@@ -1295,7 +1473,14 @@ mod tests {
             &self,
             args: &[&str],
         ) -> impl std::future::Future<Output = Result<String, JjError>> + Send {
-            // Only handle push commands.
+            if args[0] == "bookmark"
+                && args[1] == "create"
+                && let Some(ops) = &self.ops
+            {
+                ops.lock()
+                    .unwrap()
+                    .push(Op::CreateBookmark(args[2].to_string()));
+            }
             if args[0] == "git" && args[1] == "push" {
                 let bookmark = args
                     .iter()
@@ -1520,6 +1705,281 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // analysis_from_selection tests
+    // -----------------------------------------------------------------------
+
+    fn make_assignment(change_id: &str, name: &str, is_new: bool) -> BookmarkAssignment {
+        BookmarkAssignment {
+            change_id: change_id.to_string(),
+            short_change_id: change_id[..4.min(change_id.len())].to_string(),
+            bookmark_name: name.to_string(),
+            is_new,
+        }
+    }
+
+    /// A segment with several commits, described newest-first like the
+    /// internal convention. Commit change ids are `<change_id>` for the
+    /// boundary and `<change_id>_<i>` for the rest.
+    fn make_segment_multi(names: &[&str], change_id: &str, descs: &[&str]) -> BookmarkSegment {
+        let mut seg = make_segment(names, change_id, descs[0]);
+        let template = seg.commits[0].clone();
+        for (i, desc) in descs.iter().enumerate().skip(1) {
+            let mut c = template.clone();
+            c.change_id = format!("{change_id}_{i}");
+            c.commit_id = format!("c_{change_id}_{i}");
+            c.short_change_id = format!("{}{i}", template.short_change_id);
+            c.description = (*desc).to_string();
+            seg.commits.push(c);
+        }
+        seg
+    }
+
+    fn path_of(stack: &BranchStack) -> Vec<SegmentCommit> {
+        stack.commits_trunk_to_tip().cloned().collect()
+    }
+
+    /// Leaf-only selection matches `analyze_submission` with the same
+    /// selected set: the folded ancestor joins the leaf PR.
+    #[test]
+    fn from_selection_parity_leaf_only() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", "feature a"),
+                make_segment(&["feat-b"], "ch_b", "feature b"),
+            ],
+        };
+        let path = path_of(&stack);
+        let graph = make_graph(vec![stack]);
+
+        let selected = HashSet::from(["feat-b".to_string()]);
+        let reference = analyze_submission("feat-b", &graph, "main", Some(&selected)).unwrap();
+
+        let direct =
+            analysis_from_selection(&path, &[make_assignment("ch_b", "feat-b", false)], "main")
+                .unwrap();
+
+        assert_eq!(direct, reference);
+    }
+
+    /// Keeping a subset folds the unkept middle segment into the one above,
+    /// exactly like `analyze_submission`.
+    #[test]
+    fn from_selection_parity_subset() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", "feature a"),
+                make_segment(&["feat-b"], "ch_b", "feature b"),
+                make_segment(&["feat-c"], "ch_c", "feature c"),
+            ],
+        };
+        let path = path_of(&stack);
+        let graph = make_graph(vec![stack]);
+
+        let selected = HashSet::from(["feat-a".to_string(), "feat-c".to_string()]);
+        let reference = analyze_submission("feat-c", &graph, "main", Some(&selected)).unwrap();
+
+        let direct = analysis_from_selection(
+            &path,
+            &[
+                make_assignment("ch_a", "feat-a", false),
+                make_assignment("ch_c", "feat-c", false),
+            ],
+            "main",
+        )
+        .unwrap();
+
+        assert_eq!(direct, reference);
+    }
+
+    /// Selecting every boundary matches the positional no-folding path.
+    #[test]
+    fn from_selection_parity_all_boundaries() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", "feature a"),
+                make_segment(&["feat-b"], "ch_b", "feature b"),
+            ],
+        };
+        let path = path_of(&stack);
+        let graph = make_graph(vec![stack]);
+
+        let reference = analyze_submission("feat-b", &graph, "main", None).unwrap();
+
+        let direct = analysis_from_selection(
+            &path,
+            &[
+                make_assignment("ch_a", "feat-a", false),
+                make_assignment("ch_b", "feat-b", false),
+            ],
+            "main",
+        )
+        .unwrap();
+
+        assert_eq!(direct, reference);
+    }
+
+    /// A new bookmark on a mid-segment commit splits the segment — possible
+    /// without the bookmark existing anywhere, unlike `analyze_submission`.
+    #[test]
+    fn from_selection_splits_segment_at_new_bookmark() {
+        let stack = BranchStack {
+            segments: vec![make_segment_multi(
+                &["feat"],
+                "ch_f",
+                &["newest work", "older work"],
+            )],
+        };
+        let path = path_of(&stack);
+
+        let direct = analysis_from_selection(
+            &path,
+            &[
+                make_assignment("ch_f_1", "my-new-base", true),
+                make_assignment("ch_f", "feat", false),
+            ],
+            "main",
+        )
+        .unwrap();
+
+        assert_eq!(direct.segments.len(), 2);
+        assert_eq!(direct.segments[0].bookmark_names, vec!["my-new-base"]);
+        assert_eq!(direct.segments[0].change_id, "ch_f_1");
+        assert_eq!(direct.segments[0].commits.len(), 1);
+        assert_eq!(direct.segments[0].commits[0].description, "older work");
+        assert_eq!(direct.segments[1].bookmark_names, vec!["feat"]);
+        assert_eq!(direct.segments[1].commits.len(), 1);
+        assert_eq!(direct.segments[1].commits[0].description, "newest work");
+    }
+
+    /// Commits above the topmost assignment are not part of the submission
+    /// (parity with `analyze_submission`'s trunk..=target slice).
+    #[test]
+    fn from_selection_drops_commits_above_topmost_mark() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", "feature a"),
+                make_segment(&["feat-b"], "ch_b", "feature b"),
+            ],
+        };
+        let path = path_of(&stack);
+
+        let direct =
+            analysis_from_selection(&path, &[make_assignment("ch_a", "feat-a", false)], "main")
+                .unwrap();
+
+        assert_eq!(direct.segments.len(), 1);
+        assert_eq!(direct.segments[0].bookmark_names, vec!["feat-a"]);
+        assert_eq!(direct.segments[0].commits.len(), 1);
+    }
+
+    /// Segment commits stay newest-first even when several folded segments
+    /// accumulate. (`analyze_submission` interleaves folded segments in
+    /// trunk-to-leaf order here — a quirk this constructor does not copy;
+    /// same commit set, stated convention for the order.)
+    #[test]
+    fn from_selection_multi_fold_orders_newest_first() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_a", "feature a"),
+                make_segment(&["feat-b"], "ch_b", "feature b"),
+                make_segment(&["feat-c"], "ch_c", "feature c"),
+                make_segment(&["feat-d"], "ch_d", "feature d"),
+            ],
+        };
+        let path = path_of(&stack);
+        let graph = make_graph(vec![stack]);
+
+        let direct =
+            analysis_from_selection(&path, &[make_assignment("ch_d", "feat-d", false)], "main")
+                .unwrap();
+
+        assert_eq!(direct.segments.len(), 1);
+        let ids: Vec<&str> = direct.segments[0]
+            .commits
+            .iter()
+            .map(|c| c.change_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["ch_d", "ch_c", "ch_b", "ch_a"]);
+
+        // Same commit set as the analyze path, ordering aside.
+        let selected = HashSet::from(["feat-d".to_string()]);
+        let reference = analyze_submission("feat-d", &graph, "main", Some(&selected)).unwrap();
+        let mut reference_ids: Vec<String> = reference.segments[0]
+            .commits
+            .iter()
+            .map(|c| c.change_id.clone())
+            .collect();
+        let mut direct_ids: Vec<String> =
+            ids.iter().map(std::string::ToString::to_string).collect();
+        reference_ids.sort_unstable();
+        direct_ids.sort_unstable();
+        assert_eq!(direct_ids, reference_ids);
+    }
+
+    /// An assignment whose change ID is not on the path is a hard error —
+    /// silently dropping it would desync the analysis from the bookmark
+    /// creations scheduled for execution.
+    #[test]
+    fn from_selection_errors_on_off_path_assignment() {
+        let stack = BranchStack {
+            segments: vec![make_segment(&["feat-a"], "ch_a", "feature a")],
+        };
+        let path = path_of(&stack);
+
+        let err = analysis_from_selection(
+            &path,
+            &[
+                make_assignment("ch_a", "feat-a", false),
+                make_assignment("ch_elsewhere", "stray", true),
+            ],
+            "main",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SubmitError::AssignmentOffPath { ref bookmark, ref change_id }
+                if bookmark == "stray" && change_id == "ch_elsewhere"
+        ));
+    }
+
+    /// A change ID matching two path commits (divergent change) is a hard
+    /// error rather than two segments claiming the same bookmark.
+    #[test]
+    fn from_selection_errors_on_divergent_change() {
+        let stack = BranchStack {
+            segments: vec![
+                make_segment(&["feat-a"], "ch_dup", "first copy"),
+                make_segment(&["feat-b"], "ch_dup", "second copy"),
+            ],
+        };
+        let path = path_of(&stack);
+
+        let err =
+            analysis_from_selection(&path, &[make_assignment("ch_dup", "feat-a", false)], "main")
+                .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SubmitError::DivergentChange { ref change_id } if change_id == "ch_dup"
+        ));
+    }
+
+    /// Empty assignments produce an empty analysis (the callers guard
+    /// against submitting one, but the constructor itself must not panic).
+    #[test]
+    fn from_selection_empty_assignments() {
+        let stack = BranchStack {
+            segments: vec![make_segment(&["feat-a"], "ch_a", "feature a")],
+        };
+        let path = path_of(&stack);
+
+        let direct = analysis_from_selection(&path, &[], "main").unwrap();
+        assert!(direct.segments.is_empty());
+        assert_eq!(direct.default_branch, "main");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 2 tests
     // -----------------------------------------------------------------------
 
@@ -1537,6 +1997,7 @@ mod tests {
         let forge = MockForge::new();
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1569,6 +2030,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1603,6 +2065,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1636,6 +2099,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1661,6 +2125,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1686,6 +2151,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1716,6 +2182,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1745,6 +2212,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1768,6 +2236,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1792,6 +2261,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1819,6 +2289,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1846,6 +2317,7 @@ mod tests {
 
         let plan = create_submission_plan(
             &analysis,
+            vec![],
             &forge,
             "origin",
             PrMode::Regular,
@@ -1888,6 +2360,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -1916,6 +2389,7 @@ mod tests {
                 needs_title_sync: true,
                 needs_body_sync: true,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -1927,9 +2401,90 @@ mod tests {
         assert!(!output.contains("up to date"));
     }
 
+    #[test]
+    fn plan_display_shows_pending_bookmark_creations() {
+        let plan = SubmissionPlan {
+            bookmark_creations: vec![BookmarkCreation {
+                bookmark_name: "my-feature".to_string(),
+                change_id: "ch_new_full_id".to_string(),
+                short_change_id: "ch_n".to_string(),
+            }],
+            bookmark_plans: vec![BookmarkPlan {
+                bookmark_name: "my-feature".to_string(),
+                base: "main".to_string(),
+                title: "my feature".to_string(),
+                body: None,
+                existing_pr: None,
+                needs_push: true,
+                needs_create: true,
+                needs_base_update: false,
+                needs_title_sync: false,
+                needs_body_sync: false,
+            }],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+
+        let output = plan.to_string();
+        assert!(output.contains("Create bookmark my-feature at ch_n"));
+        // Creations are listed before the per-bookmark plans.
+        let creation_pos = output.find("Create bookmark").unwrap();
+        let plan_pos = output.find("my-feature (base: main)").unwrap();
+        assert!(creation_pos < plan_pos);
+    }
+
     // -----------------------------------------------------------------------
     // Phase 3 tests
     // -----------------------------------------------------------------------
+
+    /// Bookmark creations happen before any push or PR creation — pushes
+    /// require the bookmark to exist locally.
+    #[tokio::test]
+    async fn execute_creates_bookmarks_before_pushing() {
+        let ops: OpLog = Arc::new(Mutex::new(Vec::new()));
+        let plan = SubmissionPlan {
+            bookmark_creations: vec![BookmarkCreation {
+                bookmark_name: "feat-new".to_string(),
+                change_id: "ch_new".to_string(),
+                short_change_id: "ch_n".to_string(),
+            }],
+            bookmark_plans: vec![BookmarkPlan {
+                bookmark_name: "feat-new".to_string(),
+                base: "main".to_string(),
+                title: "new feature".to_string(),
+                body: None,
+                existing_pr: None,
+                needs_push: true,
+                needs_create: true,
+                needs_base_update: false,
+                needs_title_sync: false,
+                needs_body_sync: false,
+            }],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        };
+
+        let (runner, _push_calls) = MockJjRunner::new_with_ops(Arc::clone(&ops));
+        let jj = Jj::new(runner);
+        let forge = MockForge::new().with_ops(Arc::clone(&ops));
+        let env = test_comment_env();
+
+        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
+            .await
+            .unwrap();
+
+        let ops = ops.lock().unwrap();
+        assert_eq!(
+            *ops,
+            vec![
+                Op::CreateBookmark("feat-new".to_string()),
+                Op::Push("feat-new".to_string()),
+                Op::CreatePr("feat-new".to_string()),
+            ],
+        );
+    }
 
     #[tokio::test]
     async fn execute_creates_new_prs() {
@@ -1960,6 +2515,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -1999,6 +2555,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2047,6 +2604,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2129,6 +2687,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2187,6 +2746,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "my-remote".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2222,6 +2782,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Draft,
             default_branch: "main".to_string(),
@@ -2249,6 +2810,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Draft,
             default_branch: "main".to_string(),
@@ -2283,6 +2845,7 @@ mod tests {
                 needs_title_sync: true,
                 needs_body_sync: true,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2321,6 +2884,7 @@ mod tests {
                 needs_title_sync: true,
                 needs_body_sync: true,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2358,6 +2922,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2405,6 +2970,7 @@ mod tests {
                     needs_body_sync: true,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2793,6 +3359,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2857,6 +3424,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -2949,6 +3517,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3012,6 +3581,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3063,6 +3633,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3138,6 +3709,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3185,6 +3757,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3247,6 +3820,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3345,6 +3919,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3425,6 +4000,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3474,6 +4050,7 @@ mod tests {
                 needs_title_sync: false,
                 needs_body_sync: false,
             }],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Regular,
             default_branch: "main".to_string(),
@@ -3530,6 +4107,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Draft,
             default_branch: "main".to_string(),
@@ -3605,6 +4183,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Draft,
             default_branch: "main".to_string(),
@@ -3670,6 +4249,7 @@ mod tests {
                     needs_body_sync: false,
                 },
             ],
+            bookmark_creations: vec![],
             remote: "origin".to_string(),
             pr_mode: PrMode::Draft,
             default_branch: "main".to_string(),


### PR DESCRIPTION
`stakk submit` gains a fully explicit, scriptable selection mode that replaces the TUI — aimed at agents and scripts driving stakk from `stakk show --format=json`. Getting there also required moving bookmark creation out of selection and into the execute phase, so `--dry-run` no longer mutates the repo.

## Explicit selection flags

| Flag | Effect |
|---|---|
| `--keep <bookmark>` | An existing bookmark becomes a PR boundary (repeatable). |
| `--keep-all` | Every existing bookmark on the selected path. |
| `--new <rev>[=<name>]` | New bookmark at a change/commit id prefix — `stakk-<change_id>` by default, or the given name (repeatable). |
| `--new-auto <rev>` | TF-IDF name honoring `--auto-prefix`, falling back to the default name when nothing can be derived or the name is taken (repeatable). |
| `--new-command <rev>` | Name from `--bookmark-command`, which receives the same JSON payload as in the TUI (repeatable). |

Nothing is implicit: the marks fully determine the PR set. They must be colinear (one trunk→tip path); the topmost mark is the tip; unkept bookmarks on the path fold into the PR above. Bare `--keep-all` requires the stacks to agree on their bookmarks (unbookmarked heads such as the working copy do not count as disagreement); anchored, it skips explicitly marked commits. Revs resolve by prefix against mutable commits only, deduplicated by commit id across shared segments.

The resolver (`select/explicit.rs`) produces the same `SelectionResult` as the TUI and feeds `analysis_from_selection`. Errors are `stakk::selection::*` miette diagnostics whose help points at `stakk show`. The flags conflict with the positional bookmark and deliberately have no env vars or config keys (like `--dry-run`) — a persisted default would silently change what gets submitted.

Shared naming/wire-format logic is consolidated in `bookmark_gen` (`tfidf_prefixed_name`, `CommitInput: From<&BookmarkRow> / From<&SegmentCommit>`) so the TUI and flag paths cannot drift.

## `--dry-run` is now fully inert

Bookmark creation previously happened at selection time, before the `--dry-run` early return — a dry run of a TUI selection with new bookmarks mutated the repo. All repo mutations now live in the execute phase:

- `analysis_from_selection(path, assignments, default_branch)` builds the `SubmissionAnalysis` directly from the selected trunk→tip path, matching boundaries by change ID — new bookmarks need not exist yet, and the post-creation graph rebuild (a second `build_change_graph` incl. per-commit `jj diff`) is gone. Off-path assignments error with `stakk::submit::assignment_off_path`; a change ID matching two path commits errors with `stakk::submit::divergent_change`.
- `create_submission_plan` takes the pending `BookmarkCreation`s so the plan is complete at construction; its `Display` prints `Create bookmark <name> at <short_change_id>` lines, which is what `--dry-run` shows instead of performing them.
- `execute_submission_plan` creates the pending bookmarks before the push loop (`stakk::submit::bookmark_create_failed` on failure).
- `BookmarkAssignment` moves from `select` to `submit` (re-exported from `select`) so the submission engine's API no longer depends on a UI-layer type; it now carries `short_change_id` for display.
- `SelectionResult` carries the selected stack's trunk→tip commit path.
- The positional `stakk submit <bookmark>` path is unchanged (`analyze_submission(..., None)`, no folding).

## Accepted limitation

New bookmark names are no longer checked against the bookmarks revset (documented in `CLAUDE.md`): under a custom `--bookmarks-revset` excluding the new name, submission succeeds but subsequent runs will not manage that PR. The removed guard was no better — it errored only after the bookmark had already been created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
