### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0](https://github.com/glennib/stakk/compare/v2.2.1...v2.3.0) - 2026-08-31
+
+### Added
+
+- *(select)* show short change ids in the graph screen
+
+### Other
+
+- *(deps)* lock file maintenance ([#229](https://github.com/glennib/stakk/pull/229))
+- *(deps)* update dependency uv to v0.12.7 ([#228](https://github.com/glennib/stakk/pull/228))
+- *(deps)* update dependency rumdl to v0.2.62 ([#227](https://github.com/glennib/stakk/pull/227))
+- *(deps)* update dependency rumdl to v0.2.61 ([#226](https://github.com/glennib/stakk/pull/226))
+- *(deps)* lock file maintenance ([#223](https://github.com/glennib/stakk/pull/223))
+- *(deps)* update dependency uv to v0.12.6 ([#224](https://github.com/glennib/stakk/pull/224))
+
 ## [2.2.1](https://github.com/glennib/stakk/compare/v2.2.0...v2.2.1) - 2026-08-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.2.1 -> 2.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.3.0](https://github.com/glennib/stakk/compare/v2.2.1...v2.3.0) - 2026-08-31

### Added

- *(select)* show short change ids in the graph screen

### Other

- *(deps)* lock file maintenance ([#229](https://github.com/glennib/stakk/pull/229))
- *(deps)* update dependency uv to v0.12.7 ([#228](https://github.com/glennib/stakk/pull/228))
- *(deps)* update dependency rumdl to v0.2.62 ([#227](https://github.com/glennib/stakk/pull/227))
- *(deps)* update dependency rumdl to v0.2.61 ([#226](https://github.com/glennib/stakk/pull/226))
- *(deps)* lock file maintenance ([#223](https://github.com/glennib/stakk/pull/223))
- *(deps)* update dependency uv to v0.12.6 ([#224](https://github.com/glennib/stakk/pull/224))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).