### PR TITLE
ci: cache cargo artifacts and trim debug info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    env:
+      # Debug info is the bulk of the cached target directory. Line tables keep
+      # file:line in panic backtraces at a fraction of the size.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -22,6 +28,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Only the default branch writes cache entries: branch-scoped caches
+          # are invisible to other branches, so saving from a PR costs quota
+          # and helps nothing.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache mise
         uses: actions/cache@v6


### PR DESCRIPTION
Dependency work dominated CI: of the 94s spent in `mise run ci`, roughly 88s went to downloading and compiling the 397-crate dependency graph — twice over, once as `check` metadata for clippy and once as rlibs for build and test. `stakk`'s own code takes 4-6s per task and the 435 tests run in 0.744s. The workflow cached mise's tools but nothing from cargo.

- `Swatinem/rust-cache@v2` caches the registry, git checkouts and `target/`. Only the default branch saves: branch-scoped caches are invisible to other branches, so writing them from a PR costs quota without helping anything.
- `line-tables-only` debug info for the `dev` and `test` profiles keeps the cached target directory small while preserving `file:line` in panic backtraces. It lives in the workflow rather than `mise.toml` so local debug builds are unaffected.