### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0](https://github.com/glennib/stakk/compare/v2.4.1...v2.5.0) - 2026-09-02
+
+### Added
+
+- *(select)* resolve REV as a jj revset
+
+### Other
+
+- *(deps)* update dependency rumdl to v0.2.63 ([#236](https://github.com/glennib/stakk/pull/236))
+- *(stability)* let diagnostic codes change in minor releases
+- *(deps)* update dependency uv to v0.12.9 ([#234](https://github.com/glennib/stakk/pull/234))
+
 ## [2.4.1](https://github.com/glennib/stakk/compare/v2.4.0...v2.4.1) - 2026-09-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.4.1 -> 2.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.5.0](https://github.com/glennib/stakk/compare/v2.4.1...v2.5.0) - 2026-09-02

### Added

- *(select)* resolve REV as a jj revset

### Other

- *(deps)* update dependency rumdl to v0.2.63 ([#236](https://github.com/glennib/stakk/pull/236))
- *(stability)* let diagnostic codes change in minor releases
- *(deps)* update dependency uv to v0.12.9 ([#234](https://github.com/glennib/stakk/pull/234))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).