### PR TITLE
feat(remote): support GitHub Enterprise Server hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ stakk uses its own comment metadata format
 
 ### 8. CLI args, env vars, and config travel together
 
-Every user-facing `submit` arg has four touchpoints that must stay in sync.
+Every user-facing `submit` arg has five touchpoints that must stay in sync.
 When adding, renaming, or changing the default of one, update all of them in the same change:
 
 1. **`src/cli/submit.rs`** — the clap field with `#[arg(long, env = "STAKK_…",
@@ -75,6 +75,9 @@ When adding, renaming, or changing the default of one, update all of them in the
    via `set_default(...)`, and add tests mirroring the `sync_pr_content_*` set: `default`, `config_*`,
    `cli_overrides_config`.
    Extend `toml_deserialize_full`.
+   A `global = true` arg on `Cli` (like `--config` and `--github-host`) is defined on the *root* command only,
+   so its default goes through `apply_global_defaults`, not `apply_submit_defaults` —
+   `mut_arg` on a subcommand would panic with "Argument is undefined".
 4. **`README.md`** — three places:
    - the `stakk.toml` example block,
    - the **Environment variables** table,
@@ -85,6 +88,9 @@ When adding, renaming, or changing the default of one, update all of them in the
    Options with a prose section of their own need that section updated too:
    `--stack-placement` has the **Stack info placement** mode table,
    the selection flags have **Agent / scripting usage**.
+5. **`docs/config.md`** — the same three places again
+   (the full `stakk.toml` block, the **Environment variables** table, and any prose section),
+   since README only carries an abbreviated version and links here.
 
 A change that lands in only some of these will silently drop config-file support, fail to appear in `--help` defaults,
 or stay invisible in the docs.
@@ -94,7 +100,7 @@ or stay invisible in the docs.
 ```text
 src/
 ├── main.rs          # CLI entry point (clap)
-├── auth.rs          # GitHub token resolution (gh CLI, env vars)
+├── auth.rs          # Per-host GitHub token resolution (gh CLI, env vars)
 ├── cli/             # clap subcommand definitions (Cli, SubmitArgs, ShowArgs, GraphArgs, AuthArgs, DocTopic)
 ├── config/          # TOML config discovery, merging, and clap-default injection
 ├── docs/            # `stakk docs` — include_str!s docs/*.md, renders them, generates the topic index
@@ -105,7 +111,7 @@ src/
 │   ├── mod.rs       # Jj<R: JjRunner> — every jj invocation
 │   ├── runner.rs    # JjRunner trait + real/mock runners
 │   ├── types.rs     # serde structs for jj template output
-│   ├── remote.rs    # GitHub remote URL parsing (GitHubRepo)
+│   ├── remote.rs    # Remote URL parsing + GitHub host gate (GitHubRepo, api_base_uri)
 │   └── version.rs   # jj version parsing + minimum supported version
 ├── forge/           # Forge trait + GitHub implementation (octocrab)
 │   ├── mod.rs       # Forge trait, forge-agnostic types, ForgeError
@@ -338,7 +344,7 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   The variant doc comments are load-bearing:
   clap prints them as possible-value help *and* `docs::index` reads them back.
   `DocTopic` has no `Default` on purpose — `None` means "print the index", not "print a default topic".
-  `stakk docs` is exempt from the four-touchpoint rule (§8): no env var, no config key,
+  `stakk docs` is exempt from the five-touchpoint rule (§8): no env var, no config key,
   so README is the only other touchpoint.
   Add it to the `runs_jj` false-arm in `main.rs` alongside `Completions`,
   or the `_ => true` fallthrough makes it shell out to jj for a version check it does not need.
@@ -351,6 +357,21 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   Fenced blocks pass through the wrapper unwrapped
   (a folded shell command is a broken one),
   so a test caps fenced lines in `docs/*.md` at 76 chars — rumdl formats at 120 and will not catch it.
+- Remote host handling: `jj::remote::parse_remote_url` parses `<host>/<owner>/<repo>` for *any* host;
+  `parse_github_url` layers the gate on top, accepting `GITHUB_COM` plus one configured host
+  (`--github-host` / `STAKK_GITHUB_HOST` / `github_host` / `GH_HOST`, resolved once in `run()`).
+  The URL is the source of truth for the host — the setting only says which hosts are allowed,
+  so a repo with both a github.com and an Enterprise remote still works.
+  SSH ports are dropped (they say nothing about the API) and HTTP(S) ports are kept (they are the API port).
+  `GitHubRepo::api_base_uri()` returns `None` for github.com,
+  so octocrab keeps its own `https://api.github.com` default, and `https://<host>/api/v3` otherwise —
+  the two are not one template.
+  Always `https`, even for an `http://` remote.
+- The remote must be resolved *before* the token:
+  `auth::resolve_token(host)` picks `GITHUB_TOKEN`/`GH_TOKEN` for github.com
+  and `GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN` otherwise, and passes `--hostname` to `gh auth token`.
+  Without `--hostname`, gh answers for whatever `GH_HOST` names, which need not be this repo's host.
+  `env_sources`/`token_from_env` take the lookup as a closure so tests never mutate the process environment.
 - jj JSON output uses NDJSON (one JSON object per line).
   Parse with `lines()` plus a per-line `serde_json::from_str`.
 - `jj git remote list` outputs plain text, not JSON.
@@ -495,7 +516,7 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
 - **Selection flags not in env vars/config** — `--keep`, `--keep-all`, `--new`, `--new-auto`,
   `--new-command` are per-invocation decisions like `--dry-run`;
   a persisted default would silently change what gets submitted.
-  CLI + README touchpoints only (deliberate exception to the four-touchpoint rule).
+  CLI + README touchpoints only (deliberate exception to the five-touchpoint rule).
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
 - **Three-phase submission** — analyze (pure) → plan (queries forge) → execute.
   All repo mutations (bookmark creation, pushes) live in execute, so `--dry-run` —

--- a/README.md
+++ b/README.md
@@ -191,10 +191,27 @@ auto_prefix = "gb-"
 Every config key, the `inherit` field, worked examples, and the full environment variable table:
 [docs/config.md](docs/config.md), or run `stakk docs config`.
 
+### GitHub Enterprise Server
+
+github.com works out of the box.
+For a GitHub Enterprise Server host, name the host with `--github-host`, `STAKK_GITHUB_HOST`,
+`github_host` in `stakk.toml`, or `GH_HOST` —
+stakk then accepts remotes on that host and uses its API at `https://<host>/api/v3`.
+Tokens are resolved per host, mirroring the GitHub CLI, so an Enterprise token is never sent to github.com.
+
+```sh
+export GH_HOST=github.example.com
+gh auth login --hostname github.example.com
+stakk auth test
+```
+
+Details: [docs/config.md](docs/config.md), or run `stakk docs config`.
+
 ## Environment variables
 
 Every `submit` flag has a matching `STAKK_`-prefixed environment variable — `STAKK_REMOTE`, `STAKK_PR_MODE`,
-`STAKK_STACK_PLACEMENT`, and so on — plus `GITHUB_TOKEN` / `GH_TOKEN` for authentication.
+`STAKK_STACK_PLACEMENT`, and so on — plus `GITHUB_TOKEN` / `GH_TOKEN` for authentication
+(`GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` for a GitHub Enterprise Server host).
 CLI flags take precedence over environment variables, which take precedence over config files.
 
 `--dry-run` and the selection flags deliberately have no environment variables: they are per-invocation decisions.
@@ -208,8 +225,13 @@ Full table: [docs/config.md](docs/config.md), or run `stakk docs config`.
 | Flag | Env var | Description |
 |------|---------|-------------|
 | `--config <path>` | `STAKK_CONFIG` | Load this config file instead of discovering `stakk.toml` |
+| `--github-host <host>` | `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (falls back to `GH_HOST`) |
 | `--version` | | Print the stakk version |
 | `--help` | | Print help; `--help` on a subcommand shows its full flag documentation |
+
+`--config` and `--github-host` accept any subcommand, but they have to come *after* it —
+`stakk auth test --github-host <host>`, not `stakk --github-host <host> auth test`.
+Their environment variables work from either position.
 
 ### `stakk` (no arguments)
 
@@ -401,15 +423,19 @@ stakk completions fish > ~/.config/fish/completions/stakk.fish
 
 ### `stakk auth test`
 
-Validate that GitHub authentication is working and print the authenticated username.
+Validate that GitHub authentication is working, and print the resolved host and the authenticated username.
 
 ### `stakk auth setup`
 
-Print instructions for setting up authentication. stakk resolves a GitHub token in this order:
+Print instructions for setting up authentication. stakk resolves a GitHub token for the host the remote points at.
+For github.com, in this order:
 
 1. **GitHub CLI** (`gh auth token`) — recommended
 2. **`GITHUB_TOKEN`** environment variable
 3. **`GH_TOKEN`** environment variable
+
+For a GitHub Enterprise Server host, `gh auth token --hostname <host>`, then **`GH_ENTERPRISE_TOKEN`**,
+then **`GITHUB_ENTERPRISE_TOKEN`**.
 
 ## Design
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,6 +40,10 @@ Unknown fields cause a parse error, so typos are caught early.
 # Git remote to push to (default: "origin")
 remote = "origin"
 
+# Extra host to treat as GitHub, for GitHub Enterprise Server
+# (default: none — only github.com is accepted)
+github_host = "github.example.com"
+
 # PR creation mode: "regular" or "draft" (default: "regular")
 pr_mode = "draft"
 
@@ -133,12 +137,48 @@ pr_mode = "regular"
 stack_placement = "comment"
 ```
 
+## GitHub Enterprise Server
+
+github.com is always accepted.
+To work against a GitHub Enterprise Server host, name that host — stakk then accepts remotes on it,
+and talks to its REST API at `https://<host>/api/v3`.
+
+The host is resolved highest to lowest:
+
+1. `--github-host <host>` — must come after the subcommand, e.g. `stakk auth test --github-host <host>`
+2. `STAKK_GITHUB_HOST`
+3. `github_host` in `stakk.toml`
+4. `GH_HOST` — the GitHub CLI's own setting, so an existing `gh` setup needs no stakk configuration
+
+Any other host is rejected, so an unrelated forge is never mistaken for GitHub.
+
+The token is resolved for the host the remote actually points at, mirroring the GitHub CLI:
+
+| Host | Order |
+|------|-------|
+| `github.com` | `gh auth token --hostname github.com`, then `GITHUB_TOKEN`, then `GH_TOKEN` |
+| anything else | `gh auth token --hostname <host>`, then `GH_ENTERPRISE_TOKEN`, then `GITHUB_ENTERPRISE_TOKEN` |
+
+So a github.com token is never sent to an Enterprise host, or the other way around.
+
+```sh
+export GH_HOST=github.example.com
+gh auth login --hostname github.example.com
+stakk auth test
+```
+
+`stakk auth test` prints the host it resolved, so it is the quickest way to confirm the setup.
+
+Note that the API base is always `https`, even for an `http://` remote:
+an Enterprise Server reachable only over plain HTTP is not supported.
+
 ## Environment variables
 
 | Variable | Description |
 |----------|-------------|
 | `STAKK_CONFIG` | Path to config file, overrides automatic discovery (overridden by `--config`) |
 | `STAKK_REMOTE` | Default git remote to push to (overridden by `--remote`) |
+| `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (overridden by `--github-host`) |
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_DRAFT` | Set to `true` to always create draft PRs (overridden by `--draft`) |
 | `STAKK_TEMPLATE` | Path to a custom minijinja template for stack comments (overridden by `--template`) |
@@ -149,8 +189,11 @@ stack_placement = "comment"
 | `STAKK_BOOKMARK_COMMAND` | Shell command for generating custom bookmark names (overridden by `--bookmark-command`) |
 | `STAKK_BOOKMARKS_REVSET` | Revset for discovering bookmarks (overridden by `--bookmarks-revset`) |
 | `STAKK_HEADS_REVSET` | Revset for discovering unbookmarked heads (overridden by `--heads-revset`) |
-| `GITHUB_TOKEN` | GitHub personal access token (see `stakk auth setup`) |
+| `GH_HOST` | The GitHub CLI's host setting; used as the `github_host` fallback |
+| `GITHUB_TOKEN` | GitHub personal access token for github.com (see `stakk auth setup`) |
 | `GH_TOKEN` | Alternative to `GITHUB_TOKEN` |
+| `GH_ENTERPRISE_TOKEN` | Access token for a GitHub Enterprise Server host |
+| `GITHUB_ENTERPRISE_TOKEN` | Alternative to `GH_ENTERPRISE_TOKEN` |
 
 `--dry-run` and the selection flags (`--keep`, `--keep-all`, `--new`, `--new-auto`, `--new-command`) deliberately have
 no environment variables or config keys: they are per-invocation decisions, and a persisted default would be surprising.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,12 +1,18 @@
 //! GitHub authentication token resolution.
 //!
-//! Resolves a token in priority order:
-//! 1. `gh auth token` (GitHub CLI)
-//! 2. `GITHUB_TOKEN` environment variable
-//! 3. `GH_TOKEN` environment variable
+//! Resolves a token for a specific host, in priority order:
+//! 1. `gh auth token --hostname <host>` (GitHub CLI)
+//! 2. the host's environment variables — `GITHUB_TOKEN`/`GH_TOKEN` for
+//!    github.com, `GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN` for a GitHub
+//!    Enterprise Server host
+//!
+//! The env-var split mirrors the GitHub CLI, so an enterprise token is never
+//! sent to github.com and vice versa.
 
 use miette::Diagnostic;
 use thiserror::Error;
+
+use crate::GITHUB_COM;
 
 /// How the token was obtained.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +23,10 @@ pub enum TokenSource {
     GitHubTokenEnv,
     /// From `GH_TOKEN` environment variable.
     GhTokenEnv,
+    /// From `GH_ENTERPRISE_TOKEN` environment variable.
+    GhEnterpriseTokenEnv,
+    /// From `GITHUB_ENTERPRISE_TOKEN` environment variable.
+    GitHubEnterpriseTokenEnv,
 }
 
 impl std::fmt::Display for TokenSource {
@@ -25,6 +35,10 @@ impl std::fmt::Display for TokenSource {
             Self::GitHubCli => write!(f, "GitHub CLI (gh auth token)"),
             Self::GitHubTokenEnv => write!(f, "GITHUB_TOKEN environment variable"),
             Self::GhTokenEnv => write!(f, "GH_TOKEN environment variable"),
+            Self::GhEnterpriseTokenEnv => write!(f, "GH_ENTERPRISE_TOKEN environment variable"),
+            Self::GitHubEnterpriseTokenEnv => {
+                write!(f, "GITHUB_ENTERPRISE_TOKEN environment variable")
+            }
         }
     }
 }
@@ -39,67 +53,94 @@ pub struct AuthToken {
 /// Errors from authentication resolution.
 #[derive(Debug, Error, Diagnostic)]
 pub enum AuthError {
-    #[error("no GitHub authentication found")]
+    #[error("no GitHub authentication found for {host}")]
     #[diagnostic(
         code(stakk::auth::no_token),
-        help("run `gh auth login` or set GITHUB_TOKEN/GH_TOKEN")
+        help("run `gh auth login --hostname {host}`, or set {}", env_var_list(host))
     )]
-    NoAuthFound,
+    NoAuthFound { host: String },
 
     #[error("failed to run `gh auth token`: {0}")]
     #[diagnostic(
         code(stakk::auth::gh_cli_error),
-        help("install the `gh` CLI, or set GITHUB_TOKEN/GH_TOKEN to skip it")
+        help("install the `gh` CLI, or set a token environment variable to skip it")
     )]
     GhCliError(std::io::Error),
 }
 
-/// Resolve a GitHub authentication token.
+/// The token environment variables that apply to `host`, most preferred first.
 ///
-/// Tries sources in order: gh CLI, `GITHUB_TOKEN` env, `GH_TOKEN` env.
-/// Returns the first token found, or `AuthError::NoAuthFound`.
+/// github.com keeps stakk's long-standing `GITHUB_TOKEN` before `GH_TOKEN`
+/// order. Other hosts use the enterprise pair in the GitHub CLI's own order.
+fn env_sources(host: &str) -> &'static [(&'static str, TokenSource)] {
+    if host == GITHUB_COM {
+        &[
+            ("GITHUB_TOKEN", TokenSource::GitHubTokenEnv),
+            ("GH_TOKEN", TokenSource::GhTokenEnv),
+        ]
+    } else {
+        &[
+            ("GH_ENTERPRISE_TOKEN", TokenSource::GhEnterpriseTokenEnv),
+            (
+                "GITHUB_ENTERPRISE_TOKEN",
+                TokenSource::GitHubEnterpriseTokenEnv,
+            ),
+        ]
+    }
+}
+
+/// The host's environment variable names, formatted for a help message.
+fn env_var_list(host: &str) -> String {
+    let names: Vec<&str> = env_sources(host).iter().map(|(name, _)| *name).collect();
+    names.join("/")
+}
+
+/// Look up the first non-empty token among the host's environment variables.
+///
+/// `lookup` is injected so tests do not have to mutate the process
+/// environment.
+fn token_from_env(host: &str, lookup: impl Fn(&str) -> Option<String>) -> Option<AuthToken> {
+    env_sources(host).iter().find_map(|(name, source)| {
+        lookup(name)
+            .filter(|token| !token.is_empty())
+            .map(|token| AuthToken {
+                token,
+                source: *source,
+            })
+    })
+}
+
+/// Resolve a GitHub authentication token for `host`.
+///
+/// Tries the gh CLI first, then the host's environment variables. Returns the
+/// first token found, or `AuthError::NoAuthFound`.
 ///
 /// This does NOT validate the token against the GitHub API.
 /// Use `Forge::get_authenticated_user()` to validate.
-pub async fn resolve_token() -> Result<AuthToken, AuthError> {
-    // 1. Try `gh auth token`
-    if let Some(token) = try_gh_cli().await? {
+pub async fn resolve_token(host: &str) -> Result<AuthToken, AuthError> {
+    if let Some(token) = try_gh_cli(host).await? {
         return Ok(AuthToken {
             token,
             source: TokenSource::GitHubCli,
         });
     }
 
-    // 2. Try GITHUB_TOKEN
-    if let Ok(token) = std::env::var("GITHUB_TOKEN")
-        && !token.is_empty()
-    {
-        return Ok(AuthToken {
-            token,
-            source: TokenSource::GitHubTokenEnv,
-        });
-    }
-
-    // 3. Try GH_TOKEN
-    if let Ok(token) = std::env::var("GH_TOKEN")
-        && !token.is_empty()
-    {
-        return Ok(AuthToken {
-            token,
-            source: TokenSource::GhTokenEnv,
-        });
-    }
-
-    Err(AuthError::NoAuthFound)
+    token_from_env(host, |name| std::env::var(name).ok()).ok_or_else(|| AuthError::NoAuthFound {
+        host: host.to_string(),
+    })
 }
 
-/// Try to get a token from the GitHub CLI.
+/// Try to get a token from the GitHub CLI for `host`.
 ///
-/// Returns `Ok(None)` if gh is not installed or not authenticated.
+/// `--hostname` is passed explicitly: without it gh answers for whichever host
+/// `GH_HOST` or its config names, which need not be the host this repo's
+/// remote points at.
+///
+/// Returns `Ok(None)` if gh is not installed or not authenticated for the host.
 /// Returns `Err` only for unexpected I/O failures.
-async fn try_gh_cli() -> Result<Option<String>, AuthError> {
+async fn try_gh_cli(host: &str) -> Result<Option<String>, AuthError> {
     let result = tokio::process::Command::new("gh")
-        .args(["auth", "token"])
+        .args(["auth", "token", "--hostname", host])
         .output()
         .await;
 
@@ -121,6 +162,18 @@ async fn try_gh_cli() -> Result<Option<String>, AuthError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const ENTERPRISE: &str = "github.example.com";
+
+    /// A `lookup` that resolves exactly the given name/value pairs.
+    fn env<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| {
+            pairs
+                .iter()
+                .find(|(key, _)| *key == name)
+                .map(|(_, value)| (*value).to_string())
+        }
+    }
 
     #[test]
     fn token_source_display_github_cli() {
@@ -147,15 +200,99 @@ mod tests {
     }
 
     #[test]
+    fn token_source_display_enterprise_env() {
+        assert_eq!(
+            TokenSource::GhEnterpriseTokenEnv.to_string(),
+            "GH_ENTERPRISE_TOKEN environment variable"
+        );
+        assert_eq!(
+            TokenSource::GitHubEnterpriseTokenEnv.to_string(),
+            "GITHUB_ENTERPRISE_TOKEN environment variable"
+        );
+    }
+
+    #[test]
+    fn github_com_prefers_github_token() {
+        let found = token_from_env(GITHUB_COM, env(&[("GITHUB_TOKEN", "a"), ("GH_TOKEN", "b")]))
+            .expect("a token should be found");
+        assert_eq!(found.token, "a");
+        assert_eq!(found.source, TokenSource::GitHubTokenEnv);
+    }
+
+    #[test]
+    fn github_com_falls_back_to_gh_token() {
+        let found =
+            token_from_env(GITHUB_COM, env(&[("GH_TOKEN", "b")])).expect("a token should be found");
+        assert_eq!(found.token, "b");
+        assert_eq!(found.source, TokenSource::GhTokenEnv);
+    }
+
+    #[test]
+    fn github_com_ignores_the_enterprise_variables() {
+        assert!(token_from_env(GITHUB_COM, env(&[("GH_ENTERPRISE_TOKEN", "e")])).is_none());
+    }
+
+    #[test]
+    fn enterprise_prefers_gh_enterprise_token() {
+        let found = token_from_env(
+            ENTERPRISE,
+            env(&[
+                ("GH_ENTERPRISE_TOKEN", "e1"),
+                ("GITHUB_ENTERPRISE_TOKEN", "e2"),
+            ]),
+        )
+        .expect("a token should be found");
+        assert_eq!(found.token, "e1");
+        assert_eq!(found.source, TokenSource::GhEnterpriseTokenEnv);
+    }
+
+    #[test]
+    fn enterprise_falls_back_to_github_enterprise_token() {
+        let found = token_from_env(ENTERPRISE, env(&[("GITHUB_ENTERPRISE_TOKEN", "e2")]))
+            .expect("a token should be found");
+        assert_eq!(found.token, "e2");
+        assert_eq!(found.source, TokenSource::GitHubEnterpriseTokenEnv);
+    }
+
+    #[test]
+    fn enterprise_ignores_the_github_com_variables() {
+        assert!(
+            token_from_env(ENTERPRISE, env(&[("GITHUB_TOKEN", "a"), ("GH_TOKEN", "b")])).is_none()
+        );
+    }
+
+    #[test]
+    fn empty_values_are_skipped() {
+        let found = token_from_env(GITHUB_COM, env(&[("GITHUB_TOKEN", ""), ("GH_TOKEN", "b")]))
+            .expect("a token should be found");
+        assert_eq!(found.token, "b");
+    }
+
+    #[test]
     fn auth_error_no_auth_found_is_actionable() {
-        let err = AuthError::NoAuthFound;
+        let err = AuthError::NoAuthFound {
+            host: GITHUB_COM.to_string(),
+        };
         let msg = err.to_string();
         assert!(msg.contains("no GitHub authentication found"));
+        assert!(msg.contains(GITHUB_COM));
         // Actionable advice is in the miette diagnostic help.
         let help = miette::Diagnostic::help(&err).expect("NoAuthFound should have diagnostic help");
         let help_text = help.to_string();
-        assert!(help_text.contains("gh auth login"));
+        assert!(help_text.contains("gh auth login --hostname github.com"));
         assert!(help_text.contains("GITHUB_TOKEN"));
         assert!(help_text.contains("GH_TOKEN"));
+    }
+
+    #[test]
+    fn auth_error_names_the_enterprise_variables() {
+        let err = AuthError::NoAuthFound {
+            host: ENTERPRISE.to_string(),
+        };
+        let help = miette::Diagnostic::help(&err).expect("NoAuthFound should have diagnostic help");
+        let help_text = help.to_string();
+        assert!(help_text.contains("gh auth login --hostname github.example.com"));
+        assert!(help_text.contains("GH_ENTERPRISE_TOKEN"));
+        assert!(help_text.contains("GITHUB_ENTERPRISE_TOKEN"));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,6 +32,15 @@ pub struct Cli {
     #[arg(long, global = true, env = "STAKK_CONFIG", verbatim_doc_comment)]
     pub config: Option<PathBuf>,
 
+    /// Extra host to treat as GitHub, for GitHub Enterprise Server.
+    ///
+    /// github.com is always accepted. Naming a host here additionally accepts
+    /// remotes on that host and talks to its API at https://<host>/api/v3.
+    /// Falls back to GH_HOST when unset, so an existing GitHub CLI setup works
+    /// without further configuration.
+    #[arg(long, global = true, env = "STAKK_GITHUB_HOST", verbatim_doc_comment)]
+    pub github_host: Option<String>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
     /// Default submit arguments (used when no subcommand is given).
@@ -116,6 +125,7 @@ pub struct ShowArgs {
 )]
 pub fn apply_config_defaults(config: Config, cmd: Command) -> Command {
     // Apply to top-level (flattened submit args) first.
+    let cmd = apply_global_defaults(&config, cmd);
     let cmd = apply_submit_and_graph_defaults(&config, cmd);
     // Clone for the closures that mut_subcommand requires ('static).
     let config2 = config.clone();
@@ -131,6 +141,18 @@ fn set_default(cmd: Command, arg_id: &str, value: &str) -> Command {
     // bounded by the number of config fields.
     let leaked: &'static str = Box::leak(value.to_string().into_boxed_str());
     cmd.mut_arg(arg_id, |a| a.default_value(leaked))
+}
+
+/// Defaults for `global = true` args on the root command.
+///
+/// Global args are defined once on the root and propagated to subcommands by
+/// clap, so `mut_arg` must run on the root — calling it on a subcommand would
+/// panic with "Argument is undefined".
+fn apply_global_defaults(config: &Config, mut cmd: Command) -> Command {
+    if let Some(ref host) = config.github_host {
+        cmd = set_default(cmd, "github_host", host);
+    }
+    cmd
 }
 
 fn apply_submit_defaults(config: &Config, mut cmd: Command) -> Command {
@@ -309,6 +331,71 @@ mod tests {
         };
         let cli = parse_with_config(config, &["stakk", "submit", "--remote", "other", "bm"]);
         assert_eq!(submit_args(&cli).remote, "other");
+    }
+
+    // -- github_host tests --
+    //
+    // github_host is a `global = true` arg on the root command, so its config
+    // default is injected there rather than per subcommand. These cover that it
+    // still reaches every subcommand.
+
+    #[test]
+    fn github_host_default_none() {
+        let cli = parse_with_config(Config::default(), &["stakk", "submit", "bm"]);
+        assert_eq!(cli.github_host, None);
+    }
+
+    #[test]
+    fn github_host_from_config() {
+        let config = Config {
+            github_host: Some("github.example.com".into()),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "bm"]);
+        assert_eq!(cli.github_host.as_deref(), Some("github.example.com"));
+    }
+
+    #[test]
+    fn github_host_cli_overrides_config() {
+        let config = Config {
+            github_host: Some("github.example.com".into()),
+            ..Default::default()
+        };
+        let cli = parse_with_config(
+            config,
+            &["stakk", "submit", "--github-host", "ghe.other.com", "bm"],
+        );
+        assert_eq!(cli.github_host.as_deref(), Some("ghe.other.com"));
+    }
+
+    #[test]
+    fn github_host_from_config_without_subcommand() {
+        let config = Config {
+            github_host: Some("github.example.com".into()),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "bm"]);
+        assert_eq!(cli.github_host.as_deref(), Some("github.example.com"));
+    }
+
+    #[test]
+    fn github_host_from_config_reaches_show() {
+        let config = Config {
+            github_host: Some("github.example.com".into()),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "show"]);
+        assert_eq!(cli.github_host.as_deref(), Some("github.example.com"));
+    }
+
+    #[test]
+    fn github_host_from_config_reaches_auth_test() {
+        let config = Config {
+            github_host: Some("github.example.com".into()),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "auth", "test"]);
+        assert_eq!(cli.github_host.as_deref(), Some("github.example.com"));
     }
 
     // -- stack_placement tests --
@@ -658,6 +745,7 @@ mod tests {
     fn toml_deserialize_full() {
         let toml_str = r#"
 remote = "upstream"
+github_host = "github.example.com"
 pr_mode = "draft"
 template = "/path/to/template.jinja"
 stack_placement = "body"
@@ -670,6 +758,7 @@ heads_revset = "heads(all())"
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.remote.as_deref(), Some("upstream"));
+        assert_eq!(config.github_host.as_deref(), Some("github.example.com"));
         assert_eq!(config.pr_mode, Some(PrMode::Draft));
         assert_eq!(config.template.as_deref(), Some("/path/to/template.jinja"));
         assert_eq!(config.stack_placement, Some(StackPlacement::Body));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,6 +48,8 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub inherit: bool,
     pub remote: Option<String>,
+    /// Extra host to treat as GitHub, for GitHub Enterprise Server.
+    pub github_host: Option<String>,
     pub pr_mode: Option<PrMode>,
     pub template: Option<String>,
     pub stack_placement: Option<StackPlacement>,
@@ -64,6 +66,7 @@ impl Default for Config {
         Self {
             inherit: true,
             remote: None,
+            github_host: None,
             pr_mode: None,
             template: None,
             stack_placement: None,
@@ -132,6 +135,7 @@ impl Config {
         Self {
             inherit: self.inherit,
             remote: self.remote.or(fallback.remote),
+            github_host: self.github_host.or(fallback.github_host),
             pr_mode: self.pr_mode.or(fallback.pr_mode),
             template: self.template.or(fallback.template),
             stack_placement: self.stack_placement.or(fallback.stack_placement),

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,9 +50,28 @@ pub enum StakkError {
     #[error("remote '{name}' is not a GitHub URL: {url}")]
     #[diagnostic(
         code(stakk::remote::not_github),
-        help("stakk only supports GitHub remotes (github.com URLs)")
+        help(
+            "stakk expects an owner/repo remote URL, e.g. git@github.com:owner/repo.git; for a \
+             GitHub Enterprise Server host, also set --github-host"
+        )
     )]
     RemoteNotGithub { name: String, url: String },
+
+    /// The remote is an owner/repo URL, but on a host stakk has not been told
+    /// to treat as GitHub.
+    #[error("remote '{name}' is on host '{host}', which is not a configured GitHub host: {url}")]
+    #[diagnostic(
+        code(stakk::remote::host_not_configured),
+        help(
+            "if {host} is a GitHub Enterprise Server host, name it with --github-host {host}, \
+             STAKK_GITHUB_HOST, github_host in stakk.toml, or GH_HOST"
+        )
+    )]
+    RemoteHostNotConfigured {
+        name: String,
+        url: String,
+        host: String,
+    },
 
     /// The specified remote was not found.
     #[error("remote '{name}' not found")]
@@ -66,7 +85,11 @@ pub enum StakkError {
     #[error("no GitHub remote found")]
     #[diagnostic(
         code(stakk::remote::no_github),
-        help("make sure this repository has a GitHub remote configured")
+        help(
+            "make sure this repository has a GitHub remote configured; for a GitHub Enterprise \
+             Server host, name it with --github-host, STAKK_GITHUB_HOST, github_host in \
+             stakk.toml, or GH_HOST"
+        )
     )]
     NoGithubRemote,
 

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -20,17 +20,35 @@ pub struct GitHubForge {
 
 impl GitHubForge {
     /// Create a new `GitHubForge` for the given repository.
-    pub fn new(token: &str, owner: String, repo: String) -> Result<Self, ForgeError> {
-        let client = Octocrab::builder()
-            .personal_token(token.to_string())
-            .build()
-            .map_err(|e| {
-                let message = format!("failed to create GitHub client: {e}");
+    ///
+    /// `api_base_uri` is `None` for github.com, where octocrab's default
+    /// (`https://api.github.com`) applies, and `Some` for a GitHub Enterprise
+    /// Server host. It is a plain string rather than a parsed remote so this
+    /// module stays independent of `jj::remote`.
+    pub fn new(
+        token: &str,
+        owner: String,
+        repo: String,
+        api_base_uri: Option<&str>,
+    ) -> Result<Self, ForgeError> {
+        let mut builder = Octocrab::builder().personal_token(token.to_string());
+        if let Some(uri) = api_base_uri {
+            builder = builder.base_uri(uri).map_err(|e| {
+                let message = format!("invalid GitHub API base URI '{uri}': {e}");
                 ForgeError::Api {
                     message,
                     source: Box::new(e),
                 }
             })?;
+        }
+
+        let client = builder.build().map_err(|e| {
+            let message = format!("failed to create GitHub client: {e}");
+            ForgeError::Api {
+                message,
+                source: Box::new(e),
+            }
+        })?;
 
         Ok(Self {
             client,

--- a/src/jj/remote.rs
+++ b/src/jj/remote.rs
@@ -1,10 +1,29 @@
 //! GitHub remote URL parsing.
 
+use crate::GITHUB_COM;
+
 /// A parsed GitHub repository reference.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitHubRepo {
+    /// Lowercased host the remote points at, e.g. `github.com` or
+    /// `github.example.com`. Carries a port only for HTTP(S) remotes.
+    pub host: String,
     pub owner: String,
     pub repo: String,
+}
+
+impl GitHubRepo {
+    /// The REST API base URI for this repository's host.
+    ///
+    /// `None` for github.com, where octocrab's own default
+    /// (`https://api.github.com`) is correct. GitHub Enterprise Server serves
+    /// its API from `/api/v3` on the same host as the web UI.
+    ///
+    /// Always `https`, even for an `http://` remote: a GHES reachable only over
+    /// plain HTTP is not supported.
+    pub fn api_base_uri(&self) -> Option<String> {
+        (self.host != GITHUB_COM).then(|| format!("https://{}/api/v3", self.host))
+    }
 }
 
 impl std::fmt::Display for GitHubRepo {
@@ -13,35 +32,83 @@ impl std::fmt::Display for GitHubRepo {
     }
 }
 
-/// Parse a GitHub owner/repo from a remote URL.
+/// Whether a remote's host may be treated as a GitHub host.
 ///
-/// Supports:
-/// - HTTPS: `https://github.com/owner/repo.git`
-/// - SSH (SCP-style): `git@github.com:owner/repo.git`
-/// - SSH (canonical): `ssh://git@github.com/owner/repo.git`
-/// - With or without `.git` suffix
-///
-/// Returns `None` for non-GitHub URLs.
-pub fn parse_github_url(url: &str) -> Option<GitHubRepo> {
-    // SSH SCP-style format: git@github.com:owner/repo.git
-    if let Some(path) = url.strip_prefix("git@github.com:") {
-        return parse_owner_repo(path);
-    }
-
-    // SSH canonical format: ssh://git@github.com/owner/repo.git
-    if let Some(path) = url.strip_prefix("ssh://git@github.com/") {
-        return parse_owner_repo(path);
-    }
-
-    // HTTPS format: https://github.com/owner/repo.git
-    let url_without_scheme = url
-        .strip_prefix("https://github.com/")
-        .or_else(|| url.strip_prefix("http://github.com/"))?;
-
-    parse_owner_repo(url_without_scheme)
+/// github.com always qualifies. Any other host has to be named explicitly —
+/// via `--github-host`, `STAKK_GITHUB_HOST`, `github_host` in `stakk.toml`, or
+/// `GH_HOST` — so an unrelated forge is not mistaken for GitHub Enterprise
+/// Server.
+pub fn is_accepted_host(host: &str, extra_host: Option<&str>) -> bool {
+    host == GITHUB_COM || extra_host.is_some_and(|extra| extra.eq_ignore_ascii_case(host))
 }
 
-fn parse_owner_repo(path: &str) -> Option<GitHubRepo> {
+/// Parse an owner/repo and its host from a remote URL, whatever the host.
+///
+/// Supports:
+/// - HTTPS: `https://host/owner/repo.git` (also `http://`, embedded
+///   credentials, and an explicit port)
+/// - SSH (SCP-style): `git@host:owner/repo.git`
+/// - SSH (canonical): `ssh://git@host/owner/repo.git` (also with a port)
+/// - With or without `.git` suffix
+///
+/// The port is kept for HTTP(S) URLs, where it is also the port the API answers
+/// on, and dropped for SSH URLs, where it is not.
+///
+/// Returns `None` for anything that is not a `<host>/<owner>/<repo>` URL. The
+/// host is *not* checked here — see [`is_accepted_host`] and
+/// [`parse_github_url`].
+pub fn parse_remote_url(url: &str) -> Option<GitHubRepo> {
+    // SSH canonical format: ssh://git@host:2222/owner/repo.git
+    if let Some(rest) = url.strip_prefix("ssh://") {
+        let (authority, path) = rest.split_once('/')?;
+        let host = strip_userinfo(authority);
+        // An SSH port says nothing about where the API lives.
+        let host = host.split_once(':').map_or(host, |(host, _)| host);
+        return build(host, path);
+    }
+
+    // HTTPS format: https://host/owner/repo.git
+    for scheme in ["https://", "http://"] {
+        if let Some(rest) = url.strip_prefix(scheme) {
+            let (authority, path) = rest.split_once('/')?;
+            // A port here is the one the API answers on too, so it stays.
+            return build(strip_userinfo(authority), path);
+        }
+    }
+
+    // SSH SCP-style format: git@host:owner/repo.git. The user part is required:
+    // without it, `host:owner/repo` cannot be told apart from a scheme prefix.
+    let (userinfo_host, path) = url.split_once(':')?;
+    let (_, host) = userinfo_host.rsplit_once('@')?;
+    build(host, path)
+}
+
+/// Parse a GitHub owner/repo from a remote URL, rejecting hosts that are not
+/// github.com or `extra_host`.
+pub fn parse_github_url(url: &str, extra_host: Option<&str>) -> Option<GitHubRepo> {
+    parse_remote_url(url).filter(|parsed| is_accepted_host(&parsed.host, extra_host))
+}
+
+/// Drop a `user@` or `user:password@` prefix from a URL authority.
+fn strip_userinfo(authority: &str) -> &str {
+    authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host)
+}
+
+fn build(host: &str, path: &str) -> Option<GitHubRepo> {
+    if host.is_empty() {
+        return None;
+    }
+    let (owner, repo) = parse_owner_repo(path)?;
+    Some(GitHubRepo {
+        host: host.to_ascii_lowercase(),
+        owner,
+        repo,
+    })
+}
+
+fn parse_owner_repo(path: &str) -> Option<(String, String)> {
     let path = path.strip_suffix(".git").unwrap_or(path);
     let path = path.strip_suffix('/').unwrap_or(path);
 
@@ -54,70 +121,55 @@ fn parse_owner_repo(path: &str) -> Option<GitHubRepo> {
         return None;
     }
 
-    Some(GitHubRepo {
-        owner: owner.to_string(),
-        repo: repo.to_string(),
-    })
+    Some((owner.to_string(), repo.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// A github.com `GitHubRepo` for the common `glennib/stakk` case.
+    fn stakk() -> GitHubRepo {
+        GitHubRepo {
+            host: GITHUB_COM.into(),
+            owner: "glennib".into(),
+            repo: "stakk".into(),
+        }
+    }
+
+    const ENTERPRISE: &str = "github.example.com";
+
     #[test]
     fn https_with_git_suffix() {
-        let result = parse_github_url("https://github.com/glennib/stakk.git");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("https://github.com/glennib/stakk.git", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn https_without_git_suffix() {
-        let result = parse_github_url("https://github.com/glennib/stakk");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("https://github.com/glennib/stakk", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn ssh_with_git_suffix() {
-        let result = parse_github_url("git@github.com:glennib/stakk.git");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("git@github.com:glennib/stakk.git", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn ssh_without_git_suffix() {
-        let result = parse_github_url("git@github.com:glennib/stakk");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("git@github.com:glennib/stakk", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn https_with_trailing_slash() {
-        let result = parse_github_url("https://github.com/owner/repo/");
+        let result = parse_github_url("https://github.com/owner/repo/", None);
         assert_eq!(
             result,
             Some(GitHubRepo {
+                host: GITHUB_COM.into(),
                 owner: "owner".into(),
                 repo: "repo".into(),
             })
@@ -126,63 +178,188 @@ mod tests {
 
     #[test]
     fn non_github_https() {
-        let result = parse_github_url("https://gitlab.com/owner/repo.git");
+        let result = parse_github_url("https://gitlab.com/owner/repo.git", None);
         assert_eq!(result, None);
     }
 
     #[test]
     fn non_github_ssh() {
-        let result = parse_github_url("git@gitlab.com:owner/repo.git");
+        let result = parse_github_url("git@gitlab.com:owner/repo.git", None);
         assert_eq!(result, None);
     }
 
     #[test]
     fn empty_string() {
-        assert_eq!(parse_github_url(""), None);
+        assert_eq!(parse_github_url("", None), None);
     }
 
     #[test]
     fn missing_repo() {
-        assert_eq!(parse_github_url("https://github.com/owner"), None);
+        assert_eq!(parse_github_url("https://github.com/owner", None), None);
     }
 
     #[test]
     fn extra_path_segments() {
         assert_eq!(
-            parse_github_url("https://github.com/owner/repo/extra"),
+            parse_github_url("https://github.com/owner/repo/extra", None),
             None
         );
     }
 
     #[test]
     fn ssh_canonical_with_git_suffix() {
-        let result = parse_github_url("ssh://git@github.com/glennib/stakk.git");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("ssh://git@github.com/glennib/stakk.git", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn ssh_canonical_without_git_suffix() {
-        let result = parse_github_url("ssh://git@github.com/glennib/stakk");
-        assert_eq!(
-            result,
-            Some(GitHubRepo {
-                owner: "glennib".into(),
-                repo: "stakk".into(),
-            })
-        );
+        let result = parse_github_url("ssh://git@github.com/glennib/stakk", None);
+        assert_eq!(result, Some(stakk()));
     }
 
     #[test]
     fn non_github_ssh_canonical() {
         assert_eq!(
-            parse_github_url("ssh://git@gitlab.com/owner/repo.git"),
+            parse_github_url("ssh://git@gitlab.com/owner/repo.git", None),
             None
+        );
+    }
+
+    #[test]
+    fn enterprise_https() {
+        let result = parse_github_url("https://github.example.com/org/repo.git", Some(ENTERPRISE));
+        assert_eq!(
+            result,
+            Some(GitHubRepo {
+                host: ENTERPRISE.into(),
+                owner: "org".into(),
+                repo: "repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn enterprise_ssh_scp_style() {
+        let result = parse_github_url("git@github.example.com:org/repo.git", Some(ENTERPRISE));
+        assert_eq!(
+            result,
+            Some(GitHubRepo {
+                host: ENTERPRISE.into(),
+                owner: "org".into(),
+                repo: "repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn enterprise_ssh_canonical_without_git_suffix() {
+        let result = parse_github_url("ssh://git@github.example.com/org/repo", Some(ENTERPRISE));
+        assert_eq!(
+            result,
+            Some(GitHubRepo {
+                host: ENTERPRISE.into(),
+                owner: "org".into(),
+                repo: "repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn enterprise_rejected_without_configuration() {
+        assert_eq!(
+            parse_github_url("git@github.example.com:org/repo.git", None),
+            None
+        );
+    }
+
+    #[test]
+    fn github_com_still_accepted_when_enterprise_host_configured() {
+        let result = parse_github_url("git@github.com:glennib/stakk.git", Some(ENTERPRISE));
+        assert_eq!(result, Some(stakk()));
+    }
+
+    #[test]
+    fn configured_host_match_is_case_insensitive() {
+        let result = parse_github_url("git@GitHub.Example.COM:org/repo.git", Some(ENTERPRISE));
+        assert_eq!(
+            result,
+            Some(GitHubRepo {
+                host: ENTERPRISE.into(),
+                owner: "org".into(),
+                repo: "repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn ssh_port_is_dropped() {
+        let result = parse_remote_url("ssh://git@github.example.com:2222/org/repo.git");
+        assert_eq!(result.map(|r| r.host), Some(ENTERPRISE.to_string()));
+    }
+
+    #[test]
+    fn https_port_is_kept() {
+        let result = parse_remote_url("https://github.example.com:8443/org/repo.git");
+        assert_eq!(
+            result.map(|r| r.host),
+            Some("github.example.com:8443".to_string())
+        );
+    }
+
+    #[test]
+    fn https_credentials_are_stripped() {
+        let result = parse_remote_url("https://user:token@github.example.com/org/repo.git");
+        assert_eq!(result.map(|r| r.host), Some(ENTERPRISE.to_string()));
+    }
+
+    #[test]
+    fn parse_remote_url_accepts_any_host() {
+        let result = parse_remote_url("git@gitlab.com:owner/repo.git");
+        assert_eq!(
+            result,
+            Some(GitHubRepo {
+                host: "gitlab.com".into(),
+                owner: "owner".into(),
+                repo: "repo".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_remote_url_rejects_non_url() {
+        assert_eq!(parse_remote_url("not a url"), None);
+        assert_eq!(parse_remote_url("/some/local/path"), None);
+    }
+
+    #[test]
+    fn api_base_uri_is_none_for_github_com() {
+        assert_eq!(stakk().api_base_uri(), None);
+    }
+
+    #[test]
+    fn api_base_uri_is_v3_for_enterprise() {
+        let repo = GitHubRepo {
+            host: ENTERPRISE.into(),
+            owner: "org".into(),
+            repo: "repo".into(),
+        };
+        assert_eq!(
+            repo.api_base_uri().as_deref(),
+            Some("https://github.example.com/api/v3")
+        );
+    }
+
+    #[test]
+    fn api_base_uri_keeps_an_https_port() {
+        let repo = GitHubRepo {
+            host: "github.example.com:8443".into(),
+            owner: "org".into(),
+            repo: "repo".into(),
+        };
+        assert_eq!(
+            repo.api_base_uri().as_deref(),
+            Some("https://github.example.com:8443/api/v3")
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,17 @@ use crate::forge::Forge;
 use crate::forge::comment::StackPlacement;
 use crate::jj::Jj;
 use crate::jj::remote::parse_github_url;
+use crate::jj::remote::parse_remote_url;
 use crate::jj::runner::RealJjRunner;
 use crate::jj::version::MIN_SUPPORTED_JJ_VERSION;
+
+/// The public GitHub host, always accepted without configuration.
+///
+/// Lives at the crate root because it is neither a VCS nor a forge concept:
+/// `jj::remote` uses it to gate remote hosts, `auth` to pick which token
+/// environment variables apply. Either module owning it would make the other
+/// depend on it for no reason.
+pub const GITHUB_COM: &str = "github.com";
 
 #[tokio::main]
 async fn main() {
@@ -57,20 +66,29 @@ async fn run() -> Result<(), StakkError> {
         warn_if_jj_too_old().await;
     }
 
+    // The extra host to treat as GitHub. CLI, STAKK_GITHUB_HOST and the config
+    // file are resolved by clap; GH_HOST is the last resort so an existing
+    // GitHub CLI setup needs no stakk-specific configuration.
+    let github_host = cli
+        .github_host
+        .clone()
+        .or_else(|| std::env::var("GH_HOST").ok().filter(|h| !h.is_empty()));
+    let github_host = github_host.as_deref();
+
     match cli.command {
         Some(Commands::Submit(args)) => {
-            submit_bookmark(&args).await?;
+            submit_bookmark(&args, github_host).await?;
         }
         Some(Commands::Auth(args)) => match args.command {
             AuthCommands::Test => {
-                auth_test().await?;
+                auth_test(github_host).await?;
             }
             AuthCommands::Setup => {
                 auth_setup();
             }
         },
         Some(Commands::Show(args)) => {
-            show_status(&args).await?;
+            show_status(&args, github_host).await?;
         }
         Some(Commands::Completions { shell }) => {
             clap_complete::generate(shell, &mut Cli::command(), "stakk", &mut std::io::stdout());
@@ -79,7 +97,7 @@ async fn run() -> Result<(), StakkError> {
             docs::print(topic);
         }
         None => {
-            submit_bookmark(&cli.submit_args).await?;
+            submit_bookmark(&cli.submit_args, github_host).await?;
         }
     }
 
@@ -104,14 +122,20 @@ async fn warn_if_jj_too_old() {
     }
 }
 
-async fn auth_test() -> Result<(), StakkError> {
-    let auth_token = auth::resolve_token().await?;
+async fn auth_test(github_host: Option<&str>) -> Result<(), StakkError> {
+    // The remote comes first: its host decides which token to ask for.
+    let (_, github_repo) = resolve_github_remote(None, github_host).await?;
+    println!("Host: {}", github_repo.host);
+
+    let auth_token = auth::resolve_token(&github_repo.host).await?;
     println!("Authentication source: {}", auth_token.source);
 
-    let (_, github_repo) = resolve_github_remote(None).await?;
-
-    let forge =
-        forge::github::GitHubForge::new(&auth_token.token, github_repo.owner, github_repo.repo)?;
+    let forge = forge::github::GitHubForge::new(
+        &auth_token.token,
+        github_repo.owner.clone(),
+        github_repo.repo.clone(),
+        github_repo.api_base_uri().as_deref(),
+    )?;
 
     let username = forge.get_authenticated_user().await?;
     println!("Authenticated as: {username}");
@@ -120,35 +144,43 @@ async fn auth_test() -> Result<(), StakkError> {
 }
 
 fn auth_setup() {
-    println!("stakk resolves GitHub authentication in this order:\n");
+    println!("stakk resolves a GitHub token for the host your remote points at.\n");
+    println!("For github.com, in this order:\n");
     println!("  1. GitHub CLI:    Run `gh auth login` to authenticate.");
     println!("                    This is the recommended method.\n");
     println!("  2. GITHUB_TOKEN:  Set the GITHUB_TOKEN environment variable");
     println!("                    to a personal access token with `repo` scope.\n");
     println!("  3. GH_TOKEN:      Set the GH_TOKEN environment variable");
     println!("                    (same as GITHUB_TOKEN, alternative name).\n");
+    println!("For a GitHub Enterprise Server host, name the host first with");
+    println!("--github-host, STAKK_GITHUB_HOST, github_host in stakk.toml, or");
+    println!("GH_HOST. stakk then resolves the token in this order:\n");
+    println!("  1. GitHub CLI:    Run `gh auth login --hostname <host>`.\n");
+    println!("  2. GH_ENTERPRISE_TOKEN, then GITHUB_ENTERPRISE_TOKEN.\n");
     println!("To verify: run `stakk auth test`");
 }
 
 /// Submits a bookmark as a stacked pull request using the three-phase pipeline:
 /// analyze, plan, execute.
-async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
+async fn submit_bookmark(args: &SubmitArgs, github_host: Option<&str>) -> Result<(), StakkError> {
     let pb = indicatif::ProgressBar::new_spinner();
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
 
-    pb.set_message("Resolving authentication...");
     let jj = Jj::new(RealJjRunner);
 
-    // Resolve auth and remote.
-    let auth_token = auth::resolve_token().await?;
-
+    // Resolve the remote before the token: its host decides which token to ask
+    // for.
     pb.set_message("Resolving GitHub remote...");
-    let (remote_name, github_repo) = resolve_github_remote(Some(&args.remote)).await?;
+    let (remote_name, github_repo) = resolve_github_remote(Some(&args.remote), github_host).await?;
+
+    pb.set_message("Resolving authentication...");
+    let auth_token = auth::resolve_token(&github_repo.host).await?;
 
     let forge = forge::github::GitHubForge::new(
         &auth_token.token,
         github_repo.owner.clone(),
         github_repo.repo.clone(),
+        github_repo.api_base_uri().as_deref(),
     )?;
 
     // Build the change graph.
@@ -280,17 +312,29 @@ async fn submit_bookmark(args: &SubmitArgs) -> Result<(), StakkError> {
 /// If `preferred` is given, looks for that specific remote name. Otherwise,
 /// falls back to the first remote with a GitHub URL.
 ///
+/// `github_host` is an extra host to accept besides github.com.
+///
 /// Returns the remote name and parsed `GitHubRepo`.
 async fn resolve_github_remote(
     preferred: Option<&str>,
+    github_host: Option<&str>,
 ) -> Result<(String, jj::remote::GitHubRepo), StakkError> {
     let jj = Jj::new(RealJjRunner);
     let remotes = jj.get_git_remote_list().await?;
 
     if let Some(name) = preferred {
         if let Some(remote) = remotes.iter().find(|r| r.name == name) {
-            if let Some(repo) = parse_github_url(&remote.url) {
+            if let Some(repo) = parse_github_url(&remote.url, github_host) {
                 return Ok((remote.name.clone(), repo));
+            }
+            // An owner/repo URL on an unconfigured host gets a diagnostic that
+            // names the host, rather than the generic "not a GitHub URL".
+            if let Some(parsed) = parse_remote_url(&remote.url) {
+                return Err(StakkError::RemoteHostNotConfigured {
+                    name: name.to_string(),
+                    url: remote.url.clone(),
+                    host: parsed.host,
+                });
             }
             return Err(StakkError::RemoteNotGithub {
                 name: name.to_string(),
@@ -303,7 +347,7 @@ async fn resolve_github_remote(
     }
 
     for remote in &remotes {
-        if let Some(repo) = parse_github_url(&remote.url) {
+        if let Some(repo) = parse_github_url(&remote.url, github_host) {
             return Ok((remote.name.clone(), repo));
         }
     }
@@ -311,7 +355,7 @@ async fn resolve_github_remote(
     Err(StakkError::NoGithubRemote)
 }
 
-async fn show_status(args: &ShowArgs) -> Result<(), StakkError> {
+async fn show_status(args: &ShowArgs, github_host: Option<&str>) -> Result<(), StakkError> {
     // No spinner in json mode: machine-readable output stays quiet.
     let spinner = matches!(args.format, ShowFormat::Pretty).then(|| {
         let pb = indicatif::ProgressBar::new_spinner();
@@ -338,6 +382,7 @@ async fn show_status(args: &ShowArgs) -> Result<(), StakkError> {
         default_branch: &default_branch,
         remotes: &remotes,
         graph: &change_graph,
+        github_host,
     };
     match args.format {
         ShowFormat::Pretty => print!("{}", show::render_pretty(&data, console::colors_enabled())),

--- a/src/show/mod.rs
+++ b/src/show/mod.rs
@@ -33,6 +33,8 @@ pub struct ShowData<'a> {
     pub default_branch: &'a str,
     pub remotes: &'a [GitRemote],
     pub graph: &'a ChangeGraph,
+    /// Extra host to treat as GitHub, besides github.com.
+    pub github_host: Option<&'a str>,
 }
 
 // ---------------------------------------------------------------------------
@@ -117,7 +119,7 @@ fn build_report<'a>(data: &ShowData<'a>) -> ShowReport<'a> {
             .map(|r| RemoteReport {
                 name: &r.name,
                 url: &r.url,
-                github: parse_github_url(&r.url).map(|g| g.to_string()),
+                github: parse_github_url(&r.url, data.github_host).map(|g| g.to_string()),
             })
             .collect(),
         excluded_bookmark_count: data.graph.excluded_bookmark_count,
@@ -184,7 +186,7 @@ pub fn render_pretty(data: &ShowData, colors: bool) -> String {
 
     let _ = writeln!(out, "Default branch: {}", data.default_branch);
     for remote in data.remotes {
-        let github = parse_github_url(&remote.url)
+        let github = parse_github_url(&remote.url, data.github_host)
             .map(|r| format!(" ({r})"))
             .unwrap_or_default();
         let _ = writeln!(out, "Remote: {} {}{}", remote.name, remote.url, github);
@@ -425,6 +427,7 @@ mod tests {
             default_branch: "main",
             remotes: &remotes,
             graph: &graph,
+            github_host: None,
         };
         insta::assert_snapshot!(render_pretty(&data, false));
     }
@@ -437,6 +440,7 @@ mod tests {
             default_branch: "main",
             remotes: &remotes,
             graph: &graph,
+            github_host: None,
         };
         let out = render_pretty(&data, false);
         assert!(out.contains("No bookmark stacks found."));
@@ -451,6 +455,7 @@ mod tests {
             default_branch: "main",
             remotes: &remotes,
             graph: &graph,
+            github_host: None,
         };
         insta::assert_snapshot!(render_json(&data));
     }
@@ -463,6 +468,7 @@ mod tests {
             default_branch: "main",
             remotes: &remotes,
             graph: &graph,
+            github_host: None,
         };
         let v: serde_json::Value = serde_json::from_str(&render_json(&data)).unwrap();
 


### PR DESCRIPTION
stakk hardcoded `github.com` in three places — remote URL parsing, the octocrab client, and `gh auth token` — so a repository on a GitHub Enterprise Server host was rejected as not being a GitHub repository, even with a working `gh` login for that host.

The remote URL is now the source of truth for the host, and the new setting is a gate rather than a selector: `github.com` is always accepted, plus at most one configured host.

```text
--github-host <HOST>       CLI (global flag)
STAKK_GITHUB_HOST=<HOST>   env
github_host = "<HOST>"     stakk.toml
GH_HOST=<HOST>             gh's own env var (lowest)
github.com                 always accepted
```

Any other host is still rejected, now with a diagnostic that names it (`stakk::remote::host_not_configured`) instead of the generic "not a GitHub URL".

`jj::remote::parse_remote_url` parses `<host>/<owner>/<repo>` for any host and `parse_github_url` layers the gate on top. SSH ports are dropped — they say nothing about where the API lives — while HTTP(S) ports are kept. `GitHubRepo::api_base_uri` returns `None` for github.com, leaving octocrab's own `https://api.github.com` default in place, and `https://<host>/api/v3` otherwise.

Token resolution is now per host, mirroring the GitHub CLI: `gh auth token` gets an explicit `--hostname`, and the env fallback is `GITHUB_TOKEN`/`GH_TOKEN` for github.com but `GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN` elsewhere, so a token is never sent to the wrong host. The remote is therefore resolved before the token in both `submit` and `auth test`, and `auth test` prints the host it resolved.

Verified end to end against github.com and against a scratch repo with a GitHub Enterprise-shaped remote (gate, `GH_HOST` fallback, `stakk.toml` key, and the API base URI). No live Enterprise Server was reachable, so the `/api/v3` request path itself is covered only by unit tests.