### PR TITLE
chore: release v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0](https://github.com/glennib/stakk/compare/v1.22.0...v1.23.0) - 2026-08-13
+
+### Added
+
+- *(comment)* draw the stack graph leaf-first in the default template
+- *(cli)* non-interactive stack selection via --keep/--new flags
+- *(submit)* make `--dry-run` fully inert by creating bookmarks in execute
+
+### Fixed
+
+- *(select)* check new bookmark names against every local bookmark
+
+### Other
+
+- *(deps)* update dependency rumdl to v0.2.55 ([#197](https://github.com/glennib/stakk/pull/197))
+- update
+- *(cli)* tighten `--help` text without losing facts
+- gate Markdown formatting with rumdl
+- document `ignore` placement, missing flags, and rumdl workflow
+- use rumdl for formatting
+- *(ci)* run ci regardless of base branch
+- *(media)* update gif
+- *(submit)* drop `analyze_submission`'s test-only folding arm
+
 ## [1.22.0](https://github.com/glennib/stakk/compare/v1.21.0...v1.22.0) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "1.22.0"
+version = "1.23.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 1.22.0 -> 1.23.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.23.0](https://github.com/glennib/stakk/compare/v1.22.0...v1.23.0) - 2026-08-13

### Added

- *(comment)* draw the stack graph leaf-first in the default template
- *(cli)* non-interactive stack selection via --keep/--new flags
- *(submit)* make `--dry-run` fully inert by creating bookmarks in execute

### Fixed

- *(select)* check new bookmark names against every local bookmark

### Other

- *(deps)* update dependency rumdl to v0.2.55 ([#197](https://github.com/glennib/stakk/pull/197))
- update
- *(cli)* tighten `--help` text without losing facts
- gate Markdown formatting with rumdl
- document `ignore` placement, missing flags, and rumdl workflow
- use rumdl for formatting
- *(ci)* run ci regardless of base branch
- *(media)* update gif
- *(submit)* drop `analyze_submission`'s test-only folding arm
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).