### PR TITLE
chore: release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/glennib/stakk/compare/v2.2.0...v2.2.1) - 2026-08-24
+
+### Fixed
+
+- cargo upgrade
+- *(lint)* satisfy clippy 1.98 unused_async_trait_impl in mock runners
+
+### Other
+
+- *(deps)* update dependency cargo-binstall to v1.22.0 ([#221](https://github.com/glennib/stakk/pull/221))
+- *(deps)* update dependency rumdl to v0.2.60 ([#220](https://github.com/glennib/stakk/pull/220))
+- *(deps)* update dependency rumdl to v0.2.58 ([#219](https://github.com/glennib/stakk/pull/219))
+- *(deps)* update dependency rumdl to v0.2.57 ([#218](https://github.com/glennib/stakk/pull/218))
+- *(deps)* update dependency rumdl to v0.2.56 ([#216](https://github.com/glennib/stakk/pull/216))
+
 ## [2.2.0](https://github.com/glennib/stakk/compare/v2.1.3...v2.2.0) - 2026-08-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.2.0 -> 2.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.1](https://github.com/glennib/stakk/compare/v2.2.0...v2.2.1) - 2026-08-24

### Fixed

- cargo upgrade
- *(lint)* satisfy clippy 1.98 unused_async_trait_impl in mock runners

### Other

- *(deps)* update dependency cargo-binstall to v1.22.0 ([#221](https://github.com/glennib/stakk/pull/221))
- *(deps)* update dependency rumdl to v0.2.60 ([#220](https://github.com/glennib/stakk/pull/220))
- *(deps)* update dependency rumdl to v0.2.58 ([#219](https://github.com/glennib/stakk/pull/219))
- *(deps)* update dependency rumdl to v0.2.57 ([#218](https://github.com/glennib/stakk/pull/218))
- *(deps)* update dependency rumdl to v0.2.56 ([#216](https://github.com/glennib/stakk/pull/216))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).