### PR TITLE
feat: integrate GitHub's native stacked pull requests (`--native-stacks`)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -728,8 +728,13 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   third-party UIs).
   The `auto-comment`/`auto-body` placements resolve the redundancy per run instead of forbidding it,
   and an explicit `comment`/`body` choice is never overridden.
-  The intended zero-config end state at GA is `native_stacks = auto` + `stack_placement = auto-comment`:
-  native rendering where enabled, stack comments everywhere else, never both.
+  `stack_placement` already defaults to `auto-comment` —
+  extensionally identical to `comment` while `native_stacks` is `ignore`
+  (its default),
+  so the flip is not a behavior change and not a semver break —
+  and the intended GA change is a single default flip of `native_stacks` to `auto`: native rendering where enabled,
+  stack comments everywhere else, never both.
+  The `--native-stacks` docs advertise that its default may change.
 - **`--native-stacks` reuses the placement vocabulary** — its members are `on`/`auto`/`none`/`ignore`,
   where `none` and `ignore` follow the same rule as their `--stack-placement` namesakes:
   `none` registers nothing *and* dissolves the server-side stacks containing submitted PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ It complements jj by turning local bookmark state into coherent GitHub PRs with 
 All core features are complete: stack detection, three-phase submission, interactive TUI selection,
 fully explicit non-interactive selection via `--keep`/`--new*`, offline `stakk graph`
 (pretty graph + versioned JSON in sparse and full projections),
-four stack-placement modes, stack comment templating, layered config
-(CLI > env > repo/user TOML), bundled documentation via `stakk docs`, and comprehensive error handling.
+six stack-placement modes, native GitHub stacked-PR registration (`--native-stacks`), stack comment templating,
+layered config (CLI > env > repo/user TOML), bundled documentation via `stakk docs`, and comprehensive error handling.
 
 The CLI surface: `stakk` and `stakk submit` both open the TUI,
 every PR boundary of a non-interactive submission is named with a selection flag, and there is no positional bookmark,
@@ -126,7 +126,11 @@ src/
 │   └── version.rs   # jj version parsing + minimum supported version
 ├── forge/           # Forge trait + GitHub implementation (octocrab)
 │   ├── mod.rs       # Forge trait, forge-agnostic types, ForgeError
-│   ├── github.rs    # GitHubForge implementation
+│   ├── github/
+│   │   ├── mod.rs   # GitHubForge implementation
+│   │   └── stacks.rs # Hand-rolled transport for the native-stacks preview
+│   │                # endpoints — exists to be deleted once octocrab ships
+│   │                # typed support (XAMPPRocky/octocrab#934)
 │   ├── comment.rs   # Stack comment formatting, parsing, and template context
 │   └── default_comment.md.jinja  # Default minijinja template for stack comments
 ├── graph/           # Change graph construction (ChangeGraph, BookmarkSegment, BranchStack)
@@ -209,6 +213,9 @@ There is intentionally no `git/` module.
 - No `anyhow` — every error is a concrete type with `Diagnostic` metadata.
 - Use `#[diagnostic(help(...))]` for actionable advice on all variants.
   Use `#[diagnostic(code(stakk::...))]` for machine-readable error identifiers.
+  Exception: a variant that is *always* wrapped as the `#[source]` of another diagnostic carries no help of its own —
+  miette renders only the outermost help, so the advice lives once, on the wrapper
+  (see the `ForgeError` stack variants gotcha).
 
 ### jj Interface
 
@@ -468,6 +475,57 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
 - Graph traversal uses `"trunk()"` as the revset base, not a branch name.
 - octocrab treats PR comments as issue comments — use `issues().list_comments()`.
 - octocrab `pulls().create()` borrows the handler — bind to a variable first.
+- The four stack methods on `Forge` go through `forge/github/stacks.rs`,
+  which builds `http::Request`s by hand
+  and sends them through the public `Octocrab::execute` instead of octocrab's typed helpers.
+  Two octocrab defects force this (verified against octocrab 0.54.1 source):
+  `build_request` stamps a baked-in `X-GitHub-Api-Version: 2022-11-28` on every request it builds
+  and `add_header` *appends* rather than replaces,
+  so the `2026-03-10` the stack routes require would go on the wire doubled and GitHub 400s it;
+  and octocrab's `map_github_error` chokes on error bodies whose `errors` field is a string
+  (GitHub's version-rejection body is one), degrading real status codes to serde errors.
+  `execute` keeps octocrab's service layers — auth, base URI (GHES), `User-Agent` —
+  because they run below `build_request`; only the header stamping is skipped.
+  The module doc says all of this; the module is deleted wholesale
+  when octocrab ships typed stacks support (XAMPPRocky/octocrab#934).
+- Native-stack availability is *not probed* — there is no `supports_native_stacks`.
+  The reconcile step runs before the text-placement step, and its own outcome is the answer:
+  success → a native stack is in effect, `ForgeError::StacksUnavailable`
+  (a 404 on a stacks route, the reading GitHub's own `gh stack` client applies)
+  → definitively not offered here, anything else → unknown.
+  Under `--native-stacks auto`, unknown resolves the auto placements to *writing* (comment/body), never to ignore:
+  a redundant stack overview self-heals on the next successful run, while a skipped update leaves a stale one standing.
+  Only a definitive native stack triggers the destructive direction (cleanup).
+  On GitHub the unavailable case today means GHES — the preview rolled out to all github.com repositories.
+- Stacks reported closed (`"open": false` on the wire) still appear in list responses;
+  `stacks.rs` filters them out before conversion so the reconcile never tries to unstack history.
+  `StackDto` is deliberately not serde-defaulted (same rule as `LogEntryRaw`).
+- Body sync is one pass, not part of the interleaved per-bookmark loop:
+  it runs after the native reconcile and `resolve_placement`, and is skipped only when the body-splice phase covers it
+  (`EffectivePlacement::Body` with more than one PR folds each sync into its own body write).
+  The interleaving rule (#35) covers pushes and base updates only, so batching bodies is safe.
+  `single_pr_body_placement_still_syncs_the_body` pins the single-PR case,
+  `deferred_body_sync_applies_when_auto_body_resolves_to_cleanup` the cleanup-resolved one.
+- A reconcile failure under `--native-stacks on` fails the submit, but the error is *held* and
+  returned after body syncs and the text placement ran (which resolve as on an unknown native
+  state) — the help text's promise that PRs were created/updated normally must be true by the
+  time it renders.
+  `native_on_reconcile_failure_still_syncs_bodies_and_writes_comments` pins this.
+- `ForgeError::StacksUnavailable` and `ForgeError::StackConflict` carry no `#[diagnostic(help)]` on purpose:
+  every stack call is wrapped by `submit::wrap_stack_err` into a `SubmitError`,
+  and miette renders only the outermost diagnostic's help
+  (`#[source]` chains messages, not diagnostics) — a help there would be dead prose drifting from the copy that renders.
+  This is the one sanctioned exception to the "help on all variants" rule.
+- A 404 from the stacks API is route-dependent (`NotFound` in `stacks.rs`): on the collection
+  routes it means the feature is not offered (`StacksUnavailable`), on `/stacks/{n}/add` it means
+  the stack vanished since the lookup (`StackConflict`, converged by rebuilding), and on
+  `/stacks/{n}/unstack` a vanished stack *is* the goal state, so the 404 counts as success.
+- The reconcile leaves a server stack standing
+  when the submission is its *bottom prefix* (`open_pr_numbers.starts_with(desired)`):
+  the chain above is intact and rebuilding would evict those PRs from merge-time retargeting.
+  Only a bottom prefix is safe — a slice higher up means the bottom submitted PR was retargeted past open members
+  and the stack is genuinely stale.
+  Every catch-all dissolve warns with the PR numbers that lose native stacking (`evicted_pr_numbers`).
 - Commit-derived PR body is only set on creation, not on update — avoids overwriting manually-edited PR bodies.
   Body-mode stack placement updates only the fenced section.
 - `markdown::unwrap::unwrap_markdown` reflows hard-wrapped description prose into soft-wrapped paragraphs
@@ -527,8 +585,11 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   The bookmark name is not written next to it either — the reference is the whole label.
 - Body-mode fences (`STAKK_BODY_START`/`STAKK_BODY_END`) are HTML comments, invisible on GitHub.
   Migration between placement modes is automatic.
-- `StackPlacement` (4 CLI modes) resolves to `EffectivePlacement`
-  (4 behaviors) in `resolve_placement`: `comment` → `Comment`, `body` → `Body`, `none` → `Cleanup`, `ignore` → `Ignore`.
+- `StackPlacement` (6 CLI modes) resolves to `EffectivePlacement`
+  (4 behaviors)
+  in `resolve_placement(placement, native_state)`: `comment` → `Comment`, `body` → `Body`, `none` → `Cleanup`,
+  `ignore` → `Ignore`, and `auto-comment`/`auto-body` → `Cleanup` on a definitive native stack,
+  `Comment`/`Body` otherwise (including on an unknown native state — see the native-stacks gotcha above).
   Keep the two enums distinct — `Cleanup` is also reached by single-bookmark submissions,
   which have no CLI mode of their own.
 - `--stack-placement none` writes no stack info and instead runs `cleanup_stack_artifacts` on every PR,
@@ -543,6 +604,7 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
   the `EffectivePlacement::Ignore` arm short-circuits before the cleanup branch,
   so it also wins over the single-bookmark cleanup rule.
   Like `none`, it never reads or compiles `--template-path`.
+  The auto placements *always* load the template — they may resolve to rendering.
 - ratatui inline viewport: `enable_raw_mode()` before, `disable_raw_mode()` after.
 - The inline viewport is sized per screen
   (graph vs bookmark rows).
@@ -660,6 +722,37 @@ If you change any of the following, update `scripts/record-demo.py` in the same 
 - **`ignore` exists because `none` deletes** — turning stack info off and leaving other
   tooling's (or your own) comments and body fences alone are two different wishes.
   `none` serves the first, `ignore` the second; neither is a safe default for the other.
+- **`--native-stacks` is orthogonal to `--stack-placement`** —
+  registering the server-side stack and placing stakk's stack-info text are separate decisions
+  (native + comment is valid while GitHub's stack map is not rendered everywhere: mobile, notification emails,
+  third-party UIs).
+  The `auto-comment`/`auto-body` placements resolve the redundancy per run instead of forbidding it,
+  and an explicit `comment`/`body` choice is never overridden.
+  The intended zero-config end state at GA is `native_stacks = auto` + `stack_placement = auto-comment`:
+  native rendering where enabled, stack comments everywhere else, never both.
+- **`--native-stacks` reuses the placement vocabulary** — its members are `on`/`auto`/`none`/`ignore`,
+  where `none` and `ignore` follow the same rule as their `--stack-placement` namesakes:
+  `none` registers nothing *and* dissolves the server-side stacks containing submitted PRs
+  (`retire_native_stacks` — covers single-PR submissions too, and never fails the submit:
+  `StacksUnavailable` means nothing is standing, anything else is an advisory warning),
+  while `ignore` never touches the stack API.
+  There is deliberately no `off`: next to `none` it would invite "what's the difference?".
+- **Native stacks layer on, not replace** — GitHub's native stack sits on top of chained base branches
+  (`POST /stacks` rejects PR lists that do not chain base→head),
+  so the execute phase (interleaved push → base update → create) runs unchanged and remains the thing
+  that produces what the stack API requires.
+  GitHub takes over *merge-time* sequencing
+  (retarget + cascade rebase);
+  stakk keeps *submit-time* sequencing, since auto-retargeting fires on merge, not on force-push.
+- **Reconcile before placement, no probe** — the native reconcile step precedes the
+  text-placement step so the auto placements resolve on what actually happened on the server
+  rather than on a prediction; the probe endpoint's 404 semantics were never observable on
+  github.com (the preview rolled out everywhere), and the reconcile's first call answers the
+  same question for free.
+- **Single-PR submissions skip the stack registration** — one PR is not a stack, mirroring the stack comment rule;
+  a stale server-side stack containing that PR is left alone.
+  Exception: the `none` retirement runs for single-PR submissions too —
+  that stale stack is exactly what it exists to remove, mirroring how placement `none` cleans up single PRs.
 - **`--dry-run` not in env vars** — one-off decision, surprising as a default.
 - **Selection flags not in env vars/config** — `--keep`, `--new`, `--new-auto`,
   `--new-command` are per-invocation decisions like `--dry-run`;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "directories",
  "futures",
  "http",
+ "http-body-util",
  "indicatif",
  "insta",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ directories = "6"
 toml = "1.0.7"
 jiff = { version = "0.2.35", default-features = false, features = ["std"] }
 textwrap = { version = "0.16.2", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
+http-body-util = "0.1.5"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -110,10 +110,25 @@ Stack of 3 PRs merging into main
 ## Stack info placement
 
 `--stack-placement` decides where the stack overview lives on each PR: a separate PR `comment` (default),
-a fenced section in the PR `body`, `none` (write nothing and remove what is already there), or `ignore`
-(write nothing and touch nothing).
+a fenced section in the PR `body`, `none` (write nothing and remove what is already there), `ignore`
+(write nothing and touch nothing), or `auto-comment`/`auto-body` (defer to native stacks, below).
 Switching between `comment` and `body` migrates automatically,
 and a submission that produces a single PR is not a stack, so no stack info is written.
+
+`--native-stacks` registers submitted stacks with
+[GitHub's native stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests)
+(public preview):
+`on` (fail the submit where the feature is unavailable), `auto`
+(register where available, skip silently where not — GitHub Enterprise Server, for example),
+`none` (register nothing and dissolve the server-side stacks that are standing), or `ignore`
+(default; never touch the stack API)
+— `none` and `ignore` follow the same also-removes/touches-nothing rule as the placement modes.
+GitHub then renders the stack natively and retargets the remaining PRs as the stack merges bottom-up.
+Since that rendering replaces stakk's stack overview,
+`auto-comment`/`auto-body` behave like `none` on runs where a native stack is in effect
+and like `comment`/`body` otherwise,
+so `--native-stacks auto --stack-placement auto-comment` gives native rendering where available
+and stack comments everywhere else, never both.
 
 Full mode table, migration details, and stack comment templating: [docs/template.md](docs/template.md),
 or run `stakk docs template`.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Stack of 3 PRs merging into main
 
 ## Stack info placement
 
-`--stack-placement` decides where the stack overview lives on each PR: a separate PR `comment` (default),
+`--stack-placement` decides where the stack overview lives on each PR: a separate PR `comment`,
 a fenced section in the PR `body`, `none` (write nothing and remove what is already there), `ignore`
 (write nothing and touch nothing), or `auto-comment`/`auto-body` (defer to native stacks, below).
+The default is `auto-comment`, which is identical to `comment` as long as `--native-stacks` is `ignore` (its default).
 Switching between `comment` and `body` migrates automatically,
 and a submission that produces a single PR is not a stack, so no stack info is written.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -82,11 +82,14 @@ It creates no bookmark, pushes nothing, and writes nothing to GitHub — though 
 to find the pull requests that already exist.
 The plan it prints is the one a run without `--dry-run` executes.
 
-Two things it does not cover.
+Three things it does not cover.
 A configured `--bookmark-command` runs under `--dry-run` too, during selection,
 both for `--new-command` marks and for TUI rows cycled to `[*]custom`.
-And `--dry-run` returns before the execute phase,
+`--dry-run` returns before the execute phase,
 so it does not preview the *removal* of stack artifacts that `--stack-placement none` performs.
+For the same reason it does not preview the server-side stack changes of `--native-stacks`:
+the reconciliation under `on`/`auto`, which can dissolve and recreate existing stacks on GitHub,
+and the retirement `none` performs.
 
 ## Diagnostics
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,7 +45,7 @@ Two do more:
   pull request comment or body, which is outward-facing.
 
 The rest cannot act on their own.
-Revsets reach `jj` as arguments rather than through a shell, `pr_mode`, `stack_placement`,
+Revsets reach `jj` as arguments rather than through a shell, `pr_mode`, `stack_placement`, `native_stacks`,
 `sync_pr_content` and `trailers` are closed sets of values, `remote` has to name a remote that already exists,
 and `github_host` does nothing without a remote on that host.
 
@@ -81,13 +81,28 @@ pr_mode = "draft"
 # Reads any path and renders it into a PR — see the trust note above.
 template_path = "/path/to/my-template.md.jinja"
 
-# Where to place stack info: "comment", "body", "none", or "ignore"
-# (default: "comment")
+# Where to place stack info: "comment", "body", "none", "ignore",
+# "auto-comment", or "auto-body" (default: "comment")
 # "none" writes no stack info and removes existing stack comments/body
-# fences on the next submit (e.g. if you rely on GitHub's native
-# stacked PRs). "ignore" writes no stack info and leaves existing
-# artifacts untouched.
+# fences on the next submit. "ignore" writes no stack info and leaves
+# existing artifacts untouched. "auto-comment"/"auto-body" behave like
+# "none" on runs where a native server-side stack is in effect (see
+# native_stacks below) and like "comment"/"body" otherwise.
 stack_placement = "body"
+
+# Register submitted stacks with GitHub's native stacked pull requests
+# (public preview): "on", "auto", "none", or "ignore" (default:
+# "ignore"; the default may change to "auto" once the feature reaches
+# general availability)
+# "on" fails the submit if the feature is not available on the
+# repository; "auto" registers the stack where it is available and
+# skips silently where it is not. Like the placement modes, "none"
+# also removes — it registers nothing and dissolves the server-side
+# stacks that are standing — while "ignore" never touches the stack
+# API. A submission producing a single PR is not a stack and skips the
+# registration (and the "on" failure) entirely; "none" retires its
+# stacks anyway.
+native_stacks = "auto"
 
 # Prefix for auto-generated bookmark names (default: none)
 auto_prefix = "gb-"
@@ -206,7 +221,8 @@ an Enterprise Server reachable only over plain HTTP is not supported.
 | `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (overridden by `--github-host`) |
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_TEMPLATE_PATH` | Path to a custom minijinja template for stack comments (overridden by `--template-path`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, `none`, or `ignore` (overridden by `--stack-placement`) |
+| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, `none`, `ignore`, `auto-comment`, or `auto-body` (overridden by `--stack-placement`) |
+| `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs: `on`, `auto`, `none`, or `ignore` (default) (overridden by `--native-stacks`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
 | `STAKK_TRAILERS` | Whether to keep or strip git commit trailers in PR bodies: `keep` (default) or `strip` (overridden by `--trailers`) |

--- a/docs/config.md
+++ b/docs/config.md
@@ -82,7 +82,8 @@ pr_mode = "draft"
 template_path = "/path/to/my-template.md.jinja"
 
 # Where to place stack info: "comment", "body", "none", "ignore",
-# "auto-comment", or "auto-body" (default: "comment")
+# "auto-comment", or "auto-body" (default: "auto-comment", which is
+# identical to "comment" as long as native_stacks is "ignore")
 # "none" writes no stack info and removes existing stack comments/body
 # fences on the next submit. "ignore" writes no stack info and leaves
 # existing artifacts untouched. "auto-comment"/"auto-body" behave like
@@ -221,7 +222,7 @@ an Enterprise Server reachable only over plain HTTP is not supported.
 | `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (overridden by `--github-host`) |
 | `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
 | `STAKK_TEMPLATE_PATH` | Path to a custom minijinja template for stack comments (overridden by `--template-path`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment` (default), `body`, `none`, `ignore`, `auto-comment`, or `auto-body` (overridden by `--stack-placement`) |
+| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment`, `body`, `none`, `ignore`, `auto-comment` (default), or `auto-body` (overridden by `--stack-placement`) |
 | `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs: `on`, `auto`, `none`, or `ignore` (default) (overridden by `--native-stacks`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
 | `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -66,6 +66,12 @@ These may change in any release.
   They may be added or removed in any release,
   so a program must not depend on one appearing and must not treat stderr output as failure.
   The exit code is the signal.
+- **The server-side behavior behind `--native-stacks`.**
+  The flag and its values are stable surface like any other,
+  but GitHub's stacked pull requests are a public preview the vendor declares subject to change,
+  so the reconciliation's observable effect on GitHub — what a registered stack looks like,
+  when GitHub retargets or rebases — can move without a stakk release at all,
+  and stakk may adjust how it converges the stack (create, append, dissolve-and-recreate) in any release.
 
 ## Not a breaking change
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -13,11 +13,11 @@ where the stack overview lives on each PR:
 
 | Mode | Writes | Removes existing stack comments/body fences |
 |------|--------|---------------------------------------------|
-| `comment` (default) | A separate PR comment, updated in place | Yes, when migrating from `body` |
+| `comment` | A separate PR comment, updated in place | Yes, when migrating from `body` |
 | `body` | A fenced section in the PR body (`STAKK_BODY_START` … `STAKK_BODY_END`) | Yes, when migrating from `comment` |
 | `none` | Nothing | Yes, on every submit |
 | `ignore` | Nothing | No — existing artifacts are left exactly as they are |
-| `auto-comment` | Like `none` when a native stack is in effect, like `comment` otherwise | Follows the mode it resolves to |
+| `auto-comment` (default) | Like `none` when a native stack is in effect, like `comment` otherwise | Follows the mode it resolves to |
 | `auto-body` | Like `none` when a native stack is in effect, like `body` otherwise | Follows the mode it resolves to |
 
 Switching between `comment` and `body` migrates automatically.
@@ -40,7 +40,10 @@ if stack registration failed for a reason that says nothing about availability
 the auto modes still write: a redundant overview self-heals on the next successful run,
 while a skipped update would leave a stale one standing.
 While `--native-stacks` is `ignore` (its default) or `none`,
-`auto-comment` and `auto-body` are exactly `comment` and `body`.
+`auto-comment` and `auto-body` are exactly `comment` and `body` —
+which is why `auto-comment` can be the default placement without changing any behavior:
+the intended zero-config end state once GitHub's feature reaches general availability is a single default flip of
+`native_stacks` to `auto`, giving native rendering where enabled and stack comments everywhere else, never both.
 
 A submission that produces a single PR is not a stack: no stack info is written, and stale artifacts from an earlier,
 larger stack are cleaned up (unless the mode is `ignore`).

--- a/docs/template.md
+++ b/docs/template.md
@@ -17,6 +17,8 @@ where the stack overview lives on each PR:
 | `body` | A fenced section in the PR body (`STAKK_BODY_START` … `STAKK_BODY_END`) | Yes, when migrating from `comment` |
 | `none` | Nothing | Yes, on every submit |
 | `ignore` | Nothing | No — existing artifacts are left exactly as they are |
+| `auto-comment` | Like `none` when a native stack is in effect, like `comment` otherwise | Follows the mode it resolves to |
+| `auto-body` | Like `none` when a native stack is in effect, like `body` otherwise | Follows the mode it resolves to |
 
 Switching between `comment` and `body` migrates automatically.
 Content you write outside the body fences is preserved; the fenced section itself is overwritten on every run.
@@ -27,6 +29,18 @@ Use `ignore` to leave the existing comments and fences frozen in place — handy
 or when another process owns that part of the PR.
 Neither mode reads or compiles a custom `--template-path`,
 so a broken template cannot fail a submission that will not render it.
+
+`auto-comment` and `auto-body` defer to `--native-stacks`
+(see `stakk submit --help`):
+on a run where the server-side stack was registered, GitHub's own stack rendering replaces stakk's text,
+so they behave like `none` and retire it; on every other run they behave like `comment`/`body`.
+The retirement requires a *definitive* native stack —
+if stack registration failed for a reason that says nothing about availability
+(a transient network error, say),
+the auto modes still write: a redundant overview self-heals on the next successful run,
+while a skipped update would leave a stale one standing.
+While `--native-stacks` is `ignore` (its default) or `none`,
+`auto-comment` and `auto-body` are exactly `comment` and `body`.
 
 A submission that produces a single PR is not a stack: no stack info is written, and stale artifacts from an earlier,
 larger stack are cleaned up (unless the mode is `ignore`).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -469,7 +469,10 @@ mod tests {
     #[test]
     fn stack_placement_default_no_config() {
         let cli = parse_with_config(Config::default(), &["stakk", "submit"]);
-        assert_eq!(submit_args(&cli).stack_placement, StackPlacement::Comment);
+        assert_eq!(
+            submit_args(&cli).stack_placement,
+            StackPlacement::AutoComment
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -192,6 +192,9 @@ fn apply_submit_defaults(config: &Config, mut cmd: Command) -> Command {
     if let Some(sp) = config.stack_placement {
         cmd = set_default(cmd, "stack_placement", &sp.to_string());
     }
+    if let Some(ns) = config.native_stacks {
+        cmd = set_default(cmd, "native_stacks", &ns.to_string());
+    }
     if let Some(spc) = config.sync_pr_content {
         cmd = set_default(cmd, "sync_pr_content", &spc.to_string());
     }
@@ -509,6 +512,36 @@ mod tests {
         assert_eq!(submit_args(&cli).stack_placement, StackPlacement::None);
     }
 
+    // -- native_stacks tests --
+
+    use crate::cli::submit::NativeStacks;
+
+    #[test]
+    fn native_stacks_default_ignore() {
+        let cli = parse_with_config(Config::default(), &["stakk", "submit"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::Ignore);
+    }
+
+    #[test]
+    fn native_stacks_config_on() {
+        let config = Config {
+            native_stacks: Some(NativeStacks::On),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::On);
+    }
+
+    #[test]
+    fn native_stacks_cli_overrides_config() {
+        let config = Config {
+            native_stacks: Some(NativeStacks::On),
+            ..Default::default()
+        };
+        let cli = parse_with_config(config, &["stakk", "submit", "--native-stacks", "none"]);
+        assert_eq!(submit_args(&cli).native_stacks, NativeStacks::None);
+    }
+
     // -- sync_pr_content tests --
 
     #[test]
@@ -820,6 +853,7 @@ github_host = "github.example.com"
 pr_mode = "draft"
 template_path = "/path/to/template.jinja"
 stack_placement = "body"
+native_stacks = "on"
 sync_pr_content = "all"
 trailers = "strip"
 auto_prefix = "gb-"
@@ -836,6 +870,7 @@ heads_revset = "heads(all())"
             Some("/path/to/template.jinja"),
         );
         assert_eq!(config.stack_placement, Some(StackPlacement::Body));
+        assert_eq!(config.native_stacks, Some(NativeStacks::On));
         assert_eq!(
             config.sync_pr_content,
             Some(crate::cli::submit::SyncPrContent::All),
@@ -889,8 +924,44 @@ heads_revset = "heads(all())"
     }
 
     #[test]
+    fn toml_stack_placement_auto_comment() {
+        let config: Config = toml::from_str(r#"stack_placement = "auto-comment""#).unwrap();
+        assert_eq!(config.stack_placement, Some(StackPlacement::AutoComment));
+    }
+
+    #[test]
+    fn toml_stack_placement_auto_body() {
+        let config: Config = toml::from_str(r#"stack_placement = "auto-body""#).unwrap();
+        assert_eq!(config.stack_placement, Some(StackPlacement::AutoBody));
+    }
+
+    #[test]
     fn toml_stack_placement_invalid() {
         let result: Result<Config, _> = toml::from_str(r#"stack_placement = "invalid""#);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn toml_native_stacks_on() {
+        let config: Config = toml::from_str(r#"native_stacks = "on""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::On));
+    }
+
+    #[test]
+    fn toml_native_stacks_auto() {
+        let config: Config = toml::from_str(r#"native_stacks = "auto""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::Auto));
+    }
+
+    #[test]
+    fn toml_native_stacks_none() {
+        let config: Config = toml::from_str(r#"native_stacks = "none""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::None));
+    }
+
+    #[test]
+    fn toml_native_stacks_ignore() {
+        let config: Config = toml::from_str(r#"native_stacks = "ignore""#).unwrap();
+        assert_eq!(config.native_stacks, Some(NativeStacks::Ignore));
     }
 }

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -230,6 +230,8 @@ pub struct SubmitArgs {
     /// --native-stacks): when a native server-side stack is in effect
     /// for the run they behave like none, otherwise — including when
     /// native availability could not be determined — like comment/body.
+    /// The default is auto-comment, which is identical to comment as
+    /// long as --native-stacks is ignore (its default).
     ///
     /// Switching between comment and body migrates automatically: moving to
     /// body deletes the old stack comment, moving to comment strips the
@@ -241,7 +243,7 @@ pub struct SubmitArgs {
     #[arg(
         long,
         env = "STAKK_STACK_PLACEMENT",
-        default_value = "comment",
+        default_value = "auto-comment",
         value_enum,
         verbatim_doc_comment
     )]

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -73,6 +73,40 @@ impl std::fmt::Display for TrailerHandling {
     }
 }
 
+/// Whether to register submitted stacks with the forge's native
+/// server-side stack feature (GitHub's stacked pull requests, public
+/// preview).
+///
+/// `none` and `ignore` follow the same rule as their `--stack-placement`
+/// namesakes: `none` also removes what is standing, `ignore` touches
+/// nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum NativeStacks {
+    /// Register/update the server-side stack on every submit; fail the
+    /// submit if the feature is not available on the repository.
+    On,
+    /// Register/update the server-side stack where the feature is
+    /// available, and skip it silently where it is not.
+    Auto,
+    /// Register nothing, and dissolve any server-side stack containing a
+    /// submitted PR — turning the feature off retires what is standing.
+    None,
+    /// Never touch the forge's stack API, leaving any server-side stack
+    /// exactly as it is.
+    #[default]
+    Ignore,
+}
+
+impl std::fmt::Display for NativeStacks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pv = self
+            .to_possible_value()
+            .expect("all variants have possible values");
+        f.write_str(pv.get_name())
+    }
+}
+
 /// Arguments for the submit subcommand.
 #[derive(Debug, Args)]
 pub struct SubmitArgs {
@@ -192,6 +226,11 @@ pub struct SubmitArgs {
     /// comments and body fences on submit. ignore leaves them exactly as
     /// they are — use it when something else owns that part of the PR.
     ///
+    /// auto-comment and auto-body defer to native stacks (see
+    /// --native-stacks): when a native server-side stack is in effect
+    /// for the run they behave like none, otherwise — including when
+    /// native availability could not be determined — like comment/body.
+    ///
     /// Switching between comment and body migrates automatically: moving to
     /// body deletes the old stack comment, moving to comment strips the
     /// fenced section from the PR body.
@@ -207,6 +246,47 @@ pub struct SubmitArgs {
         verbatim_doc_comment
     )]
     pub stack_placement: StackPlacement,
+
+    /// Whether to register submitted stacks with GitHub's native
+    /// stacked-pull-requests feature (public preview).
+    ///
+    /// When on, the server-side stack is created or updated after every
+    /// submit, and the submit fails with guidance if the feature is not
+    /// available on the repository (branches and PRs are still submitted
+    /// normally first). GitHub then renders the stack natively and
+    /// retargets the remaining PRs as the stack merges bottom-up.
+    ///
+    /// When auto, the server-side stack is registered where the feature
+    /// is available and skipped silently where it is not (GitHub
+    /// Enterprise Server, for example). There is no upfront probe: the
+    /// registration itself is the availability check.
+    ///
+    /// none and ignore follow the same rule as their --stack-placement
+    /// namesakes: none registers nothing and also dissolves any
+    /// server-side stack containing a submitted PR, retiring the feature
+    /// cleanly; ignore never touches the stack API and leaves any
+    /// server-side stack exactly as it is.
+    ///
+    /// A submission that produces a single pull request is not a stack
+    /// and skips the registration entirely: nothing is registered, and
+    /// the on-mode availability failure cannot fire there. A stale
+    /// server-side stack containing that PR is left alone — except under
+    /// none, whose retirement covers single-PR submissions too.
+    ///
+    /// The native stack is independent of --stack-placement: stack
+    /// comments or body fences are still written unless placement is
+    /// none, ignore, or an auto mode that resolved to native.
+    ///
+    /// The default may change to auto once GitHub's stacked pull
+    /// requests reach general availability.
+    #[arg(
+        long,
+        env = "STAKK_NATIVE_STACKS",
+        default_value = "ignore",
+        value_enum,
+        verbatim_doc_comment
+    )]
+    pub native_stacks: NativeStacks,
 
     /// Whether existing PR titles and/or bodies are updated from jj commit
     /// descriptions on every submit.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+use crate::cli::submit::NativeStacks;
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
 use crate::cli::submit::TrailerHandling;
@@ -113,6 +114,7 @@ pub struct Config {
     pub pr_mode: Option<PrMode>,
     pub template_path: Option<String>,
     pub stack_placement: Option<StackPlacement>,
+    pub native_stacks: Option<NativeStacks>,
     pub sync_pr_content: Option<SyncPrContent>,
     pub trailers: Option<TrailerHandling>,
     pub auto_prefix: Option<String>,
@@ -130,6 +132,7 @@ impl Default for Config {
             pr_mode: None,
             template_path: None,
             stack_placement: None,
+            native_stacks: None,
             sync_pr_content: None,
             trailers: None,
             auto_prefix: None,
@@ -199,6 +202,7 @@ impl Config {
             pr_mode: self.pr_mode.or(fallback.pr_mode),
             template_path: self.template_path.or(fallback.template_path),
             stack_placement: self.stack_placement.or(fallback.stack_placement),
+            native_stacks: self.native_stacks.or(fallback.native_stacks),
             sync_pr_content: self.sync_pr_content.or(fallback.sync_pr_content),
             trailers: self.trailers.or(fallback.trailers),
             auto_prefix: self.auto_prefix.or(fallback.auto_prefix),

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -17,7 +17,6 @@ use crate::submit::SubmitError;
 #[serde(rename_all = "kebab-case")]
 pub enum StackPlacement {
     /// Place the stack comment as a separate PR comment (issue comment).
-    #[default]
     Comment,
     /// Place the stack content in a fenced section of the PR body.
     Body,
@@ -30,6 +29,9 @@ pub enum StackPlacement {
     /// Behave like `none` when a native server-side stack is in effect
     /// for this run (see --native-stacks), like `comment` otherwise —
     /// including when native availability could not be determined.
+    /// Identical to `comment` as long as --native-stacks is ignore (its
+    /// default) or none, which is what makes it a safe default.
+    #[default]
     AutoComment,
     /// Behave like `none` when a native server-side stack is in effect
     /// for this run (see --native-stacks), like `body` otherwise —

--- a/src/forge/comment.rs
+++ b/src/forge/comment.rs
@@ -27,6 +27,14 @@ pub enum StackPlacement {
     /// Write no stack info and leave existing stack comments and body
     /// fences untouched.
     Ignore,
+    /// Behave like `none` when a native server-side stack is in effect
+    /// for this run (see --native-stacks), like `comment` otherwise —
+    /// including when native availability could not be determined.
+    AutoComment,
+    /// Behave like `none` when a native server-side stack is in effect
+    /// for this run (see --native-stacks), like `body` otherwise —
+    /// including when native availability could not be determined.
+    AutoBody,
 }
 
 impl std::fmt::Display for StackPlacement {
@@ -285,9 +293,10 @@ mod tests {
         let env = default_env();
         let tmpl = env.get_template("stack_comment").unwrap();
         let body = format_stack_comment(&data, &ctx, &tmpl).unwrap();
-        // The current PR carries the pointing marker; the others carry nothing but
-        // their link. Each row is a list item and the URL is bare, which is what
-        // makes GitHub render it as a reference with the PR's live title and state.
+        // The current PR carries the pointing marker; the others carry nothing
+        // but their link. Each row is a list item and the URL is bare,
+        // which is what makes GitHub render it as a reference with the
+        // PR's live title and state.
         assert!(
             body.contains(
                 "- https://github.com/owner/repo/pull/2 (top of stack) \u{1f448} **this PR**"

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,5 +1,7 @@
 //! GitHub implementation of the Forge trait using octocrab.
 
+mod stacks;
+
 use octocrab::Octocrab;
 use octocrab::models::CommentId;
 
@@ -7,6 +9,7 @@ use super::Comment;
 use super::CreatePrParams;
 use super::Forge;
 use super::ForgeError;
+use super::ForgeStack;
 use super::PullRequest;
 
 /// GitHub implementation of the `Forge` trait.
@@ -171,6 +174,37 @@ impl Forge for GitHubForge {
             .await
             .map_err(map_octocrab_error)?;
         Ok(())
+    }
+
+    // The four stack methods go through `stacks`, a hand-rolled transport
+    // for the preview endpoints — see that module for why octocrab's typed
+    // helpers cannot serve them yet.
+
+    async fn get_stacks_for_pr(&self, pr_number: u64) -> Result<Vec<ForgeStack>, ForgeError> {
+        stacks::get_stacks_for_pr(&self.client, &self.owner, &self.repo, pr_number).await
+    }
+
+    async fn create_stack(&self, pr_numbers: &[u64]) -> Result<ForgeStack, ForgeError> {
+        stacks::create_stack(&self.client, &self.owner, &self.repo, pr_numbers).await
+    }
+
+    async fn add_to_stack(
+        &self,
+        stack_number: u64,
+        pr_numbers: &[u64],
+    ) -> Result<ForgeStack, ForgeError> {
+        stacks::add_to_stack(
+            &self.client,
+            &self.owner,
+            &self.repo,
+            stack_number,
+            pr_numbers,
+        )
+        .await
+    }
+
+    async fn unstack(&self, stack_number: u64) -> Result<(), ForgeError> {
+        stacks::unstack(&self.client, &self.owner, &self.repo, stack_number).await
     }
 }
 

--- a/src/forge/github/stacks.rs
+++ b/src/forge/github/stacks.rs
@@ -1,0 +1,486 @@
+//! Hand-rolled transport for GitHub's stacked-pull-requests endpoints.
+//!
+//! **This module exists to be deleted.** Once octocrab ships typed support
+//! for the stacks API (<https://github.com/XAMPPRocky/octocrab/issues/934>),
+//! replace the calls in `super` with the typed equivalents and remove this
+//! file — nothing outside `forge::github` touches it.
+//!
+//! Why the requests are built by hand instead of going through octocrab's
+//! `get`/`post` helpers: the stacks endpoints require
+//! `X-GitHub-Api-Version: 2026-03-10`, and octocrab stamps its own baked-in
+//! `2022-11-28` onto every request its `build_request` produces (from the
+//! `[package.metadata.github-api]` table in octocrab's own Cargo.toml).
+//! `OctocrabBuilder::add_header` *appends* rather than replaces, so both
+//! versions go on the wire as `"2022-11-28,2026-03-10"` and GitHub rejects
+//! the request with a 400. Building the `http::Request` ourselves and
+//! sending it through the public `Octocrab::execute` skips the stamping
+//! while keeping octocrab's service layers, which still provide
+//! authentication, the base URI (github.com or an Enterprise Server), and
+//! the `User-Agent` header GitHub requires.
+//!
+//! Error handling is also deliberately not octocrab's: its
+//! `map_github_error` re-parses error bodies into a struct whose `errors`
+//! field must be an array, and GitHub's version-rejection body carries a
+//! *string* there, degrading the real status code to a serde error. Here
+//! the status code is read first and the body is parsed leniently.
+
+use http::Method;
+use http_body_util::BodyExt;
+use octocrab::Octocrab;
+use serde::Deserialize;
+
+use super::super::ForgeError;
+use super::super::ForgeStack;
+
+/// API version required by the stacked-pull-requests endpoints.
+const STACKS_API_VERSION: &str = "2026-03-10";
+
+/// What a 404 answer means on the route being called.
+///
+/// GitHub signals "stacked pull requests are not offered on this repository"
+/// with a 404, but only on the collection routes (`/stacks`,
+/// `/stacks?pull_request=`) is that the whole story. The numbered routes
+/// (`/stacks/{n}/add`, `/stacks/{n}/unstack`) are only reached after a
+/// collection call on the same repository succeeded, so a 404 there means
+/// the addressed stack no longer exists — merged away or dissolved since the
+/// lookup. That is a state race to converge on, not an availability answer.
+#[derive(Debug, Clone, Copy)]
+enum NotFound {
+    /// The feature is not offered on this repository (definitive).
+    FeatureUnavailable,
+    /// The addressed stack no longer exists; the caller converges by
+    /// rebuilding, like any other state conflict.
+    StackGone,
+    /// The addressed stack no longer exists *and* absence is the goal
+    /// state — the 404 counts as success.
+    StackAlreadyGone,
+}
+
+/// List the open server-side stacks containing the given PR.
+pub async fn get_stacks_for_pr(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Result<Vec<ForgeStack>, ForgeError> {
+    let route = format!("/repos/{owner}/{repo}/stacks?pull_request={pr_number}");
+    let body = request(
+        client,
+        Method::GET,
+        &route,
+        None,
+        NotFound::FeatureUnavailable,
+    )
+    .await?;
+    let stacks: Vec<StackDto> = parse_response(&body)?;
+    Ok(stacks
+        .into_iter()
+        .filter(|s| s.open)
+        .map(convert_stack)
+        .collect())
+}
+
+/// Create a server-side stack from PR numbers ordered bottom-to-top.
+pub async fn create_stack(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    pr_numbers: &[u64],
+) -> Result<ForgeStack, ForgeError> {
+    let route = format!("/repos/{owner}/{repo}/stacks");
+    let payload = serde_json::json!({ "pull_requests": pr_numbers });
+    let body = request(
+        client,
+        Method::POST,
+        &route,
+        Some(&payload),
+        NotFound::FeatureUnavailable,
+    )
+    .await?;
+    let stack: StackDto = parse_response(&body)?;
+    Ok(convert_stack(stack))
+}
+
+/// Append PRs (ordered bottom-to-top) on top of an existing stack.
+///
+/// A stack that no longer exists surfaces as [`ForgeError::StackConflict`],
+/// which the reconciliation converges on by rebuilding — not as
+/// [`ForgeError::StacksUnavailable`], since this route is only reached after
+/// a collection call proved the feature exists here.
+pub async fn add_to_stack(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    stack_number: u64,
+    pr_numbers: &[u64],
+) -> Result<ForgeStack, ForgeError> {
+    let route = format!("/repos/{owner}/{repo}/stacks/{stack_number}/add");
+    let payload = serde_json::json!({ "pull_requests": pr_numbers });
+    let body = request(
+        client,
+        Method::POST,
+        &route,
+        Some(&payload),
+        NotFound::StackGone,
+    )
+    .await?;
+    let stack: StackDto = parse_response(&body)?;
+    Ok(convert_stack(stack))
+}
+
+/// Remove all unmerged PRs from a stack. The server answers 200 (stack
+/// remains, with merged members) or 204 (stack dissolved, empty body);
+/// either way the response body is not needed.
+///
+/// A 404 — the stack no longer exists — counts as success: absence is
+/// exactly the state this call is after, and the route is only reached
+/// after a collection call proved the feature exists here.
+pub async fn unstack(
+    client: &Octocrab,
+    owner: &str,
+    repo: &str,
+    stack_number: u64,
+) -> Result<(), ForgeError> {
+    let route = format!("/repos/{owner}/{repo}/stacks/{stack_number}/unstack");
+    request(
+        client,
+        Method::POST,
+        &route,
+        None,
+        NotFound::StackAlreadyGone,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Build a stacks request by hand and send it through `Octocrab::execute`.
+///
+/// The route stays relative: octocrab's `BaseUriLayer` absolutizes it
+/// against the configured base URI, and its `AuthHeaderLayer` attaches the
+/// token to requests whose URI carries no authority — which is exactly the
+/// relative-route case, the same path octocrab's own typed helpers take.
+///
+/// Returns the raw response body on 2xx, a mapped [`ForgeError`] otherwise.
+async fn request(
+    client: &Octocrab,
+    method: Method,
+    route: &str,
+    payload: Option<&serde_json::Value>,
+    not_found: NotFound,
+) -> Result<Vec<u8>, ForgeError> {
+    let mut builder = http::Request::builder()
+        .method(method)
+        .uri(route)
+        .header("x-github-api-version", STACKS_API_VERSION)
+        .header(http::header::ACCEPT, "application/vnd.github+json");
+
+    let body = if let Some(value) = payload {
+        builder = builder.header(http::header::CONTENT_TYPE, "application/json");
+        serde_json::to_string(value).map_err(|e| ForgeError::Api {
+            message: format!("failed to serialize stack request body: {e}"),
+            source: Box::new(e),
+        })?
+    } else {
+        builder = builder.header(http::header::CONTENT_LENGTH, "0");
+        String::new()
+    };
+
+    let request = builder.body(body).map_err(|e| ForgeError::Api {
+        message: format!("failed to build stack request: {e}"),
+        source: Box::new(e),
+    })?;
+
+    let response = client.execute(request).await.map_err(|e| ForgeError::Api {
+        message: format!("stack request failed: {e}"),
+        source: Box::new(e),
+    })?;
+
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .map_err(|e| ForgeError::Api {
+            message: format!("failed to read stack response body: {e}"),
+            source: Box::new(e),
+        })?
+        .to_bytes()
+        .to_vec();
+
+    status_outcome(status, &body, not_found)?;
+    Ok(body)
+}
+
+/// Decide what a response status means for the route: `Ok` when the call
+/// achieved its goal (2xx, or a 404 whose route-meaning is "already
+/// absent"), the mapped [`ForgeError`] otherwise.
+fn status_outcome(
+    status: http::StatusCode,
+    body: &[u8],
+    not_found: NotFound,
+) -> Result<(), ForgeError> {
+    if status.is_success() {
+        return Ok(());
+    }
+    if status == http::StatusCode::NOT_FOUND && matches!(not_found, NotFound::StackAlreadyGone) {
+        return Ok(());
+    }
+    Err(map_status(status, body, not_found))
+}
+
+/// Map a non-2xx stacks response to a [`ForgeError`], status code first.
+///
+/// A 404 is mapped per route — see [`NotFound`]. GitHub's own `gh stack`
+/// client reads every 404 as "feature not offered here", which is sound on
+/// the collection routes but conflates a deleted stack with unavailability
+/// on the numbered ones. 409/422 signal that a stack mutation conflicts
+/// with current server state (PRs that do not chain, or PRs already held
+/// by another stack).
+fn map_status(status: http::StatusCode, body: &[u8], not_found: NotFound) -> ForgeError {
+    let message = error_message(body, status);
+    let source: Box<dyn std::error::Error + Send + Sync> =
+        format!("GitHub answered {status}: {message}").into();
+    match status {
+        http::StatusCode::NOT_FOUND => match not_found {
+            NotFound::FeatureUnavailable => ForgeError::StacksUnavailable { message, source },
+            // `StackAlreadyGone` is consumed as a success in
+            // `status_outcome`; a stray one degrades to the conflict
+            // reading, which a re-run converges on.
+            NotFound::StackGone | NotFound::StackAlreadyGone => {
+                ForgeError::StackConflict { message, source }
+            }
+        },
+        http::StatusCode::CONFLICT | http::StatusCode::UNPROCESSABLE_ENTITY => {
+            ForgeError::StackConflict { message, source }
+        }
+        http::StatusCode::UNAUTHORIZED | http::StatusCode::FORBIDDEN => {
+            ForgeError::AuthFailed { message, source }
+        }
+        _ => ForgeError::Api { message, source },
+    }
+}
+
+/// Pull the `message` field out of a GitHub error body, leniently.
+///
+/// GitHub error bodies are JSON objects with a `message` string, but the
+/// other fields vary by endpoint (the version-rejection body carries a
+/// *string*-valued `errors`, for example), so nothing here insists on a
+/// shape beyond the one field it reads. Falls back to the raw body text,
+/// then to the status code alone.
+fn error_message(body: &[u8], status: http::StatusCode) -> String {
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body)
+        && let Some(message) = value.get("message").and_then(|m| m.as_str())
+    {
+        return message.to_string();
+    }
+    let text = String::from_utf8_lossy(body);
+    let text = text.trim();
+    if text.is_empty() {
+        format!("HTTP {status}")
+    } else {
+        text.to_string()
+    }
+}
+
+fn parse_response<T: for<'de> Deserialize<'de>>(body: &[u8]) -> Result<T, ForgeError> {
+    serde_json::from_slice(body).map_err(|e| ForgeError::Api {
+        message: format!("failed to parse stack response: {e}"),
+        source: Box::new(e),
+    })
+}
+
+/// Wire format of a stack object from the stacks endpoints
+/// (API version 2026-03-10). Fields the reconciliation does not consume
+/// (`id`, `node_id`, `url`, `base`, `created_at`) are ignored by serde.
+#[derive(Debug, Deserialize)]
+struct StackDto {
+    number: u64,
+    /// `false` once the stack has fully merged away. Closed stacks still
+    /// appear in list responses; they are filtered out before conversion.
+    open: bool,
+    pull_requests: Vec<StackPrDto>,
+}
+
+/// Wire format of a stack member PR.
+#[derive(Debug, Deserialize)]
+struct StackPrDto {
+    number: u64,
+    state: String,
+    merged_at: Option<String>,
+}
+
+fn convert_stack(dto: StackDto) -> ForgeStack {
+    ForgeStack {
+        number: dto.number,
+        open_pr_numbers: dto
+            .pull_requests
+            .into_iter()
+            .filter(|p| p.state == "open" && p.merged_at.is_none())
+            .map(|p| p.number)
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The live wire shape of a stack, captured from
+    /// `GET /repos/glennib/stakk/stacks` (2026-09-01) with irrelevant
+    /// values shortened.
+    const STACK_JSON: &str = r#"{
+        "id": 341775,
+        "number": 204,
+        "node_id": "PRS_kwDORUKw6s4ABTcP",
+        "url": "https://api.github.com/repos/glennib/stakk/stacks/204",
+        "base": {"ref": "main"},
+        "open": true,
+        "created_at": "2026-08-13T13:44:58Z",
+        "pull_requests": [
+            {"number": 201, "state": "open", "draft": false,
+             "merged_at": null,
+             "head": {"ref": "feat-a", "sha": "aaaa"}},
+            {"number": 203, "state": "closed", "draft": false,
+             "merged_at": "2026-08-13T13:45:53Z",
+             "head": {"ref": "feat-b", "sha": "bbbb"}},
+            {"number": 205, "state": "closed", "draft": false,
+             "merged_at": null,
+             "head": {"ref": "feat-c", "sha": "cccc"}}
+        ]
+    }"#;
+
+    #[test]
+    fn stack_parses_and_keeps_only_open_unmerged_prs() {
+        let dto: StackDto = serde_json::from_str(STACK_JSON).unwrap();
+        assert!(dto.open);
+        let stack = convert_stack(dto);
+        // #203 is merged, #205 is closed without merging — only #201 stays.
+        assert_eq!(
+            stack,
+            ForgeStack {
+                number: 204,
+                open_pr_numbers: vec![201],
+            }
+        );
+    }
+
+    #[test]
+    fn closed_stacks_are_filtered_from_list_responses() {
+        // A fully merged stack keeps appearing in list responses with
+        // `"open": false` — observed live; the listing must drop it so the
+        // reconciliation never tries to unstack a stack that is already
+        // history.
+        let closed = STACK_JSON.replace(r#""open": true"#, r#""open": false"#);
+        let listing = format!("[{closed}]");
+        let stacks: Vec<StackDto> = serde_json::from_str(&listing).unwrap();
+        let open: Vec<ForgeStack> = stacks
+            .into_iter()
+            .filter(|s| s.open)
+            .map(convert_stack)
+            .collect();
+        assert!(open.is_empty());
+    }
+
+    #[test]
+    fn missing_open_field_fails_loudly() {
+        // Like `LogEntryRaw`, the DTO is deliberately not serde-defaulted:
+        // an API-shape change should fail as a parse error rather than
+        // silently treating every stack as closed or open.
+        let without_open = STACK_JSON.replace(r#""open": true,"#, "");
+        assert!(serde_json::from_str::<StackDto>(&without_open).is_err());
+    }
+
+    #[test]
+    fn status_mapping_is_read_before_the_body_shape() {
+        // GitHub's version-rejection body carries a *string*-valued
+        // `errors`; octocrab's own error mapping chokes on it. Ours only
+        // reads `message`.
+        let body = br#"{"message": "The version you specified is not a supported version.", "errors": "bad", "documentation_url": "https://docs.github.com"}"#;
+        let err = map_status(
+            http::StatusCode::BAD_REQUEST,
+            body,
+            NotFound::FeatureUnavailable,
+        );
+        match err {
+            ForgeError::Api { message, .. } => {
+                assert!(message.starts_with("The version you specified"));
+            }
+            other => panic!("expected Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_on_collection_routes_maps_to_stacks_unavailable() {
+        let body = br#"{"message": "Not Found"}"#;
+        assert!(matches!(
+            map_status(
+                http::StatusCode::NOT_FOUND,
+                body,
+                NotFound::FeatureUnavailable
+            ),
+            ForgeError::StacksUnavailable { .. }
+        ));
+    }
+
+    /// On the numbered routes a 404 means the addressed stack vanished — a
+    /// state race the reconcile converges on, never an availability answer
+    /// that would misadvise switching `--native-stacks` away from the
+    /// feature.
+    #[test]
+    fn not_found_on_numbered_routes_is_a_conflict_not_unavailability() {
+        let body = br#"{"message": "Not Found"}"#;
+        assert!(matches!(
+            map_status(http::StatusCode::NOT_FOUND, body, NotFound::StackGone),
+            ForgeError::StackConflict { .. }
+        ));
+    }
+
+    /// For `unstack`, a vanished stack *is* the goal state: the 404 counts
+    /// as success, while every other failure on the route still fails.
+    #[test]
+    fn unstack_of_an_already_gone_stack_counts_as_success() {
+        let body = br#"{"message": "Not Found"}"#;
+        assert!(
+            status_outcome(
+                http::StatusCode::NOT_FOUND,
+                body,
+                NotFound::StackAlreadyGone
+            )
+            .is_ok()
+        );
+        assert!(
+            status_outcome(http::StatusCode::CONFLICT, body, NotFound::StackAlreadyGone).is_err()
+        );
+        // The success reading is scoped to the already-gone routes.
+        assert!(status_outcome(http::StatusCode::NOT_FOUND, body, NotFound::StackGone).is_err());
+    }
+
+    #[test]
+    fn conflict_statuses_map_to_stack_conflict() {
+        for status in [
+            http::StatusCode::CONFLICT,
+            http::StatusCode::UNPROCESSABLE_ENTITY,
+        ] {
+            assert!(matches!(
+                map_status(
+                    status,
+                    br#"{"message": "conflict"}"#,
+                    NotFound::FeatureUnavailable
+                ),
+                ForgeError::StackConflict { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn error_message_falls_back_to_body_then_status() {
+        assert_eq!(
+            error_message(b"plain text error", http::StatusCode::BAD_GATEWAY),
+            "plain text error"
+        );
+        assert_eq!(
+            error_message(b"", http::StatusCode::BAD_GATEWAY),
+            "HTTP 502 Bad Gateway"
+        );
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -30,6 +30,42 @@ pub enum ForgeError {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    /// A stacks collection endpoint answered 404: the forge does not offer
+    /// native stacked pull requests here (on GitHub, a host or repository
+    /// without the feature — GitHub Enterprise Server, for example).
+    ///
+    /// Deliberately no `help` on this variant or on
+    /// [`ForgeError::StackConflict`]: every stack call is wrapped by
+    /// `submit::wrap_stack_err` into a `SubmitError`, and miette renders
+    /// only the outermost diagnostic's help — `#[source]` chains the error
+    /// *messages*, not the diagnostics. The user-facing guidance lives on
+    /// `SubmitError::StacksUnavailable` / `StackReconcileFailed`, the one
+    /// copy that actually renders; a second copy here would be dead prose
+    /// that can only drift from it.
+    #[error("native stacked pull requests are not available on this repository: {message}")]
+    #[diagnostic(code(stakk::forge::stacks_unavailable))]
+    StacksUnavailable {
+        message: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// A stack mutation conflicted with current server state (409/422 —
+    /// e.g. PRs that do not chain, or PRs already held by another stack —
+    /// or a 404 on a numbered stack route: the addressed stack no longer
+    /// exists). The reconciliation converges on it by rebuilding; when it
+    /// surfaces to the user it does so wrapped in
+    /// `SubmitError::StackReconcileFailed`, whose help carries the
+    /// re-run advice (see [`ForgeError::StacksUnavailable`] on why no
+    /// `help` sits here).
+    #[error("stack operation conflicted with current server state: {message}")]
+    #[diagnostic(code(stakk::forge::stack_conflict))]
+    StackConflict {
+        message: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 /// A pull request, forge-agnostic.
@@ -41,6 +77,19 @@ pub struct PullRequest {
     pub base_ref: String,
     /// The PR body/description text.
     pub body: Option<String>,
+}
+
+/// A server-side stack of pull requests, forge-agnostic.
+///
+/// Only *open* stacks reach this type — implementations skip stacks the
+/// forge reports as closed (fully merged away).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgeStack {
+    /// Stack number, used to address the stack in later calls.
+    pub number: u64,
+    /// Numbers of the stack's *open* PRs, bottom-to-top. Merged and closed
+    /// members are filtered out by the implementation.
+    pub open_pr_numbers: Vec<u64>,
 }
 
 /// A comment on a pull request.
@@ -122,5 +171,39 @@ pub trait Forge: Send + Sync {
     fn delete_comment(
         &self,
         comment_id: u64,
+    ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
+
+    /// List the *open* server-side stacks containing the given PR (empty if
+    /// none). A 404 from the forge maps to [`ForgeError::StacksUnavailable`]:
+    /// the feature is not offered on this repository.
+    fn get_stacks_for_pr(
+        &self,
+        pr_number: u64,
+    ) -> impl std::future::Future<Output = Result<Vec<ForgeStack>, ForgeError>> + Send;
+
+    /// Create a server-side stack from PR numbers ordered bottom-to-top.
+    /// A 404 maps to [`ForgeError::StacksUnavailable`], like
+    /// [`Forge::get_stacks_for_pr`].
+    fn create_stack(
+        &self,
+        pr_numbers: &[u64],
+    ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send;
+
+    /// Append PRs (ordered bottom-to-top) on top of an existing stack.
+    /// A stack that no longer exists surfaces as
+    /// [`ForgeError::StackConflict`] — a state race for the caller to
+    /// converge on, never [`ForgeError::StacksUnavailable`].
+    fn add_to_stack(
+        &self,
+        stack_number: u64,
+        pr_numbers: &[u64],
+    ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send;
+
+    /// Remove all unmerged PRs from a stack, dissolving it if it empties.
+    /// Unstacking a stack that no longer exists succeeds — absence is the
+    /// goal state.
+    fn unstack(
+        &self,
+        stack_number: u64,
     ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send;
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -47,8 +47,8 @@ pub async fn build_change_graph<R: JjRunner>(
 ) -> Result<ChangeGraph, StakkError> {
     let bookmarks = jj.get_my_bookmarks(bookmarks_revset).await?;
 
-    // Collect user bookmark names so traversal can filter out non-user bookmarks
-    // that appear on commits (e.g. bookmarks from other users).
+    // Collect user bookmark names so traversal can filter out non-user
+    // bookmarks that appear on commits (e.g. bookmarks from other users).
     let user_bookmark_names: HashSet<String> = bookmarks.iter().map(|b| b.name.clone()).collect();
 
     let mut fully_collected: HashSet<String> = HashSet::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ async fn run() -> Result<(), StakkError> {
         config::warn_removed_env_vars();
     }
 
-    // Warn about an outdated jj for commands that shell out to it. Commands that
-    // never touch jj (completions, docs) skip the check.
+    // Warn about an outdated jj for commands that shell out to it. Commands
+    // that never touch jj (completions, docs) skip the check.
     let runs_jj = match &cli.command {
         Some(Commands::Completions { .. } | Commands::Docs { .. }) => false,
         _ => true, // Submit, Graph, and None (= submit) all use jj.
@@ -243,24 +243,38 @@ async fn submit_bookmark(args: &SubmitArgs, github_host: Option<&str>) -> Result
 
     // Load template. In `none`/`ignore` placement no stack content is ever
     // rendered, so a custom template is neither read nor compiled — a broken
-    // or missing one must not fail a submission that will not use it.
-    let template_source = match (&args.template_path, args.stack_placement) {
-        (Some(path), StackPlacement::Comment | StackPlacement::Body) => Some(
-            std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
-                path: path.clone(),
-                reason: e.to_string(),
-            })?,
-        ),
-        _ => None,
+    // or missing one must not fail a submission that will not use it. Every
+    // other placement may render (the autos resolve only at execute time),
+    // so the non-rendering placements are the ones enumerated: a placement
+    // added later loads the template by default instead of silently
+    // ignoring --template-path.
+    let template_source = match args.stack_placement {
+        StackPlacement::None | StackPlacement::Ignore => None,
+        _ => args
+            .template_path
+            .as_ref()
+            .map(|path| {
+                std::fs::read_to_string(path).map_err(|e| StakkError::TemplateLoadFailed {
+                    path: path.clone(),
+                    reason: e.to_string(),
+                })
+            })
+            .transpose()?,
     };
     let comment_env = forge::comment::build_comment_env(template_source.as_deref())?;
 
     // Phase 3: Execute. The header separates the plan from the result lines
     // printed during execution.
     println!("\nExecuting:");
-    let result =
-        submit::execute_submission_plan(&plan, &jj, &forge, &comment_env, args.stack_placement)
-            .await?;
+    let result = submit::execute_submission_plan(
+        &plan,
+        &jj,
+        &forge,
+        &comment_env,
+        args.stack_placement,
+        args.native_stacks,
+    )
+    .await?;
 
     println!("\nSubmitted {} bookmark(s).", result.stack_entries.len());
 

--- a/src/select/app.rs
+++ b/src/select/app.rs
@@ -458,7 +458,8 @@ fn run_event_loop(
                             };
                             match result {
                                 VaryResult::NeedsRefire => {
-                                    // Bust the cache so the command actually re-runs
+                                    // Bust the cache so the command actually
+                                    // re-runs
                                     // instead of returning the previous result.
                                     let segment = bookmark_gen::dynamic_segment_commits(
                                         &state.rows,

--- a/src/select/bookmark_widget.rs
+++ b/src/select/bookmark_widget.rs
@@ -1137,8 +1137,8 @@ mod tests {
         // Trunk is not toggleable.
         assert!(state.rows[0].is_trunk);
 
-        // Base has existing bookmark → UseExisting(0); generated_name is always set
-        // now.
+        // Base has existing bookmark → UseExisting(0); generated_name is always
+        // set now.
         assert_eq!(state.rows[1].state, RowState::UseExisting(0));
         assert_eq!(state.rows[1].existing_bookmarks, vec!["base".to_string()]);
         assert_eq!(state.rows[1].generated_name, Some("stakk-ch_a".to_string()));

--- a/src/select/tfidf.rs
+++ b/src/select/tfidf.rs
@@ -569,8 +569,8 @@ mod tests {
         let v1 = tfidf_bookmark_name(&commits, 3, 1, 255, " ~^:?*[\\");
         assert!(v0.is_some());
         assert!(v1.is_some());
-        // With enough terms, different variations should produce different names
-        // (unless the pool is too small).
+        // With enough terms, different variations should produce different
+        // names (unless the pool is too small).
         if v0 != v1 {
             assert_ne!(v0, v1);
         }
@@ -613,9 +613,10 @@ mod tests {
     #[test]
     fn tfidf_orders_terms_by_occurrence() {
         // Force the word set so only the ordering varies: `implement` is a stop
-        // word, leaving exactly {foo, baz, bar} across the two commits. The pool
-        // then yields a single combo, so the rendered name is determined purely
-        // by first-occurrence order (trunk-to-tip), not alphabetically.
+        // word, leaving exactly {foo, baz, bar} across the two commits. The
+        // pool then yields a single combo, so the rendered name is
+        // determined purely by first-occurrence order (trunk-to-tip),
+        // not alphabetically.
         let commits = vec![
             CommitData {
                 description: "implement foo",

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -12,12 +12,14 @@ use std::fmt;
 use miette::Diagnostic;
 use thiserror::Error;
 
+use crate::cli::submit::NativeStacks;
 use crate::cli::submit::PrMode;
 use crate::cli::submit::SyncPrContent;
 use crate::cli::submit::TrailerHandling;
 use crate::forge::CreatePrParams;
 use crate::forge::Forge;
 use crate::forge::ForgeError;
+use crate::forge::ForgeStack;
 use crate::forge::PullRequest;
 use crate::forge::comment::STAKK_REPO_URL;
 use crate::forge::comment::StackCommentContext;
@@ -218,6 +220,47 @@ pub enum SubmitError {
         #[source]
         source: ForgeError,
     },
+
+    /// Native stacks were requested but the forge does not offer them here.
+    #[error("native stacked pull requests are not available on this repository")]
+    #[diagnostic(
+        code(stakk::submit::stacks_unavailable),
+        help(
+            "your branches were pushed and PRs were created/updated normally — only the \
+             server-side stack linkage was skipped. GitHub's stacked pull requests are not \
+             available everywhere (GitHub Enterprise Server does not have them); set \
+             `--native-stacks auto` to use the feature only where available, or `ignore` (env: \
+             STAKK_NATIVE_STACKS)"
+        )
+    )]
+    StacksUnavailable {
+        #[source]
+        source: ForgeError,
+    },
+
+    /// Failed to reconcile the server-side stack after PRs were submitted.
+    #[error("failed to reconcile the server-side stack")]
+    #[diagnostic(
+        code(stakk::submit::stack_reconcile_failed),
+        help(
+            "your branches were pushed and PRs were created/updated normally — only the \
+             server-side stack linkage failed. Re-running `stakk submit` retries the \
+             reconciliation from scratch"
+        )
+    )]
+    StackReconcileFailed {
+        #[source]
+        source: ForgeError,
+    },
+}
+
+/// Wrap a stack-API error, routing the not-available case to its dedicated
+/// variant so miette renders the switch-mode guidance.
+fn wrap_stack_err(source: ForgeError) -> SubmitError {
+    match source {
+        ForgeError::StacksUnavailable { .. } => SubmitError::StacksUnavailable { source },
+        _ => SubmitError::StackReconcileFailed { source },
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -650,11 +693,10 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
     forge: &F,
     comment_env: &minijinja::Environment<'_>,
     placement: StackPlacement,
+    native: NativeStacks,
 ) -> Result<SubmissionResult, SubmitError> {
     let pb = indicatif::ProgressBar::new_spinner();
     pb.enable_steady_tick(std::time::Duration::from_millis(120));
-
-    let effective = resolve_placement(placement);
 
     // Check every pending name against the repo before creating any of them.
     // Selection already rejects taken names, but the repo can change in
@@ -745,24 +787,10 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
                 })?;
         }
 
-        // Body sync: skip when body-mode stacking is active — the
-        // body-mode stack phase will splice the fence onto bp.body,
-        // combining both updates into a single API call.
-        if bp.needs_body_sync
-            && effective != EffectivePlacement::Body
-            && let Some(pr) = &bp.existing_pr
-        {
-            let new_body = bp.body.as_deref().unwrap_or("");
-            pb.set_message(format!("Syncing PR #{} body...", pr.number));
-            forge
-                .update_pr_body(pr.number, new_body)
-                .await
-                .map_err(|source| SubmitError::BodySyncFailed {
-                    pr_number: pr.number,
-                    bookmark: bp.bookmark_name.clone(),
-                    source,
-                })?;
-        }
+        // Body syncs happen in one pass after the placement resolves, not
+        // here: the interleaving rule (#35) covers pushes and base updates
+        // only, and a body-resolved placement folds the sync into its own
+        // body write below.
 
         let pr = if let Some(existing) = &bp.existing_pr {
             pb.println(format!(
@@ -794,6 +822,106 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
             pr_url: pr.html_url.clone(),
             pr_number: pr.number,
         });
+    }
+
+    // Step 2b: When native stacks are requested, converge the forge's
+    // server-side stack with the submitted PRs — *before* the text
+    // placement, so the auto placements resolve on what actually happened
+    // rather than on a prediction (there is no availability probe; the
+    // reconcile's own outcome is the answer). A single PR is not a stack,
+    // so single-bookmark submissions skip the registration entirely (a
+    // stale server-side stack containing that PR is left alone — except
+    // under `none`, whose retirement covers single-PR submissions too).
+    let (native_state, native_err) = match native {
+        // `ignore` never touches the stack API.
+        NativeStacks::Ignore => (NativeState::Inactive, None),
+        // `none` mirrors `--stack-placement none`: turning the feature off
+        // retires the server-side stacks that are standing rather than
+        // leaving them stale.
+        NativeStacks::None => {
+            pb.set_message("Retiring server-side stacks...");
+            let submitted: Vec<u64> = stack_entries.iter().map(|e| e.pr_number).collect();
+            retire_native_stacks(forge, &submitted, &pb).await;
+            (NativeState::Inactive, None)
+        }
+        NativeStacks::On | NativeStacks::Auto if stack_entries.len() < 2 => {
+            (NativeState::Inactive, None)
+        }
+        NativeStacks::On | NativeStacks::Auto => {
+            pb.set_message("Reconciling server-side stack...");
+            let desired: Vec<u64> = stack_entries.iter().map(|e| e.pr_number).collect();
+            let outcome = reconcile_native_stack(forge, &desired, &pb).await;
+            match (native, outcome) {
+                (_, Ok(())) => (NativeState::Active, None),
+                // Definitive: the feature is not offered on this repository.
+                // `auto` promises to skip silently where that is the case.
+                (NativeStacks::Auto, Err(SubmitError::StacksUnavailable { .. })) => {
+                    (NativeState::Inactive, None)
+                }
+                // Not an answer (network trouble, rate limit): warn and let
+                // the auto placements fall back to writing — a redundant
+                // comment self-heals on the next successful run, while a
+                // skipped update would leave *stale* stack info standing.
+                (NativeStacks::Auto, Err(SubmitError::StackReconcileFailed { source })) => {
+                    pb.println(format!(
+                        "  Warning: could not reconcile the server-side stack: {source}. Stack \
+                         comments and body fences are still updated this run; re-running `stakk \
+                         submit` retries the reconciliation."
+                    ));
+                    (NativeState::Unknown, None)
+                }
+                // With `on`, any reconcile failure fails the submit — but
+                // only after the body syncs and text placement below have
+                // run, so that everything the error's help text promises
+                // ("PRs were created/updated normally") has actually
+                // happened. The placements resolve as on an unknown native
+                // state: writing, never the destructive cleanup direction
+                // (whether the state is definitively unavailable or merely
+                // unknown makes no difference to a run that is going to
+                // fail anyway).
+                (_, Err(e)) => (NativeState::Unknown, Some(e)),
+            }
+        }
+    };
+
+    let effective = resolve_placement(placement, native_state);
+
+    // Body syncs, in one pass for every placement. Skipped only when the
+    // body-splice phase below covers them — a body-resolved placement on a
+    // real stack folds each sync into its own body write, one API call
+    // instead of two. This runs before step 3 so `effective_body` stays
+    // truthful for every later reader.
+    let body_splice_runs = effective == EffectivePlacement::Body && stack_entries.len() > 1;
+    if !body_splice_runs {
+        let sync_futures: Vec<_> = plan
+            .bookmark_plans
+            .iter()
+            .filter_map(|bp| {
+                if !bp.needs_body_sync {
+                    return None;
+                }
+                let pr = bp.existing_pr.as_ref()?;
+                let pr_number = pr.number;
+                let bookmark = bp.bookmark_name.clone();
+                let new_body = bp.body.clone().unwrap_or_default();
+                Some(async move {
+                    forge
+                        .update_pr_body(pr_number, &new_body)
+                        .await
+                        .map_err(|source| SubmitError::BodySyncFailed {
+                            pr_number,
+                            bookmark,
+                            source,
+                        })
+                })
+            })
+            .collect();
+        if !sync_futures.is_empty() {
+            pb.set_message("Syncing PR bodies...");
+            for result in futures::future::join_all(sync_futures).await {
+                result?;
+            }
+        }
     }
 
     // Step 3: Concurrently create/update stack comments on all PRs.
@@ -964,7 +1092,8 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
                                     |source| SubmitError::BodyUpdateFailed { pr_number, source },
                                 )?;
 
-                                // Migration: if no existing fenced section was found,
+                                // Migration: if no existing fenced section was
+                                // found,
                                 // check for an old stack comment and delete it.
                                 if !had_fence {
                                     let comments =
@@ -1001,7 +1130,30 @@ pub async fn execute_submission_plan<R: JjRunner, F: Forge>(
 
     pb.finish_and_clear();
 
+    // A reconcile failure under `--native-stacks on` fails the submit —
+    // reported last, after body syncs and the text placement ran.
+    if let Some(e) = native_err {
+        return Err(e);
+    }
+
     Ok(SubmissionResult { stack_entries })
+}
+
+/// Whether a native server-side stack is in effect for one run.
+///
+/// Derived from the outcome of the reconcile step, not from a probe — what
+/// actually happened on the server, not a prediction about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeState {
+    /// The server-side stack was reconciled and now matches the submission.
+    Active,
+    /// Native stacks are not requested (`ignore`/`none`), definitively
+    /// unavailable here, or the submission is a single PR (not a stack).
+    Inactive,
+    /// The reconcile failed for a reason that says nothing about
+    /// availability. Only the destructive placement direction (cleanup)
+    /// requires a definitive answer, so auto placements write as usual.
+    Unknown,
 }
 
 /// The artifact behavior a `StackPlacement` resolves to for one run.
@@ -1017,13 +1169,215 @@ enum EffectivePlacement {
     Ignore,
 }
 
-fn resolve_placement(placement: StackPlacement) -> EffectivePlacement {
+/// Resolve the requested placement against the native-stack state.
+///
+/// The auto placements retire stakk's text (cleanup) only on a *definitive*
+/// native stack — `Unknown` falls back to writing, because a redundant
+/// comment is harmless and self-heals while a skipped update leaves stale
+/// stack info standing.
+fn resolve_placement(placement: StackPlacement, native: NativeState) -> EffectivePlacement {
     match placement {
         StackPlacement::Comment => EffectivePlacement::Comment,
         StackPlacement::Body => EffectivePlacement::Body,
         StackPlacement::None => EffectivePlacement::Cleanup,
         StackPlacement::Ignore => EffectivePlacement::Ignore,
+        StackPlacement::AutoComment => match native {
+            NativeState::Active => EffectivePlacement::Cleanup,
+            NativeState::Inactive | NativeState::Unknown => EffectivePlacement::Comment,
+        },
+        StackPlacement::AutoBody => match native {
+            NativeState::Active => EffectivePlacement::Cleanup,
+            NativeState::Inactive | NativeState::Unknown => EffectivePlacement::Body,
+        },
     }
+}
+
+/// Converge the forge's server-side stack with the submitted PRs.
+///
+/// `desired` holds the PR numbers bottom-to-top; the caller guarantees at
+/// least two entries. Idempotent: every failure point leaves the server in
+/// a state from which a re-run converges.
+async fn reconcile_native_stack<F: Forge>(
+    forge: &F,
+    desired: &[u64],
+    pb: &indicatif::ProgressBar,
+) -> Result<(), SubmitError> {
+    // Query every desired PR, not just the bottom one — an upper PR held by
+    // a foreign stack would otherwise make create/add fail opaquely.
+    let lookups = futures::future::join_all(desired.iter().map(|&n| forge.get_stacks_for_pr(n)));
+    let mut stacks: Vec<ForgeStack> = Vec::new();
+    for result in lookups.await {
+        for stack in result.map_err(wrap_stack_err)? {
+            if !stacks.iter().any(|s| s.number == stack.number) {
+                stacks.push(stack);
+            }
+        }
+    }
+
+    match stacks.as_slice() {
+        [] => {
+            let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+            pb.println(format!(
+                "  Created server-side stack #{} ({} PRs).",
+                created.number,
+                desired.len()
+            ));
+        }
+        [stack] if stack.open_pr_numbers == desired => {
+            pb.println(format!(
+                "  Server-side stack #{} is up to date.",
+                stack.number
+            ));
+        }
+        // The server stack extends *above* the submission: the submitted PRs
+        // are already its bottom prefix, correctly ordered, and the execute
+        // phase never touched the bases of the PRs above them — the chain is
+        // intact. Rebuilding here would evict the upper PRs from merge-time
+        // retargeting (the empty-diff auto-close hazard the stack exists to
+        // prevent), so the stack is left standing. Only a *bottom* prefix is
+        // safe to no-op: a slice higher up means the bottom submitted PR was
+        // retargeted past open stack members and the chain is broken.
+        [stack] if stack.open_pr_numbers.starts_with(desired) => {
+            pb.println(format!(
+                "  Server-side stack #{} already contains the submission; {} PR(s) above it keep \
+                 their stack membership.",
+                stack.number,
+                stack.open_pr_numbers.len() - desired.len()
+            ));
+        }
+        [stack]
+            if !stack.open_pr_numbers.is_empty() && desired.starts_with(&stack.open_pr_numbers) =>
+        {
+            let suffix = &desired[stack.open_pr_numbers.len()..];
+            match forge.add_to_stack(stack.number, suffix).await {
+                Ok(_) => {
+                    pb.println(format!(
+                        "  Added {} PR(s) to server-side stack #{}.",
+                        suffix.len(),
+                        stack.number
+                    ));
+                }
+                // If the server rejects the append (the add semantics leave
+                // room for that — e.g. a PR already held elsewhere),
+                // converge via the universal dissolve-and-recreate path.
+                Err(ForgeError::StackConflict { .. }) => {
+                    forge.unstack(stack.number).await.map_err(wrap_stack_err)?;
+                    let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+                    pb.println(format!(
+                        "  Recreated server-side stack #{} ({} PRs).",
+                        created.number,
+                        desired.len()
+                    ));
+                }
+                Err(e) => return Err(wrap_stack_err(e)),
+            }
+        }
+        _ => {
+            // Reorder, foreign members, multiple stacks, or a stack whose
+            // open PRs all merged away: dissolve everything and rebuild.
+            // `unstack` removes unmerged PRs wholesale (the API has no
+            // per-PR removal); merged leftovers cannot conflict with the
+            // new stack. Open PRs that are dissolved along and not part of
+            // the new stack lose native stacking silently on GitHub's side,
+            // so they are named in a warning.
+            let evicted = evicted_pr_numbers(&stacks, desired);
+            for stack in &stacks {
+                forge.unstack(stack.number).await.map_err(wrap_stack_err)?;
+            }
+            let created = forge.create_stack(desired).await.map_err(wrap_stack_err)?;
+            pb.println(format!(
+                "  Recreated server-side stack #{} ({} PRs).",
+                created.number,
+                desired.len()
+            ));
+            warn_evicted(&evicted, pb);
+        }
+    }
+
+    Ok(())
+}
+
+/// Dissolve every server-side stack containing a submitted PR.
+///
+/// `--native-stacks none` mirrors `--stack-placement none`: turning the
+/// feature off retires what is standing rather than leaving it stale.
+/// Unlike the reconcile this covers single-PR submissions too, and it never
+/// fails the submit: `StacksUnavailable` means there is nothing to retire,
+/// and any other failure is an advisory warning — a re-run retries.
+async fn retire_native_stacks<F: Forge>(forge: &F, submitted: &[u64], pb: &indicatif::ProgressBar) {
+    let lookups = futures::future::join_all(submitted.iter().map(|&n| forge.get_stacks_for_pr(n)));
+    let mut stacks: Vec<ForgeStack> = Vec::new();
+    for result in lookups.await {
+        match result {
+            Ok(found) => {
+                for stack in found {
+                    if !stacks.iter().any(|s| s.number == stack.number) {
+                        stacks.push(stack);
+                    }
+                }
+            }
+            // The feature is not offered here, so nothing can be standing.
+            Err(ForgeError::StacksUnavailable { .. }) => return,
+            Err(e) => {
+                pb.println(format!(
+                    "  Warning: could not check for server-side stacks to retire: {e}. Re-running \
+                     `stakk submit` retries."
+                ));
+                return;
+            }
+        }
+    }
+    if stacks.is_empty() {
+        return;
+    }
+    // Dissolving a stack unstacks *all* its unmerged members, so open PRs
+    // beyond the submitted ones lose native stacking too — name them, like
+    // the reconcile's rebuild path does.
+    let evicted = evicted_pr_numbers(&stacks, submitted);
+    for stack in &stacks {
+        match forge.unstack(stack.number).await {
+            Ok(()) => {
+                pb.println(format!("  Retired server-side stack #{}.", stack.number));
+            }
+            Err(e) => {
+                pb.println(format!(
+                    "  Warning: failed to retire server-side stack #{}: {e}. Re-running `stakk \
+                     submit` retries.",
+                    stack.number
+                ));
+            }
+        }
+    }
+    warn_evicted(&evicted, pb);
+}
+
+/// Open PR numbers that lose their server-side stack membership when
+/// `stacks` are dissolved and only `desired` is restacked (or nothing is,
+/// for the retirement path).
+fn evicted_pr_numbers(stacks: &[ForgeStack], desired: &[u64]) -> Vec<u64> {
+    let mut evicted: Vec<u64> = stacks
+        .iter()
+        .flat_map(|s| s.open_pr_numbers.iter().copied())
+        .filter(|n| !desired.contains(n))
+        .collect();
+    evicted.sort_unstable();
+    evicted.dedup();
+    evicted
+}
+
+/// Warn with the PR numbers that lost native stacking in a dissolve.
+fn warn_evicted(evicted: &[u64], pb: &indicatif::ProgressBar) {
+    if evicted.is_empty() {
+        return;
+    }
+    let list = evicted
+        .iter()
+        .map(|n| format!("#{n}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    pb.println(format!(
+        "  Warning: {list} left the dissolved stack(s) and are no longer natively stacked."
+    ));
 }
 
 /// Remove any stack artifacts (stack comment and body fence) from a single PR.
@@ -1167,6 +1521,21 @@ mod tests {
         listed_comments: Mutex<Vec<u64>>,
         next_pr_number: Mutex<u64>,
         ops: Option<OpLog>,
+        existing_stacks: Vec<ForgeStack>,
+        /// When set, every stack call fails with `StacksUnavailable` — the
+        /// repository does not offer the feature.
+        stacks_unavailable: bool,
+        /// When set, every stack call fails with a generic `Api` error —
+        /// the "not an answer" failure mode.
+        stacks_api_error: bool,
+        /// When set, `add_to_stack` fails with `StackConflict`.
+        add_conflicts: bool,
+        /// PR numbers `get_stacks_for_pr` was called for.
+        stack_lookups: Mutex<Vec<u64>>,
+        created_stacks: Mutex<Vec<Vec<u64>>>,
+        added_to_stacks: Mutex<Vec<(u64, Vec<u64>)>>,
+        unstacked: Mutex<Vec<u64>>,
+        next_stack_number: Mutex<u64>,
     }
 
     impl MockForge {
@@ -1184,6 +1553,15 @@ mod tests {
                 listed_comments: Mutex::new(Vec::new()),
                 next_pr_number: Mutex::new(100),
                 ops: None,
+                existing_stacks: Vec::new(),
+                stacks_unavailable: false,
+                stacks_api_error: false,
+                add_conflicts: false,
+                stack_lookups: Mutex::new(Vec::new()),
+                created_stacks: Mutex::new(Vec::new()),
+                added_to_stacks: Mutex::new(Vec::new()),
+                unstacked: Mutex::new(Vec::new()),
+                next_stack_number: Mutex::new(500),
             }
         }
 
@@ -1200,6 +1578,46 @@ mod tests {
         fn with_existing_comments(mut self, pr_number: u64, comments: Vec<Comment>) -> Self {
             self.existing_comments.insert(pr_number, comments);
             self
+        }
+
+        fn with_existing_stack(mut self, number: u64, open_prs: &[u64]) -> Self {
+            self.existing_stacks.push(ForgeStack {
+                number,
+                open_pr_numbers: open_prs.to_vec(),
+            });
+            self
+        }
+
+        fn with_stacks_unavailable(mut self) -> Self {
+            self.stacks_unavailable = true;
+            self
+        }
+
+        fn with_stacks_api_error(mut self) -> Self {
+            self.stacks_api_error = true;
+            self
+        }
+
+        fn with_add_conflict(mut self) -> Self {
+            self.add_conflicts = true;
+            self
+        }
+
+        /// The configured failure for stack calls, if any.
+        fn stack_failure(&self) -> Option<ForgeError> {
+            if self.stacks_unavailable {
+                return Some(ForgeError::StacksUnavailable {
+                    message: "Not Found".to_string(),
+                    source: "404".into(),
+                });
+            }
+            if self.stacks_api_error {
+                return Some(ForgeError::Api {
+                    message: "boom".to_string(),
+                    source: "boom".into(),
+                });
+            }
+            None
         }
     }
 
@@ -1320,6 +1738,91 @@ mod tests {
         ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send {
             self.deleted_comments.lock().unwrap().push(comment_id);
             async { Ok(()) }
+        }
+
+        fn get_stacks_for_pr(
+            &self,
+            pr_number: u64,
+        ) -> impl std::future::Future<Output = Result<Vec<ForgeStack>, ForgeError>> + Send {
+            self.stack_lookups.lock().unwrap().push(pr_number);
+            let result = if let Some(e) = self.stack_failure() {
+                Err(e)
+            } else {
+                Ok(self
+                    .existing_stacks
+                    .iter()
+                    .filter(|s| s.open_pr_numbers.contains(&pr_number))
+                    .cloned()
+                    .collect())
+            };
+            async move { result }
+        }
+
+        fn create_stack(
+            &self,
+            pr_numbers: &[u64],
+        ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send {
+            let result = if let Some(e) = self.stack_failure() {
+                Err(e)
+            } else {
+                let mut counter = self.next_stack_number.lock().unwrap();
+                let number = *counter;
+                *counter += 1;
+                self.created_stacks
+                    .lock()
+                    .unwrap()
+                    .push(pr_numbers.to_vec());
+                Ok(ForgeStack {
+                    number,
+                    open_pr_numbers: pr_numbers.to_vec(),
+                })
+            };
+            async move { result }
+        }
+
+        fn add_to_stack(
+            &self,
+            stack_number: u64,
+            pr_numbers: &[u64],
+        ) -> impl std::future::Future<Output = Result<ForgeStack, ForgeError>> + Send {
+            let result = match self.stack_failure() {
+                Some(e) => Err(e),
+                None if self.add_conflicts => Err(ForgeError::StackConflict {
+                    message: "already stacked".to_string(),
+                    source: "409".into(),
+                }),
+                None => {
+                    self.added_to_stacks
+                        .lock()
+                        .unwrap()
+                        .push((stack_number, pr_numbers.to_vec()));
+                    let mut open_pr_numbers = self
+                        .existing_stacks
+                        .iter()
+                        .find(|s| s.number == stack_number)
+                        .map(|s| s.open_pr_numbers.clone())
+                        .unwrap_or_default();
+                    open_pr_numbers.extend_from_slice(pr_numbers);
+                    Ok(ForgeStack {
+                        number: stack_number,
+                        open_pr_numbers,
+                    })
+                }
+            };
+            async move { result }
+        }
+
+        fn unstack(
+            &self,
+            stack_number: u64,
+        ) -> impl std::future::Future<Output = Result<(), ForgeError>> + Send {
+            let result = if let Some(e) = self.stack_failure() {
+                Err(e)
+            } else {
+                self.unstacked.lock().unwrap().push(stack_number);
+                Ok(())
+            };
+            async move { result }
         }
     }
 
@@ -2170,9 +2673,16 @@ mod tests {
         let forge = MockForge::new().with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -2226,9 +2736,16 @@ mod tests {
         let forge = MockForge::new().with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        let err = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap_err();
+        let err = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(&err, SubmitError::BookmarkNamesTaken { bookmarks } if bookmarks == &["feat-taken"]),
             "unexpected error: {err:?}",
@@ -2269,9 +2786,16 @@ mod tests {
         let forge = MockForge::new().with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             *ops.lock().unwrap(),
@@ -2323,9 +2847,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 2);
 
@@ -2363,9 +2894,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated = forge.updated_bases.lock().unwrap();
         assert_eq!(updated.len(), 1);
@@ -2412,9 +2950,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let comments = forge.created_comments.lock().unwrap();
         // One stack comment per PR.
@@ -2501,9 +3046,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Should have updated the existing comment on PR #50, not created a
         // new one. A new comment is created for the second PR.
@@ -2555,9 +3107,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let calls = push_calls.lock().unwrap();
         assert_eq!(calls.len(), 2);
@@ -2619,9 +3178,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let created = forge.created_prs.lock().unwrap();
         assert_eq!(created.len(), 1);
@@ -2654,9 +3220,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert_eq!(updated_titles.len(), 1);
@@ -2693,9 +3266,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert_eq!(updated_titles[0], (42, "title only".to_string()));
@@ -2731,9 +3311,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated_titles = forge.updated_titles.lock().unwrap();
         assert!(updated_titles.is_empty());
@@ -2779,16 +3366,24 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Body sync is skipped in the per-bookmark loop when body-mode is
         // active — the fence-splicing phase handles it in a single API call.
         // So there should be exactly 2 body updates (one per PR), not 4.
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 2);
-        // Both bodies should contain the commit text and the STAKK_BODY_START fence.
+        // Both bodies should contain the commit text and the STAKK_BODY_START
+        // fence.
         assert!(updated_bodies[0].1.contains("new commit body"));
         assert!(updated_bodies[0].1.contains("STAKK_BODY_START"));
         assert!(updated_bodies[1].1.contains("commit body b"));
@@ -3180,9 +3775,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 2);
@@ -3245,9 +3847,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let updated_bodies = forge.updated_bodies.lock().unwrap();
         assert_eq!(updated_bodies.len(), 2);
@@ -3344,9 +3953,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Should have written body for both PRs.
         let updated_bodies = forge.updated_bodies.lock().unwrap();
@@ -3405,9 +4021,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Should have created comments for both PRs.
         let created_comments = forge.created_comments.lock().unwrap();
@@ -3455,9 +4078,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 1);
 
@@ -3537,9 +4167,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Old stack comment should be deleted.
         let deleted = forge.deleted_comments.lock().unwrap();
@@ -3580,9 +4217,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Body)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Body,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Body fence should be stripped.
         let updated_bodies = forge.updated_bodies.lock().unwrap();
@@ -3643,9 +4287,16 @@ mod tests {
         let forge = MockForge::new();
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.stack_entries.len(), 2);
 
@@ -3748,9 +4399,16 @@ mod tests {
             }],
         );
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::None)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::None,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // Old stack comment on PR #50 should be deleted.
         let deleted = forge.deleted_comments.lock().unwrap();
@@ -3830,9 +4488,16 @@ mod tests {
         );
         let env = test_comment_env();
 
-        let result = execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Ignore)
-            .await
-            .unwrap();
+        let result = execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Ignore,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         // The submission itself runs normally...
         assert_eq!(result.stack_entries.len(), 2);
@@ -3880,9 +4545,16 @@ mod tests {
         );
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Ignore)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Ignore,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         assert!(forge.deleted_comments.lock().unwrap().is_empty());
         assert!(forge.listed_comments.lock().unwrap().is_empty());
@@ -3934,9 +4606,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -4011,9 +4690,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -4075,9 +4761,16 @@ mod tests {
             .with_ops(Arc::clone(&ops));
         let env = test_comment_env();
 
-        execute_submission_plan(&plan, &jj, &forge, &env, StackPlacement::Comment)
-            .await
-            .unwrap();
+        execute_submission_plan(
+            &plan,
+            &jj,
+            &forge,
+            &env,
+            StackPlacement::Comment,
+            NativeStacks::Ignore,
+        )
+        .await
+        .unwrap();
 
         let ops = ops.lock().unwrap();
         assert_eq!(
@@ -4089,6 +4782,450 @@ mod tests {
                 Op::CreatePr("feat-b".to_string()),
             ],
             "base update for feat-a must complete before feat-b is pushed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Native stack reconciliation tests
+    // -----------------------------------------------------------------------
+
+    /// A two-PR plan whose PRs already exist (#41 bottom, #42 top), so PR
+    /// numbers are stable for stack assertions.
+    fn two_existing_pr_plan() -> SubmissionPlan {
+        SubmissionPlan {
+            bookmark_plans: vec![
+                BookmarkPlan {
+                    bookmark_name: "feat-a".to_string(),
+                    base: "main".to_string(),
+                    title: "feature a".to_string(),
+                    body: None,
+                    existing_pr: Some(make_pr(41, "feat-a", "main")),
+                    needs_push: false,
+                    needs_create: false,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+                BookmarkPlan {
+                    bookmark_name: "feat-b".to_string(),
+                    base: "feat-a".to_string(),
+                    title: "feature b".to_string(),
+                    body: None,
+                    existing_pr: Some(make_pr(42, "feat-b", "feat-a")),
+                    needs_push: false,
+                    needs_create: false,
+                    needs_base_update: false,
+                    needs_title_sync: false,
+                    needs_body_sync: false,
+                },
+            ],
+            bookmark_creations: vec![],
+            remote: "origin".to_string(),
+            pr_mode: PrMode::Regular,
+            default_branch: "main".to_string(),
+        }
+    }
+
+    async fn run_plan(
+        plan: &SubmissionPlan,
+        forge: &MockForge,
+        placement: StackPlacement,
+        native: NativeStacks,
+    ) -> Result<SubmissionResult, SubmitError> {
+        let (runner, _push_calls) = MockJjRunner::new();
+        let jj = Jj::new(runner);
+        let env = test_comment_env();
+        execute_submission_plan(plan, &jj, forge, &env, placement, native).await
+    }
+
+    #[test]
+    fn resolve_placement_matrix() {
+        use EffectivePlacement as E;
+        use NativeState as N;
+        use StackPlacement as P;
+
+        // Literal placements ignore the native state entirely.
+        for native in [N::Active, N::Inactive, N::Unknown] {
+            assert_eq!(resolve_placement(P::Comment, native), E::Comment);
+            assert_eq!(resolve_placement(P::Body, native), E::Body);
+            assert_eq!(resolve_placement(P::None, native), E::Cleanup);
+            assert_eq!(resolve_placement(P::Ignore, native), E::Ignore);
+        }
+
+        // Auto placements retire the text only on a *definitive* native
+        // stack; an unknown state falls back to writing, never to silence —
+        // a redundant comment self-heals, a stale one misleads.
+        assert_eq!(resolve_placement(P::AutoComment, N::Active), E::Cleanup);
+        assert_eq!(resolve_placement(P::AutoComment, N::Inactive), E::Comment);
+        assert_eq!(resolve_placement(P::AutoComment, N::Unknown), E::Comment);
+        assert_eq!(resolve_placement(P::AutoBody, N::Active), E::Cleanup);
+        assert_eq!(resolve_placement(P::AutoBody, N::Inactive), E::Body);
+        assert_eq!(resolve_placement(P::AutoBody, N::Unknown), E::Body);
+    }
+
+    #[tokio::test]
+    async fn native_ignore_never_touches_the_stack_api() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[41, 42]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::Ignore)
+            .await
+            .unwrap();
+
+        assert!(forge.stack_lookups.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    /// `none` mirrors `--stack-placement none`: it registers nothing and
+    /// retires the server-side stacks that are standing.
+    #[tokio::test]
+    async fn native_none_retires_existing_stacks() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[41, 42]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::None)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![7]);
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+        // Inactive native state: the requested placement still writes.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+    }
+
+    /// Unlike the reconcile, the retirement covers single-PR submissions:
+    /// a stale stack containing the one PR is exactly what `none` retires.
+    #[tokio::test]
+    async fn native_none_retires_stacks_for_single_pr_submissions() {
+        let mut plan = two_existing_pr_plan();
+        plan.bookmark_plans.truncate(1);
+        let forge = MockForge::new().with_existing_stack(7, &[41, 43]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::None)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![7]);
+    }
+
+    /// Where the feature is not offered nothing can be standing — `none`
+    /// skips silently instead of failing.
+    #[tokio::test]
+    async fn native_none_skips_silently_when_unavailable() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_stacks_unavailable();
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::None)
+            .await
+            .unwrap();
+
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    /// A transient failure while retiring is an advisory warning, never a
+    /// failed submit — a re-run retries.
+    #[tokio::test]
+    async fn native_none_transient_error_does_not_fail_the_submit() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_stacks_api_error();
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::None)
+            .await
+            .unwrap();
+
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+    }
+
+    /// One PR is not a stack: even `on` skips the stack API entirely.
+    #[tokio::test]
+    async fn native_on_single_pr_skips_the_stack_api() {
+        let mut plan = two_existing_pr_plan();
+        plan.bookmark_plans.truncate(1);
+        let forge = MockForge::new();
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert!(forge.stack_lookups.lock().unwrap().is_empty());
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn native_on_creates_a_stack_when_none_exists() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new();
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        // Every desired PR is queried, not only the bottom one.
+        assert_eq!(*forge.stack_lookups.lock().unwrap(), vec![41, 42]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![41, 42]]);
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn native_on_is_a_noop_when_the_stack_matches() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[41, 42]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    /// A server stack extending *above* the submission is left standing:
+    /// the submitted PRs are already its bottom prefix, and rebuilding
+    /// would evict the upper PRs from merge-time retargeting.
+    #[tokio::test]
+    async fn native_on_leaves_a_superset_stack_standing() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[41, 42, 43]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.added_to_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    /// The eviction warning names each open PR that is dissolved along
+    /// with a foreign stack but not restacked — once, however many stacks
+    /// carried it.
+    #[test]
+    fn evicted_pr_numbers_reports_lost_members_once() {
+        let stacks = vec![
+            ForgeStack {
+                number: 7,
+                open_pr_numbers: vec![41, 99],
+            },
+            ForgeStack {
+                number: 8,
+                open_pr_numbers: vec![42, 99],
+            },
+        ];
+        assert_eq!(evicted_pr_numbers(&stacks, &[41, 42]), vec![99]);
+        assert!(evicted_pr_numbers(&stacks, &[41, 42, 99]).is_empty());
+    }
+
+    #[tokio::test]
+    async fn native_on_appends_when_server_stack_is_a_bottom_prefix() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[41]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.added_to_stacks.lock().unwrap(), vec![(7, vec![42])]);
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+        assert!(forge.unstacked.lock().unwrap().is_empty());
+    }
+
+    /// A rejected append converges via dissolve-and-recreate instead of
+    /// failing the submit.
+    #[tokio::test]
+    async fn add_conflict_falls_back_to_dissolve_and_recreate() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new()
+            .with_existing_stack(7, &[41])
+            .with_add_conflict();
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![7]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![41, 42]]);
+    }
+
+    /// A reordered stack cannot be converged by appending — dissolve and
+    /// rebuild.
+    #[tokio::test]
+    async fn mismatched_stack_is_dissolved_and_recreated() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_existing_stack(7, &[42, 41]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        assert_eq!(*forge.unstacked.lock().unwrap(), vec![7]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![41, 42]]);
+    }
+
+    /// Desired PRs spread over several foreign stacks: all of them are
+    /// dissolved before the new stack is created.
+    #[tokio::test]
+    async fn foreign_stacks_holding_desired_prs_are_dissolved() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new()
+            .with_existing_stack(7, &[41, 99])
+            .with_existing_stack(8, &[42]);
+        run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        let mut unstacked = forge.unstacked.lock().unwrap().clone();
+        unstacked.sort_unstable();
+        assert_eq!(unstacked, vec![7, 8]);
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![41, 42]]);
+    }
+
+    /// With `on`, an unavailable stacks API fails the submit — after the
+    /// PRs themselves went through normally.
+    #[tokio::test]
+    async fn native_on_fails_the_submit_when_unavailable() {
+        let mut plan = two_existing_pr_plan();
+        // Make the PRs newly created so "submitted normally first" is
+        // observable on the mock.
+        for bp in &mut plan.bookmark_plans {
+            bp.existing_pr = None;
+            bp.needs_create = true;
+            bp.needs_push = true;
+        }
+        let forge = MockForge::new().with_stacks_unavailable();
+        let err = run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SubmitError::StacksUnavailable { .. }));
+        assert_eq!(forge.created_prs.lock().unwrap().len(), 2);
+        // The text placement still ran before the failure was reported.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+    }
+
+    /// With `auto`, an unavailable stacks API is skipped silently and the
+    /// requested placement carries on as if native stacks were never
+    /// requested.
+    #[tokio::test]
+    async fn native_auto_skips_silently_when_unavailable() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_stacks_unavailable();
+        run_plan(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Auto,
+        )
+        .await
+        .unwrap();
+
+        // Inactive: auto-comment behaves like comment.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+        assert!(forge.created_stacks.lock().unwrap().is_empty());
+    }
+
+    /// A failure that says nothing about availability must not stop the
+    /// stack info from being written: a redundant comment self-heals on the
+    /// next successful run, a skipped update leaves *stale* info standing.
+    #[tokio::test]
+    async fn native_auto_transient_error_still_writes_auto_comments() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_stacks_api_error();
+        run_plan(
+            &plan,
+            &forge,
+            StackPlacement::AutoComment,
+            NativeStacks::Auto,
+        )
+        .await
+        .unwrap();
+
+        // Unknown: auto-comment falls back to comment, not to ignore.
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+    }
+
+    /// The same transient error under `on` is a hard failure.
+    #[tokio::test]
+    async fn native_on_transient_error_fails_the_submit() {
+        let plan = two_existing_pr_plan();
+        let forge = MockForge::new().with_stacks_api_error();
+        let err = run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SubmitError::StackReconcileFailed { .. }));
+    }
+
+    /// With `on`, a reconcile failure fails the submit only *after* body
+    /// syncs and the text placement ran, so everything the error's help
+    /// text promises ("PRs were created/updated normally") has happened.
+    /// In particular a requested `--sync-pr-content` body update must not
+    /// be dropped by the failure.
+    #[tokio::test]
+    async fn native_on_reconcile_failure_still_syncs_bodies_and_writes_comments() {
+        let mut plan = two_existing_pr_plan();
+        plan.bookmark_plans[0].needs_body_sync = true;
+        plan.bookmark_plans[0].body = Some("synced body".to_string());
+        let forge = MockForge::new().with_stacks_api_error();
+        let err = run_plan(&plan, &forge, StackPlacement::Comment, NativeStacks::On)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SubmitError::StackReconcileFailed { .. }));
+        assert_eq!(
+            *forge.updated_bodies.lock().unwrap(),
+            vec![(41, "synced body".to_string())]
+        );
+        assert_eq!(forge.created_comments.lock().unwrap().len(), 2);
+    }
+
+    /// When the reconcile establishes a native stack, auto-comment retires
+    /// stakk's own stack comment instead of updating it.
+    #[tokio::test]
+    async fn auto_comment_cleans_up_when_native_is_active() {
+        let plan = two_existing_pr_plan();
+        let stack_comment = Comment {
+            id: 900,
+            body: "<!--- STAKK_STACK: e30= --->\nold stack".to_string(),
+        };
+        let forge = MockForge::new().with_existing_comments(41, vec![stack_comment]);
+        run_plan(&plan, &forge, StackPlacement::AutoComment, NativeStacks::On)
+            .await
+            .unwrap();
+
+        // The native stack was registered, and the old comment retired.
+        assert_eq!(*forge.created_stacks.lock().unwrap(), vec![vec![41, 42]]);
+        assert_eq!(*forge.deleted_comments.lock().unwrap(), vec![900]);
+        assert!(forge.created_comments.lock().unwrap().is_empty());
+        assert!(forge.updated_comments.lock().unwrap().is_empty());
+    }
+
+    /// A deferred body sync must still land when the placement resolves
+    /// away from body mode (auto-body with a native stack in effect).
+    #[tokio::test]
+    async fn deferred_body_sync_applies_when_auto_body_resolves_to_cleanup() {
+        let mut plan = two_existing_pr_plan();
+        plan.bookmark_plans[0].needs_body_sync = true;
+        plan.bookmark_plans[0].body = Some("synced body".to_string());
+        let forge = MockForge::new();
+        run_plan(&plan, &forge, StackPlacement::AutoBody, NativeStacks::On)
+            .await
+            .unwrap();
+
+        let updated_bodies = forge.updated_bodies.lock().unwrap();
+        assert_eq!(*updated_bodies, vec![(41, "synced body".to_string())]);
+        // The synced body carries no fence — a native stack renders the
+        // overview, stakk's text is retired.
+        assert!(!updated_bodies[0].1.contains("STAKK_BODY_START"));
+    }
+
+    /// A single-PR submission takes the cleanup path even in body
+    /// placement, so the body-splice phase never runs — the deferred body
+    /// sync must be applied explicitly rather than dropped.
+    #[tokio::test]
+    async fn single_pr_body_placement_still_syncs_the_body() {
+        let mut plan = two_existing_pr_plan();
+        plan.bookmark_plans.truncate(1);
+        plan.bookmark_plans[0].needs_body_sync = true;
+        plan.bookmark_plans[0].body = Some("synced body".to_string());
+        let forge = MockForge::new();
+        run_plan(&plan, &forge, StackPlacement::Body, NativeStacks::Ignore)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *forge.updated_bodies.lock().unwrap(),
+            vec![(41, "synced body".to_string())]
         );
     }
 }


### PR DESCRIPTION
Adds `--native-stacks <on|auto|none|ignore>` (env: `STAKK_NATIVE_STACKS`, config: `native_stacks`, default `ignore`), which registers submitted stacks with GitHub's server-side stacked-pull-requests feature (public preview) after the PRs are pushed and updated. Closes #179. Supersedes #190, rebuilt from scratch on v2 main with the design changes below.

## What this PR does

- **`feat(forge): integrate GitHub's native stacked pull requests (--native-stacks)`** — four new `Forge` primitives (`get_stacks_for_pr`, `create_stack`, `add_to_stack`, `unstack`) and an idempotent post-submit reconcile: no-op on exact match; no-op when the server stack extends *above* the submission (the submitted PRs are its bottom prefix, and rebuilding would evict the upper PRs from merge-time retargeting); `/add` when the server stack is a bottom-prefix of the desired list; dissolve-and-recreate otherwise (also the fallback when the server rejects an append), warning with the numbers of any open PRs that lose native stacking. Comparison uses open PRs of open stacks only, so merged bottoms drop out naturally.
  The values follow the `--stack-placement` vocabulary: `on` fails the submit when the feature is unavailable — reported only after body syncs and the text placement have run, so the error's "branches and PRs were submitted normally" guidance is true when it renders; `auto` registers where available and skips silently where not; `none` registers nothing *and* dissolves the server-side stacks containing submitted PRs (single-PR submissions included; never fails the submit); `ignore` (default) never touches the stack API. Otherwise, a submission producing a single PR is not a stack and skips the registration.
  New placements `auto-comment`/`auto-body` retire stakk's stack comment / body fence on runs where a native stack is in effect and behave like `comment`/`body` otherwise.
- **`feat(cli): default --stack-placement to auto-comment`** — behaviorally identical to `comment` while `--native-stacks` is `ignore` (its default), so nothing changes for existing configurations. It positions the defaults so the GA change is a single default flip of `native_stacks` to `auto`, which never overrides an explicit `comment`/`body` choice.

## How it differs from #190

1. **No octocrab wait, no octocrab workaround.** The stack routes require `X-GitHub-Api-Version: 2026-03-10`, and octocrab both stamps a baked-in `2022-11-28` on every request its `build_request` produces and *appends* (rather than replaces) `add_header` values, so #190's second client sent both versions and GitHub 400'd every call. Here the stack requests are built by hand with `http::Request` and sent through the public `Octocrab::execute`, which skips the stamping while keeping octocrab's service layers (auth, base URI for GHES, User-Agent). Error handling is status-code-first with lenient body parsing, sidestepping octocrab's second bug (string-valued `errors` fields degrade to serde errors). All of it is confined to `src/forge/github/stacks.rs`, whose module doc declares it exists to be deleted once octocrab ships typed stacks support (XAMPPRocky/octocrab#934) — nothing outside `forge::github` touches it, and the swap is: delete the file, retype the four method bodies in `github/mod.rs`.
2. **No availability probe, and 404 is read per route.** `supports_native_stacks` is gone. The reconcile step runs *before* the text-placement step, and its own outcome is the availability answer: success → native stack in effect; a 404 on the collection routes → definitively not offered (the reading GitHub's own `gh stack` client applies — in practice GitHub Enterprise Server, since the preview rolled out to all github.com repositories); anything else → unknown. On the numbered routes (`/stacks/{n}/add`, `/stacks/{n}/unstack`) a 404 instead means the addressed stack vanished since the lookup — a state race, not an availability answer: `/add` maps it to a conflict the reconcile converges on by rebuilding, and `/unstack` counts it as success (absence is the goal state). #190's probe endpoint semantics were never observable on github.com.
3. **Unknown resolves to writing, not `ignore`.** A transient reconcile failure under `auto` warns and keeps updating stack comments. Only a *definitive* native stack triggers the destructive direction (retiring the comment/fence): a redundant overview self-heals on the next successful run, while a skipped update leaves a *stale* one standing.
4. **Closed-stack hardening.** Fully merged stacks stay in list responses with `"open": false` (observed live); they are filtered out before reconciliation so stakk never tries to unstack history.
5. **Body sync is one pass, after the placement resolves.** #190's design (and an early revision of this PR) deferred body syncs to the body-splice phase and silently dropped them whenever that phase did not run — single-PR submissions, cleanup-resolved placements, or an `on`-mode reconcile failure. Here body sync is a single pass that runs after the reconcile and placement resolution, skipped only when the body-splice phase folds each sync into its own body write — so it survives all of those paths, and there is exactly one implementation to keep correct.

## Verification

- `mise run ci` green on both commits (535 tests). Coverage includes the reconcile convergence cases (exact match, bottom-prefix append, the superset no-op, dissolve-and-recreate with the eviction warning), the placement-resolution matrix, per-route 404 mapping, `none` retirement (multi- and single-PR, unavailable, transient failure), held `on`-mode failures still syncing bodies and writing comments, body-sync regressions, and DTO parsing pinned against a captured live payload.
- The transport was exercised **live** against this repository with a real token: the hand-built request authenticated through `Octocrab::execute`, carried the single `2026-03-10` header, parsed the real stack #204 wire payload, and filtered it as closed. The doubled-header failure that put #190 on hold does not occur on this path.
- Request/response shapes re-verified against the 2026-03-10 REST docs (`pull_requests` arrays of integers bottom-to-top; stack objects with `number`/`open`/`pull_requests[].{number,state,merged_at}`; unstack 200/204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
