### PR TITLE
docs: prune README redundancies and fix docs/ inaccuracies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ stakk uses its own comment metadata format
 
 ### 8. CLI args, env vars, and config travel together
 
-Every user-facing `submit` arg has five touchpoints that must stay in sync.
+Every user-facing `submit` arg has four touchpoints that must stay in sync.
 When adding, renaming, or changing the default of one, update all of them in the same change:
 
 1. **`src/cli/submit.rs`** — the clap field with `#[arg(long, env = "STAKK_…",
@@ -78,22 +78,25 @@ When adding, renaming, or changing the default of one, update all of them in the
    A `global = true` arg on `Cli` (like `--config` and `--github-host`) is defined on the *root* command only,
    so its default goes through `apply_global_defaults`, not `apply_submit_defaults` —
    `mut_arg` on a subcommand would panic with "Argument is undefined".
-4. **`README.md`** — three places:
-   - the `stakk.toml` example block,
-   - the **Environment variables** table,
-   - the per-subcommand flag table (e.g. under `stakk submit`).
-     `GraphArgs` flags (`--bookmarks-revset`, `--heads-revset`) appear in *two* tables —
-     `stakk submit` and `stakk show` — because both subcommands flatten them.
+4. **`docs/config.md`** — two places:
+   - the annotated `stakk.toml` example block (the exhaustive one; document the default in the comment),
+   - the **Environment variables** table.
 
-   Options with a prose section of their own need that section updated too:
-   `--stack-placement` has the **Stack info placement** mode table,
-   the selection flags have **Agent / scripting usage**.
-5. **`docs/config.md`** — the same three places again
-   (the full `stakk.toml` block, the **Environment variables** table, and any prose section),
-   since README only carries an abbreviated version and links here.
+   `README.md` deliberately carries *no* flag or env-var reference tables — `stakk --help`,
+   `stakk <subcommand> --help` and `docs/config.md` are the reference.
+   Only touch the README when the option changes something it describes in prose: the four-key `stakk.toml` sample,
+   the **Stack info placement** summary, **GitHub Enterprise Server**, **Non-interactive selection**,
+   **PR titles and bodies**, **Custom bookmark names**, or **Immutable commits**.
+   Deeper reference material for those lives in `docs/template.md` and `docs/scripting.md`,
+   which each README section links to alongside its `stakk docs <topic>` command.
 
 A change that lands in only some of these will silently drop config-file support, fail to appear in `--help` defaults,
 or stay invisible in the docs.
+
+The README describes only encouraged flows.
+The bare `stakk <bookmark>` form works but is never shown there — `stakk` with no arguments means the TUI,
+and submitting a named bookmark means `stakk submit <bookmark>`.
+Subcommand shadowing and `stakk -- <bookmark>` are documented in `docs/scripting.md` only.
 
 ## Architecture
 
@@ -344,7 +347,7 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   The variant doc comments are load-bearing:
   clap prints them as possible-value help *and* `docs::index` reads them back.
   `DocTopic` has no `Default` on purpose — `None` means "print the index", not "print a default topic".
-  `stakk docs` is exempt from the five-touchpoint rule (§8): no env var, no config key,
+  `stakk docs` is exempt from the four-touchpoint rule (§8): no env var, no config key,
   so README is the only other touchpoint.
   Add it to the `runs_jj` false-arm in `main.rs` alongside `Completions`,
   or the `_ => true` fallthrough makes it shell out to jj for a version check it does not need.
@@ -516,7 +519,7 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
 - **Selection flags not in env vars/config** — `--keep`, `--keep-all`, `--new`, `--new-auto`,
   `--new-command` are per-invocation decisions like `--dry-run`;
   a persisted default would silently change what gets submitted.
-  CLI + README touchpoints only (deliberate exception to the five-touchpoint rule).
+  CLI + README touchpoints only (deliberate exception to the four-touchpoint rule).
 - **Generic `Jj<R: JjRunner>`** — zero-cost dispatch, edition 2024 async traits.
 - **Three-phase submission** — analyze (pure) → plan (queries forge) → execute.
   All repo mutations (bookmark creation, pushes) live in execute, so `--dry-run` —

--- a/README.md
+++ b/README.md
@@ -278,6 +278,21 @@ or several that agree on their bookmarks
 (e.g. differing only in unbookmarked heads such as the working copy); anchor it with `--keep`/`--new` otherwise.
 Commits already carrying an explicit mark are skipped by `--keep-all` (explicit beats bulk).
 
+#### Bookmark names that collide with subcommands
+
+A leading subcommand name wins over the positional bookmark.
+`stakk show` runs the `show` subcommand even when a bookmark of that name exists, and the same holds for `submit`,
+`auth`, `docs`, `completions` and `help`.
+Name the subcommand, or end option parsing with `--`, to submit such a bookmark:
+
+```console
+stakk submit show
+stakk -- show
+```
+
+Submit flags belong after the subcommand: `stakk submit --dry-run show` works,
+while `stakk --dry-run submit show` is rejected.
+
 #### Agent / scripting usage
 
 Non-interactive submission is a two-command loop — discover, then submit.

--- a/README.md
+++ b/README.md
@@ -13,40 +13,29 @@ and idempotent updates.
 
 - **Automatic stack detection** — analyzes the jj change graph to find bookmark
   chains and their topological order.
-- **No bookmarks required** — stakk discovers unbookmarked heads
-  and lets you create bookmarks on-the-fly via the interactive TUI.
-  Auto-generated `stakk-<change_id>` names keep things simple.
-- **Auto bookmark naming** — the `[~]auto` toggle in the TUI generates descriptive bookmark names from commit
-  descriptions and file paths using TF-IDF (term frequency–inverse document frequency) scoring.
-  Press `r` to cycle through alternative names.
-  An optional `--auto-prefix` lets you brand the names (e.g. `gb-caching-database`).
-- **Stacked PR submission** — creates or updates GitHub PRs with correct base
-  branches so each PR shows only its own diff.
-- **Stack-awareness comments** — adds a comment to every PR listing the full stack with links,
-  updated in place on re-runs.
-  `--stack-placement` picks where the stack info goes: a PR `comment` (default), the PR `body`, `none`
-  (write nothing and remove what is already there), or `ignore` (write nothing and touch nothing).
+- **No bookmarks required** — stakk discovers unbookmarked heads and creates bookmarks for them,
+  interactively or from explicit flags.
+- **Interactive TUI** — `stakk` opens a graph of every branch stack,
+  then a screen for assigning bookmarks to the commits that need them.
+  Each commit cycles through: `[x]` existing → `[~]` auto → `[>]` typed by hand → `[+]` generated `stakk-xxxx` → `[*]`
+  custom command → `[ ]` skip.
+- **Auto bookmark naming** — the `[~]auto` state derives names from commit descriptions and file paths via TF-IDF
+  scoring; `r` cycles alternatives and `--auto-prefix` brands them (e.g. `gb-caching-database`).
+- **Stacked PR submission** — creates or updates GitHub PRs with correct base branches so each PR shows only its own
+  diff; `--draft` creates new ones as drafts.
+- **Stack-awareness comments** — every PR gets the full stack with links,
+  updated in place on re-runs and rendered with customizable [minijinja](https://github.com/mitsuhiko/minijinja)
+  templates.
   See [Stack info placement](#stack-info-placement).
-  Comments are rendered with [minijinja](https://github.com/mitsuhiko/minijinja) templates
-  and can be customized with `--template` or the `STAKK_TEMPLATE` environment variable.
 - **Idempotent** — re-running `stakk submit` is always safe.
   Existing PRs are updated, never duplicated.
 - **Dry-run mode** — `--dry-run` shows exactly what would happen without
   touching GitHub — or the repo: no bookmarks are created, nothing is pushed.
-- **Interactive TUI** — running `stakk` without arguments launches a ratatui TUI: a graph view shows all branch stacks,
-  then a bookmark assignment screen lets you toggle bookmarks on unmarked commits before submitting.
-  Each commit cycles through: `[x]` existing → `[~]` auto → `[>]` typed by hand → `[+]` generated `stakk-xxxx` → `[*]`
-  custom command → `[ ]` skip.
 - **Non-interactive selection** — `--keep`/`--keep-all`/`--new`/`--new-auto`/`--new-command` build the exact same
   submission the TUI would, without a terminal.
-  Pair them with `stakk show --format=json` for scripts and coding agents.
+- **PR titles and bodies from descriptions** — populated from jj change descriptions on creation, so manual edits on
+  GitHub survive; `--sync-pr-content` opts into keeping them in sync.
 - **Self-documenting** — `stakk docs` prints the bundled documentation, version-locked to the binary you are running.
-  `stakk docs scripting` is the whole non-interactive workflow in one command, which is the fastest way to bring a
-  coding agent up to speed.
-- **Draft PRs** — `--draft` creates new PRs as drafts.
-- **PR body from descriptions** — PR titles and bodies are populated from jj change descriptions.
-  By default they are only written when the PR is created, so manual edits on GitHub survive;
-  `--sync-pr-content` opts into keeping them in sync.
 - **No direct git usage** — all VCS operations go through `jj` commands, so
   workspaces and non-colocated repos work automatically.
 - **Forge-agnostic core** — GitHub is the first implementation, but the
@@ -91,49 +80,34 @@ Download from the [latest release](https://github.com/glennib/stakk/releases/lat
 ## Quick start
 
 ```text
-# Submit interactively — pick a stack and assign bookmarks via TUI
+# Submit interactively — pick a stack and assign bookmarks in the TUI
 stakk
 
-# Works even without any bookmarks — the TUI lets you create them
-stakk
+# See your stacks without submitting (offline: jj only, never GitHub)
+stakk show
 
-# Submit a specific bookmark (and its ancestors) as stacked PRs
+# Submit a specific bookmark and its ancestors as stacked PRs
 stakk submit my-feature
 
-# Preview what would happen without doing anything
+# Preview a submission without touching the repo or GitHub
 stakk submit my-feature --dry-run
-
-# Create PRs as drafts
-stakk submit my-feature --draft
-
-# See your bookmark stacks without submitting
-stakk show
 ```
 
 ## How stacking works
 
 In jj, bookmarks point at changes.
 When bookmarks form a linear chain — each building on the previous — they represent a stack.
-You can create bookmarks yourself, or let stakk discover unbookmarked heads and create them interactively:
+Create the bookmarks yourself, or let stakk discover unbookmarked heads and create them for you:
 
 ```text
-trunk
-  └── feat-auth        ← bookmark 1
-        └── feat-api   ← bookmark 2
-              └── feat-ui  ← bookmark 3
+ ○  feat-ui    ← leaf
+ ○  feat-api
+ ○  feat-auth
+ ◆  main       ← trunk
 ```
 
-When you run `stakk submit feat-ui`, stakk:
-
-1. **Analyzes** the change graph to find the stack containing `feat-ui` and
-   all its ancestors (`feat-auth`, `feat-api`, `feat-ui`).
-2. **Plans** the submission by checking GitHub for existing PRs, determining
-   which bookmarks need pushing, which PRs need creating, and which base
-   branches need updating.
-3. **Executes** the plan: pushes bookmarks, creates or updates PRs with
-   correct base branches, and adds stack-awareness comments to every PR.
-
-The result on GitHub:
+`stakk submit feat-ui` pushes every bookmark from the trunk up to `feat-ui` and creates or updates one PR per bookmark,
+basing each on the bookmark below it:
 
 - `feat-auth` → PR targeting `main`
 - `feat-api` → PR targeting `feat-auth`
@@ -156,28 +130,20 @@ Re-running `stakk submit` is always safe — it updates existing PRs rather than
 
 ## Stack info placement
 
-`--stack-placement` (or `stack_placement` in a config file, or `STAKK_STACK_PLACEMENT`) decides
-where the stack overview lives on each PR:
-
-- `comment` (default) — a separate PR comment, updated in place
-- `body` — a fenced section in the PR body
-- `none` — write nothing, and remove stack comments and body fences that are already there
-- `ignore` — write nothing, and leave existing artifacts exactly as they are
-
-Switching between `comment` and `body` migrates automatically.
-A submission that produces a single PR is not a stack, so no stack info is written.
+`--stack-placement` decides where the stack overview lives on each PR: a separate PR `comment` (default),
+a fenced section in the PR `body`, `none` (write nothing and remove what is already there), or `ignore`
+(write nothing and touch nothing).
+Switching between `comment` and `body` migrates automatically,
+and a submission that produces a single PR is not a stack, so no stack info is written.
 
 Full mode table, migration details, and stack comment templating: [docs/template.md](docs/template.md),
 or run `stakk docs template`.
 
 ## Configuration
 
-stakk loads settings from TOML config files, environment variables, and CLI flags.
-The precedence order, highest to lowest, is CLI flags, then environment variables, then the repository `stakk.toml`,
-then the user config, then built-in defaults.
-
-Repository config is found by walking up from the current directory to the jj workspace root.
-User config lives in your platform's standard config directory (`~/.config/stakk/config.toml` on Linux).
+Settings come from CLI flags, then `STAKK_`-prefixed environment variables, then a repository `stakk.toml`
+(found by walking up to the jj workspace root),
+then the user config (`~/.config/stakk/config.toml` on Linux), then built-in defaults.
 All fields are optional, and unknown fields cause a parse error.
 
 ```toml
@@ -188,8 +154,8 @@ stack_placement = "body"
 auto_prefix = "gb-"
 ```
 
-Every config key, the `inherit` field, worked examples, and the full environment variable table:
-[docs/config.md](docs/config.md), or run `stakk docs config`.
+Every config key and environment variable, the `inherit` field, and worked examples: [docs/config.md](docs/config.md),
+or run `stakk docs config`.
 
 ### GitHub Enterprise Server
 
@@ -205,98 +171,32 @@ gh auth login --hostname github.example.com
 stakk auth test
 ```
 
-Details: [docs/config.md](docs/config.md), or run `stakk docs config`.
-
-## Environment variables
-
-Every `submit` flag has a matching `STAKK_`-prefixed environment variable — `STAKK_REMOTE`, `STAKK_PR_MODE`,
-`STAKK_STACK_PLACEMENT`, and so on — plus `GITHUB_TOKEN` / `GH_TOKEN` for authentication
-(`GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` for a GitHub Enterprise Server host).
-CLI flags take precedence over environment variables, which take precedence over config files.
-
-`--dry-run` and the selection flags deliberately have no environment variables: they are per-invocation decisions.
-
-Full table: [docs/config.md](docs/config.md), or run `stakk docs config`.
+Host resolution order, the per-host token order, and the API base: [docs/config.md](docs/config.md),
+or run `stakk docs config`.
 
 ## Usage
 
-### Global flags
+`stakk --help` and `stakk <subcommand> --help` are the flag reference: every flag, its default,
+and its environment variable.
 
-| Flag | Env var | Description |
-|------|---------|-------------|
-| `--config <path>` | `STAKK_CONFIG` | Load this config file instead of discovering `stakk.toml` |
-| `--github-host <host>` | `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (falls back to `GH_HOST`) |
-| `--version` | | Print the stakk version |
-| `--help` | | Print help; `--help` on a subcommand shows its full flag documentation |
-
-`--config` and `--github-host` accept any subcommand, but they have to come *after* it —
-`stakk auth test --github-host <host>`, not `stakk --github-host <host> auth test`.
-Their environment variables work from either position.
-
-### `stakk` (no arguments)
+### `stakk`
 
 Launches the interactive submission flow.
 A ratatui TUI shows a graph of all branch stacks; select a leaf branch, then toggle bookmarks on commits that need them.
 Works even in repos with no pre-existing bookmarks — stakk creates `stakk-<change_id>` bookmarks for unmarked commits.
-Equivalent to `stakk submit` without arguments.
+Identical to `stakk submit` with no arguments.
 
 ### `stakk submit [bookmark]`
 
 Submit a bookmark and all its ancestors as stacked PRs.
-When run without a bookmark argument, an interactive ratatui TUI lets you select a branch from a graph view,
-then assign bookmarks to any unmarked commits before submitting.
+Without a bookmark argument, it runs the interactive flow above.
 
-| Flag | Env var | Description |
-|------|--------|-------------|
-| `--dry-run` | | Show the submission plan without executing |
-| `--keep <bookmark>` | | Non-interactive: keep an existing bookmark as a PR boundary (repeatable) |
-| `--keep-all` | | Non-interactive: keep every existing bookmark on the selected path |
-| `--new <rev>[=<name>]` | | Non-interactive: new bookmark at `rev` — `stakk-<change_id>` by default, or `name` (repeatable) |
-| `--new-auto <rev>` | | Non-interactive: new TF-IDF-named bookmark at `rev`, honoring `--auto-prefix`; falls back to `stakk-<change_id>` when nothing can be derived or the name is taken (repeatable) |
-| `--new-command <rev>` | | Non-interactive: new bookmark at `rev` named by `--bookmark-command` (repeatable) |
-| `--pr-mode <mode>` | `STAKK_PR_MODE` | Create new PRs as `regular` (default) or `draft` |
-| `--draft` | `STAKK_DRAFT` | Shortcut for `--pr-mode draft`; wins if both are given |
-| `--remote <name>` | `STAKK_REMOTE` | Push to a specific remote (default: `origin`) |
-| `--template <path>` | `STAKK_TEMPLATE` | Use a custom minijinja template for stack comments |
-| `--stack-placement <mode>` | `STAKK_STACK_PLACEMENT` | Place stack info as a PR `comment` (default), in the PR `body`, or write none with `none`/`ignore` — see [Stack info placement](#stack-info-placement) |
-| `--auto-prefix <prefix>` | `STAKK_AUTO_PREFIX` | Prefix for `[~]auto` bookmark names (e.g. `gb-`) |
-| `--sync-pr-content <mode>` | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, `all` |
-| `--trailers <mode>` | `STAKK_TRAILERS` | Keep or strip git commit trailers in PR bodies: `keep` (default), `strip` |
-| `--bookmark-command <cmd>` | `STAKK_BOOKMARK_COMMAND` | Shell command that names bookmarks, enabling the `[*]` TUI state and `--new-command` |
-| `--bookmarks-revset <revset>` | `STAKK_BOOKMARKS_REVSET` | Which bookmarks become stack segments (default: `mine() ~ trunk() ~ immutable()`) |
-| `--heads-revset <revset>` | `STAKK_HEADS_REVSET` | Which unbookmarked heads are discovered (default: `heads((mine() ~ empty() ~ immutable()) & trunk()..)`) |
+#### Non-interactive selection
 
-The selection flags (`--keep`, `--keep-all`, `--new`, `--new-auto`, `--new-command`) replace the TUI with a fully
-explicit, scriptable selection; they conflict with the positional bookmark argument and are deliberately CLI-only (no
-env vars, no config keys — like `--dry-run`, per-invocation decisions make surprising defaults).
-The marks fully determine the PR set: nothing is implicit.
-All marks must lie on one trunk-to-tip path, the topmost mark is the tip of the submission,
-and bookmarks on the path that are not kept fold into the PR above them.
-`rev` is a change id or commit id prefix as printed by `stakk show`.
-Bare `--keep-all` requires the choice of stack to be unambiguous — a single stack,
-or several that agree on their bookmarks
-(e.g. differing only in unbookmarked heads such as the working copy); anchor it with `--keep`/`--new` otherwise.
-Commits already carrying an explicit mark are skipped by `--keep-all` (explicit beats bulk).
-
-#### Bookmark names that collide with subcommands
-
-A leading subcommand name wins over the positional bookmark.
-`stakk show` runs the `show` subcommand even when a bookmark of that name exists, and the same holds for `submit`,
-`auth`, `docs`, `completions` and `help`.
-Name the subcommand, or end option parsing with `--`, to submit such a bookmark:
-
-```console
-stakk submit show
-stakk -- show
-```
-
-Submit flags belong after the subcommand: `stakk submit --dry-run show` works,
-while `stakk --dry-run submit show` is rejected.
-
-#### Agent / scripting usage
-
-Non-interactive submission is a two-command loop — discover, then submit.
-Everything `stakk submit` needs (change id prefixes, bookmark names) is in `stakk show`'s output:
+`--keep`, `--keep-all`, `--new`, `--new-auto` and `--new-command` replace the TUI with a fully explicit,
+scriptable selection: the marks determine the PR set with nothing implicit, all marks must lie on one trunk-to-tip path,
+the topmost mark is the tip, and bookmarks on the path that are not kept fold into the PR above them.
+`rev` is a change id or commit id prefix as printed by `stakk show`, which makes submission a two-command loop:
 
 ```console
 stakk show --format=json
@@ -304,29 +204,21 @@ stakk submit --keep base --new qzvs=my-feature --new-auto wmtk --dry-run
 stakk submit --keep base --new qzvs=my-feature --new-auto wmtk
 ```
 
-`--dry-run` is fully inert: it prints the planned bookmark creations and PR actions without creating, pushing,
-or changing anything — safe for validation before the real run.
-Selection errors carry machine-readable diagnostic codes (`stakk::selection::*`) and point back at `stakk show`.
-
-The complete reference — every selection rule, the diagnostic codes, and the JSON schema — is in
-[docs/scripting.md](docs/scripting.md).
-Point a coding agent at `stakk docs scripting`: it prints that document,
-so the agent never has to read this README or guess at flag semantics.
+Every selection rule, the machine-readable `stakk::selection::*` diagnostic codes, and the JSON schema:
+[docs/scripting.md](docs/scripting.md), or run `stakk docs scripting`.
+Pointing a coding agent at `stakk docs scripting` is the fastest way to bring it up to speed.
 
 #### PR titles and bodies
 
-PR titles come from the first line of the jj change description.
-PR bodies are populated from the full description (everything after the title line).
-For segments with multiple commits, descriptions are joined with `---` separators.
-By default, titles and bodies are only set on PR creation — manually edited PR descriptions are never overwritten.
-Use `--sync-pr-content` to update existing PRs: `title` syncs only the title, `body` only the body, or `all` for both.
-Only fields that actually changed are updated.
+PR titles come from the first line of the jj change description and bodies from everything after it;
+segments with multiple commits join their descriptions with `---` separators.
+Both are written only on PR creation, so manually edited PR descriptions are never overwritten — `--sync-pr-content`
+(`title`, `body`, `all`) opts into updating existing PRs, and only changed fields are sent.
 
 Descriptions are reflowed on the way into the PR body: hard-wrapped prose lines are joined into soft-wrapped paragraphs,
 so a commit message wrapped at 72 columns does not render as ragged lines on GitHub.
 Structural Markdown — headers, lists, tables, block quotes, fenced and indented code, thematic breaks —
 is passed through verbatim.
-
 `--trailers strip` removes the trailing key/value block
 (`Signed-off-by`, `Co-authored-by`, `Refs`, …) from the generated body; the default `keep` passes it through.
 
@@ -336,8 +228,8 @@ is passed through verbatim.
 The command is run through `sh -c` (Unix) or `cmd /C` (Windows),
 receives a JSON description of one segment of commits on stdin, and must print a single bookmark name on stdout.
 It powers the `[*]` state in the TUI and the `--new-command` selection flag.
-
-The full JSON schema, with a worked example, is in `stakk submit --help`.
+The full JSON schema, with a worked example, is in `stakk submit --help`;
+the surrounding context is in [docs/template.md](docs/template.md), or run `stakk docs template`.
 
 #### Immutable commits
 
@@ -350,17 +242,14 @@ a bookmark exists on it *and* the bookmarks revset does not filter that bookmark
 (the default `~ immutable()` term does).
 So if you really need a PR there, create the bookmark yourself and drop `~ immutable()` from `--bookmarks-revset`;
 otherwise move the work onto mutable commits.
+The non-interactive side of this is in [docs/scripting.md](docs/scripting.md), or run `stakk docs scripting`.
 
 ### `stakk show`
 
 Display repository status and all bookmark stacks without submitting.
 Fully offline: only `jj` is queried, never GitHub — PR state is `stakk submit --dry-run`'s job.
-
-| Flag | Env var | Description |
-|------|--------|-------------|
-| `--format <format>` | | Output format: `pretty` (default) or `json` |
-| `--bookmarks-revset <revset>` | `STAKK_BOOKMARKS_REVSET` | Which bookmarks become stack segments |
-| `--heads-revset <revset>` | `STAKK_HEADS_REVSET` | Which unbookmarked heads are discovered |
+`show` and `submit` build the graph the same way, so `--bookmarks-revset`/`--heads-revset` apply to both:
+what `show` prints is what `submit` would work on.
 
 The default `pretty` format renders a jj-log-style graph of all stacks, always fully expanded.
 Every commit row carries its short change id, bookmarks, and description summary;
@@ -382,38 +271,16 @@ Remote: origin git@github.com:you/repo.git (you/repo)
 Bookmarks whose history contains a merge commit cannot be stacked and are left out of the graph; when that happens,
 `pretty` prints a `(N bookmark(s) excluded due to merge commits)` footer.
 
-`stakk show` and `stakk submit` build the graph the same way, so `--bookmarks-revset`/`--heads-revset`
-(and their config keys) apply to both — what `show` prints is what `submit` would work on.
-
-`--format=json` emits a schema-versioned JSON document for machine consumption (scripts, agents).
-Identifiers in the document — change id prefixes and bookmark names — can be passed directly to `stakk submit`.
-
-- `schema_version` — currently `1`; bumped on breaking schema changes
-- `default_branch`
-- `remotes[]` — `name`, `url`, `github` (`owner/repo`, or `null` for
-  non-GitHub remotes)
-- `excluded_bookmark_count` — bookmarks excluded due to merge commits
-- `stacks[]` — one per leaf, trunk-to-leaf; shared ancestor segments are
-  repeated in every stack that contains them
-  - `segments[]` — `bookmark_names[]` and `commits[]` (oldest first)
-    - each commit: `change_id`, `short_change_id`, `commit_id`,
-      `description` (full), `author` (`name`, `email`, `timestamp`),
-      `files[]`, `is_immutable`, `local_bookmark_names[]` (unfiltered —
-      includes bookmarks the bookmarks revset excluded), `is_boundary`
-      (the commit its segment's bookmarks point at), `is_leaf` (the tip
-      of its stack)
+`--format=json` emits a schema-versioned document for machine consumption
+(scripts, agents); its change id prefixes and bookmark names can be passed directly to `stakk submit`.
+Field-by-field schema: [docs/scripting.md](docs/scripting.md), or run `stakk docs scripting`.
 
 ### `stakk docs [topic]`
 
 Print the documentation bundled into the binary.
 Because it ships inside the binary, it always describes the version you are actually running.
-
 Run `stakk docs` with no arguments for the list of topics.
 Each topic is one of the Markdown files in [docs/](docs/), which is also where to read them on GitHub.
-
-| Flag | Env var | Description |
-|------|---------|-------------|
-| `[topic]` | | Topic to print; omit to list the available topics |
 
 At a terminal the prose is re-flowed to your terminal width.
 Redirected, the source is emitted verbatim —

--- a/docs/config.md
+++ b/docs/config.md
@@ -195,5 +195,10 @@ an Enterprise Server reachable only over plain HTTP is not supported.
 | `GH_ENTERPRISE_TOKEN` | Access token for a GitHub Enterprise Server host |
 | `GITHUB_ENTERPRISE_TOKEN` | Alternative to `GH_ENTERPRISE_TOKEN` |
 
+`--draft` is a shortcut for `--pr-mode draft`, and draft-ness wins from whichever source sets it:
+`--draft` *or* `STAKK_DRAFT=true` forces a draft even alongside an explicit `--pr-mode regular`.
+Unset `STAKK_DRAFT` rather than passing `--pr-mode regular` when you want a non-draft PR.
+There is no `draft` config key — use `pr_mode = "draft"` in a config file.
+
 `--dry-run` and the selection flags (`--keep`, `--keep-all`, `--new`, `--new-auto`, `--new-command`) deliberately have
 no environment variables or config keys: they are per-invocation decisions, and a persisted default would be surprising.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -79,13 +79,17 @@ Selection failures carry machine-readable diagnostic codes and point back at `st
 | `stakk::selection::rev_not_found` | No commit on the graph matches the prefix |
 | `stakk::selection::rev_ambiguous` | The prefix matches more than one commit |
 | `stakk::selection::rev_immutable` | The commit is jj-immutable and cannot take a bookmark |
+| `stakk::selection::empty_rev` | A selection flag was given an empty `REV` |
+| `stakk::selection::invalid_new_spec` | A `--new` value is neither `REV` nor `REV=NAME` |
 | `stakk::selection::not_colinear` | The marks do not lie on a single trunk-to-tip path |
 | `stakk::selection::keep_not_found` | No such bookmark on the selected path |
 | `stakk::selection::keep_all_ambiguous` | Bare `--keep-all` cannot pick between stacks |
 | `stakk::selection::no_marks` | No marks given, so there is nothing to submit |
+| `stakk::selection::no_stacks` | The repository has no bookmark stacks to select from |
 | `stakk::selection::duplicate_mark` | The same revision was marked twice |
 | `stakk::selection::duplicate_name` | Two marks would create the same bookmark name |
 | `stakk::selection::name_exists` | The requested name is already taken by a local bookmark |
+| `stakk::selection::bookmark_command_not_configured` | `--new-command` was used without `--bookmark-command` |
 
 ## The `stakk show --format=json` document
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -13,6 +13,18 @@ stakk submit --keep base --new qzvs=my-feature --new-auto wmtk
 
 `stakk show` is fully offline — it queries only `jj`, never GitHub — so discovery is cheap and safe to run at any time.
 
+## Always name the subcommand
+
+Write `stakk submit`, never the bare `stakk <bookmark>` form.
+A leading subcommand name wins over the positional bookmark,
+so `stakk show` runs the `show` subcommand even when a bookmark of that name exists.
+The reserved set is `submit`, `auth`, `show`, `completions`, `docs` and `help`,
+and it grows whenever stakk gains a subcommand.
+Both `stakk submit show` and `stakk -- show` submit the bookmark.
+
+Flags belong after the subcommand.
+`stakk submit --dry-run my-feature` works, while `stakk --dry-run submit my-feature` is rejected.
+
 ## Selection flags
 
 The selection flags replace the TUI with a fully explicit selection.

--- a/docs/template.md
+++ b/docs/template.md
@@ -32,12 +32,13 @@ larger stack are cleaned up (unless the mode is `ignore`).
 Stack comments are rendered with [minijinja](https://github.com/mitsuhiko/minijinja).
 `--template <path>` (or `template` in a config file, or `STAKK_TEMPLATE`) replaces the built-in template.
 
-The template receives a context with a `stack` array, ordered **trunk-first** —
-`position` is 1 for the entry nearest the trunk.
+The context holds `stack`, `stack_size`, `default_branch`, `current_bookmark` and `stakk_url`.
+The `stack` array is ordered **trunk-first** — `position` is 1 for the entry nearest the trunk.
 The default template reverses it (`stack | reverse`) so the rendered graph reads leaf-at-top,
 matching `stakk show` and the TUI.
 
-Each entry carries its `position`, `bookmark`, `pr_url`, `title`, and whether it is the PR currently being rendered.
+Each entry carries `bookmark_name`, `pr_url`, `pr_number`, `title`, `base`, `is_draft`, `position` and `is_current`.
+`stakk submit --help` prints the same list with a worked example template.
 Note that `title` is the *commit-derived* title,
 which can differ from the PR's live title on GitHub when `--sync-pr-content` does not include titles.
 The default template deliberately shows the bare `pr_url` — GitHub renders it as `#N` with the real title on hover —

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -47,7 +47,7 @@ pub enum SubmitError {
     #[error("bookmark '{bookmark}' not found in any stack")]
     #[diagnostic(
         code(stakk::submit::bookmark_not_found),
-        help("run `stakk` with no arguments to see available stacks")
+        help("run `stakk show` to list the bookmarks in every stack")
     )]
     BookmarkNotFound { bookmark: String },
 


### PR DESCRIPTION
docs: prune README redundancies and fix docs/ inaccuracies

Tighten `README.md` and make `docs/*.md` fully carry what it now defers to.

## README

- **Quick start**: drop the duplicated bare `stakk` invocation and the `--draft` one-liner; four commands, each showing something distinct.
- **How stacking works**: draw the stack with `stakk show`'s glyphs (`○`/`◆`, leaf at top) instead of an ASCII tree, and drop the numbered analyze/plan/execute list that restated the **Design** section.
- Remove the *Bookmark names that collide with subcommands* section and every trace of the bare `stakk <bookmark>` form. `stakk` with no arguments now means the TUI, and naming a bookmark means `stakk submit <bookmark>`.
- Remove the reference tables: global flags, `submit`, `show`, `docs`, the **Environment variables** section, and the `stakk show --format=json` schema list (a verbatim copy of `docs/scripting.md`). `stakk --help`, `stakk <subcommand> --help` and `docs/config.md` are the reference. `--github-host` and the Enterprise token variables go with those tables; the **GitHub Enterprise Server** section is prose, so it stays and now links to `docs/config.md` for the resolution orders.
- Every section summarizing a doc now ends with both the file link and the `stakk docs <topic>` command, including *Custom bookmark names* and *Immutable commits*, which had neither.
- Deduplicate **Features** against the body.

## docs

Gaps that mattered once the README stopped duplicating them:

- `template.md`: the entry field was documented as `bookmark`; it is `bookmark_name`. List the full render context (`pr_number`, `base`, `is_draft`, `is_current`, and the top-level fields).
- `scripting.md`: add the four missing diagnostic codes (`empty_rev`, `invalid_new_spec`, `no_stacks`, `bookmark_command_not_configured`) so the table matches the codes the binary emits.
- `config.md`: document that draft-ness wins from whichever source sets it — `STAKK_DRAFT=true` forces a draft even alongside an explicit `--pr-mode regular` — and that there is no `draft` config key.

## CLAUDE.md

Touchpoint 4 of the four-touchpoint rule pointed at README tables that no longer exist; it now points at `docs/config.md` and lists the README prose sections that can still need updating. Also record that the README shows only encouraged flows.

`docs/config.md` absorbs the README tables' role rather than sitting on top of them as a fifth step, so the rule stays at four touchpoints. The `global = true` note about `apply_global_defaults` belongs to touchpoint 3, where the other `src/cli/mod.rs` wiring lives.

---

fix: point bookmark_not_found at `stakk show`, document subcommand shadowing

The `bookmark_not_found` help told users to "run `stakk` with no arguments to see available stacks", which launches the interactive TUI rather than listing anything. It now points at `stakk show`, which actually lists the bookmarks in every stack.

Also document two consequences of `SubmitArgs` being flattened onto `Cli`, neither of which was written down anywhere:

- A leading subcommand name wins over the positional bookmark, so `submit`, `auth`, `show`, `completions`, `docs` and `help` are unreachable as bare bookmark names. `stakk submit <name>` and `stakk -- <name>` both work.
- Submit flags must follow the subcommand. `args_conflicts_with_subcommands` rejects `stakk --dry-run submit <name>`, which is deliberate: the flatten gives every submit arg two homes and only the subcommand's copy is read, so without that guard a top-level `--dry-run` would be silently dropped and the submission would run for real.

Covered in the README CLI reference and in docs/scripting.md, where it matters most for scripts and coding agents.