### PR TITLE
chore: release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1](https://github.com/glennib/stakk/compare/v2.5.0...v2.5.1) - 2026-09-07
+
+### Other
+
+- compress the README and every docs/ topic for their readers
+- *(deps)* update dependency rumdl to v0.2.64 ([#240](https://github.com/glennib/stakk/pull/240))
+- *(deps)* lock file maintenance ([#244](https://github.com/glennib/stakk/pull/244))
+- *(deps)* update dependency cargo:release-plz to v0.3.162 ([#243](https://github.com/glennib/stakk/pull/243))
+- *(deps)* update dependency cargo-binstall to v1.23.0 ([#242](https://github.com/glennib/stakk/pull/242))
+- *(deps)* update dependency uv to v0.12.10 ([#241](https://github.com/glennib/stakk/pull/241))
+- *(deps)* update dependency cargo:release-plz to v0.3.161 ([#239](https://github.com/glennib/stakk/pull/239))
+
 ## [2.5.0](https://github.com/glennib/stakk/compare/v2.4.1...v2.5.0) - 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakk"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "base64 0.23.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakk"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2024"
 repository = "https://github.com/glennib/stakk"
 description = "A CLI tool that bridges Jujutsu (jj) bookmarks to GitHub stacked pull requests"


### PR DESCRIPTION



## 🤖 New release

* `stakk`: 2.5.0 -> 2.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.5.1](https://github.com/glennib/stakk/compare/v2.5.0...v2.5.1) - 2026-09-07

### Other

- compress the README and every docs/ topic for their readers
- *(deps)* update dependency rumdl to v0.2.64 ([#240](https://github.com/glennib/stakk/pull/240))
- *(deps)* lock file maintenance ([#244](https://github.com/glennib/stakk/pull/244))
- *(deps)* update dependency cargo:release-plz to v0.3.162 ([#243](https://github.com/glennib/stakk/pull/243))
- *(deps)* update dependency cargo-binstall to v1.23.0 ([#242](https://github.com/glennib/stakk/pull/242))
- *(deps)* update dependency uv to v0.12.10 ([#241](https://github.com/glennib/stakk/pull/241))
- *(deps)* update dependency cargo:release-plz to v0.3.161 ([#239](https://github.com/glennib/stakk/pull/239))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).