### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/glennib/stakk/compare/v2.0.0...v2.1.0) - 2026-08-14
+
+### Added
+
+- *(cli)* add one-letter aliases for submit, graph and docs
+- *(cli)* rename `stakk show` to `stakk graph`
+
+### Other
+
+- *(cli)* rename GraphArgs to RevsetArgs
+- move the stability contract into a `stakk docs` topic
+- improve README
+- *(media)* update gif
+
 ## [2.0.0](https://github.com/glennib/stakk/compare/v1.25.0...v2.0.0) - 2026-08-13
 
 v2 is a surface release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.0.0 -> 2.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.0](https://github.com/glennib/stakk/compare/v2.0.0...v2.1.0) - 2026-08-14

### Added

- *(cli)* add one-letter aliases for submit, graph and docs
- *(cli)* rename `stakk show` to `stakk graph`

### Other

- *(cli)* rename GraphArgs to RevsetArgs
- move the stability contract into a `stakk docs` topic
- improve README
- *(media)* update gif
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).