### PR TITLE
chore: release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2](https://github.com/glennib/stakk/compare/v2.1.1...v2.1.2) - 2026-08-14
+
+### Other
+
+- *(docs)* generate the `stakk docs` topics from the docs/ directory
+- *(docs)* snapshot the `stakk docs` index and help output
+
 ## [2.1.1](https://github.com/glennib/stakk/compare/v2.1.0...v2.1.1) - 2026-08-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,7 +2824,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.1.1 -> 2.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.2](https://github.com/glennib/stakk/compare/v2.1.1...v2.1.2) - 2026-08-14

### Other

- *(docs)* generate the `stakk docs` topics from the docs/ directory
- *(docs)* snapshot the `stakk docs` index and help output
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).