### PR TITLE
docs: compress the README and every docs/ topic for their readers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ When adding, renaming, or changing the default of one, update all of them in the
    `README.md` deliberately carries *no* flag or env-var reference tables — `stakk --help`,
    `stakk <subcommand> --help` and `docs/config.md` are the reference.
    Only touch the README when the option changes something it describes in prose: the four-key `stakk.toml` sample,
-   the **Stack info placement** summary, **GitHub Enterprise Server**, **Non-interactive selection**,
-   **PR titles and bodies**, **Custom bookmark names**, or **Immutable commits**.
+   the **GitHub native stacks** and **Stack info placement** summaries, **GitHub Enterprise Server**,
+   **Non-interactive selection**, **PR titles and bodies**, **Custom bookmark names**, or **Immutable commits**.
    Deeper reference material for those lives in `docs/template.md`, `docs/agents.md` and `docs/graph.md`,
    which each README section links to alongside its `stakk docs <topic>` command.
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,47 @@
 # stakk
 
-**stakk** bridges [Jujutsu](https://github.com/jj-vcs/jj) bookmarks to GitHub stacked pull requests.
-It reads your change graph, lets you select a stack and name bookmarks for the commits that need them,
-then pushes and maintains one PR per bookmark: correct base branches, stack comments, no duplicates on re-runs.
+**stakk** turns [Jujutsu](https://github.com/jj-vcs/jj) bookmarks into GitHub stacked pull requests.
+Pick a stack, name the bookmarks that still need one, and stakk pushes and maintains one PR per bookmark:
+correct base branches, a stack overview on every PR, no duplicates on re-runs.
+It works with
+[GitHub's native stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests): opt in
+with `--native-stacks auto` and GitHub renders the stack itself and retargets PRs as the stack merges.
 
-It is not a jj wrapper. jj stays in charge of your commits and bookmarks;
-stakk takes over only where that local state has to exist on GitHub.
+jj stays in charge of your commits and bookmarks; stakk acts only where that state has to exist on GitHub.
+It never calls `git` — everything goes through `jj`, so workspaces and non-colocated repos just work.
 
 ![Interactive stakk submission flow](media/stakk.gif)
 
-## Features
-
-- **Automatic stack detection** — finds bookmark chains and their topological order in the jj change graph,
-  including unbookmarked heads, which stakk can bookmark for you.
-- **Interactive TUI** — a graph of every branch stack, then a screen for assigning bookmarks.
-  Each commit cycles through: `[x]` existing → `[~]` auto → `[>]` typed by hand → `[+]` generated `stakk-xxxx` → `[*]`
-  custom command → `[ ]` skip.
-- **Auto bookmark naming** — the `[~]auto` state derives names from commit descriptions and file paths via TF-IDF
-  scoring; `r` cycles alternatives and `--auto-prefix` brands them (e.g. `gb-caching-database`).
-- **Non-interactive selection** — `--keep`/`--new`/`--new-auto`/`--new-command` build the exact same
-  submission the TUI would, without a terminal.
-- **Stack-awareness comments** — every PR gets the full stack with links,
-  updated in place on re-runs and rendered with customizable [minijinja](https://github.com/mitsuhiko/minijinja)
-  templates.
-  See [Stack info placement](#stack-info-placement).
-- **Dry-run mode** — `--dry-run` prints the submission plan and stops: no bookmark is created,
-  nothing is pushed, and nothing is written to GitHub.
-- **No direct git usage** — all VCS operations go through `jj` commands, so
-  workspaces and non-colocated repos work automatically.
-
 ## Installation
 
-### Requirements
-
-stakk shells out to the [`jj`](https://github.com/jj-vcs/jj) CLI, which must be installed and on your `PATH`.
-The minimum supported jj version is **0.39.0**.
-Older versions may work but are untested; stakk prints a warning when it detects one.
-Raising that floor is not a breaking change — see [Stability](#stability).
-
-### mise (recommended)
+Requires the [`jj`](https://github.com/jj-vcs/jj) CLI on your `PATH`, version 0.39.0 or newer.
 
 ```shell
-mise use -g 'github:glennib/stakk'
+mise use -g 'github:glennib/stakk'   # recommended
+mise use -g 'cargo:stakk'            # from crates.io
+cargo binstall stakk
+cargo install stakk
 ```
 
-### Other methods
-
-```shell
-mise use -g 'cargo:stakk' # from crates.io
-cargo binstall stakk # using cargo-binstall
-cargo install stakk # install from source
-```
-
-Or pre-built binaries from the [latest release](https://github.com/glennib/stakk/releases/latest).
+Or download a binary from the [latest release](https://github.com/glennib/stakk/releases/latest).
 
 ## Quick start
 
 ```shell
-# Submit interactively — pick a stack and assign bookmarks in the TUI
-stakk
+stakk          # pick a stack and assign bookmarks in the TUI
+stakk graph    # show your stacks and their change ids (offline)
 
-# See your stacks, and the change ids to name on the command line
-# (offline: jj only, never GitHub)
-stakk graph
-
-# Submit without the TUI — one mark per PR boundary: keep an existing
-# bookmark, name a new one at change qzvs, auto-name one at wmtk
-stakk submit --keep feat-auth --new qzvs=feat-api --new-auto wmtk
-
-# Add --dry-run to any submission to see the plan and stop
+# Without the TUI: one mark per PR boundary
 stakk submit --keep feat-auth --new qzvs=feat-api --new-auto wmtk --dry-run
 ```
 
+`--dry-run` prints the plan and stops: no bookmark is created, nothing is pushed, nothing is written to GitHub.
+`stakk --help` and `stakk <subcommand> --help` are the flag reference;
+`stakk docs` prints the same documentation as [docs/](docs/), bundled into the binary.
+
 ## How stacking works
 
-In jj, bookmarks point at changes.
-When bookmarks form a linear chain — each building on the previous — they represent a stack.
-Create the bookmarks yourself, or let stakk discover unbookmarked heads and create them for you:
+Bookmarks that form a linear chain are a stack:
 
 ```text
  ○  feat-ui    ← leaf
@@ -85,18 +50,32 @@ Create the bookmarks yourself, or let stakk discover unbookmarked heads and crea
  ◆  main       ← trunk
 ```
 
-Picking `feat-ui` as the tip and keeping all three bookmarks — in the TUI,
-or as `stakk submit --keep feat-auth --keep feat-api --keep feat-ui` —
-pushes every one of them and creates or updates one PR per bookmark, basing each on the bookmark below it:
+Submitting all three — in the TUI, or as `stakk submit --keep feat-auth --keep feat-api --keep feat-ui` —
+pushes each bookmark and creates or updates one PR per bookmark, based on the one below it: `feat-auth` → `main`,
+`feat-api` → `feat-auth`, `feat-ui` → `feat-api`.
+Each PR shows only its own diff.
 
-- `feat-auth` → PR targeting `main`
-- `feat-api` → PR targeting `feat-auth`
-- `feat-ui` → PR targeting `feat-api`
+Unbookmarked commits can become PRs too.
+In the TUI each commit cycles through `[x]` existing bookmark, `[~]` name derived from the commit (TF-IDF), `[>]` typed,
+`[+]` generated `stakk-<change_id>`, `[*]` from `--bookmark-command`, and `[ ]` skip.
+`--auto-prefix` brands the derived names (`gb-caching-database`).
 
-Each PR shows only its own diff, and a stack comment on every PR links all related PRs together.
-The comment orders the stack the way `stakk graph` and the TUI do, leaf at the top and trunk at the bottom,
-and marks both the tip of the stack and the PR you are looking at.
-Each row is a bare PR link, which GitHub renders as a reference carrying that PR's live title and merge state:
+## GitHub native stacks
+
+`--native-stacks` registers the submitted stack with GitHub's native stacked pull requests
+(public preview), so GitHub draws the stack on every PR and retargets the remaining PRs as the stack merges bottom-up.
+Modes: `on` (fail where the feature is unavailable), `auto`
+(register where available, skip where not — GitHub Enterprise Server, for example),
+`none` (register nothing and dissolve the server-side stacks stakk's PRs are in), and `ignore`
+(never touch the stack API).
+The default is `ignore` until the feature reaches general availability, then `auto`.
+
+Native stacks layer on top of the base-branch chain stakk maintains anyway; nothing else about a submission changes.
+
+## Stack info placement
+
+Every PR in a stack also gets a stack overview from stakk, leaf at the top like `stakk graph` and the TUI.
+Each row is a bare PR link, which GitHub renders with the PR's live title and merge state:
 
 ```text
 Stack of 3 PRs merging into main
@@ -107,37 +86,21 @@ Stack of 3 PRs merging into main
 • main
 ```
 
-## Stack info placement
+`--stack-placement` decides where it lives: a PR `comment`, a fenced section in the PR `body`, `none`
+(write nothing and remove what is there),
+`ignore` (write nothing, touch nothing), or `auto-comment` (default) / `auto-body`,
+which write like `comment`/`body` except on runs where a native stack is in effect,
+where GitHub's rendering replaces it.
+So `--native-stacks auto` gives native rendering where available and stack comments everywhere else, never both.
+Switching between `comment` and `body` migrates automatically.
 
-`--stack-placement` decides where the stack overview lives on each PR: a separate PR `comment`,
-a fenced section in the PR `body`, `none` (write nothing and remove what is already there), `ignore`
-(write nothing and touch nothing), or `auto-comment`/`auto-body` (defer to native stacks, below).
-The default is `auto-comment`, which is identical to `comment` as long as `--native-stacks` is `ignore` (its default).
-Switching between `comment` and `body` migrates automatically,
-and a submission that produces a single PR is not a stack, so no stack info is written.
-
-`--native-stacks` registers submitted stacks with
-[GitHub's native stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests) (public
-preview): `on` (fail the submit where the feature is unavailable), `auto` (register where available, skip silently where
-not — GitHub Enterprise Server, for example), `none` (register nothing and dissolve the server-side stacks that are
-standing), or `ignore` (default; never touch the stack API) — `none` and `ignore` follow the same
-also-removes/touches-nothing rule as the placement modes.
-GitHub then renders the stack natively and retargets the remaining PRs as the stack merges bottom-up.
-Since that rendering replaces stakk's stack overview,
-`auto-comment`/`auto-body` behave like `none` on runs where a native stack is in effect
-and like `comment`/`body` otherwise,
-so `--native-stacks auto --stack-placement auto-comment` gives native rendering where available
-and stack comments everywhere else, never both.
-
-Full mode table, migration details, and stack comment templating: [docs/template.md](docs/template.md),
-or run `stakk docs template`.
+Mode table and [minijinja](https://github.com/mitsuhiko/minijinja) templating:
+[docs/template.md](docs/template.md) or `stakk docs template`.
 
 ## Configuration
 
-Settings come from CLI flags, then `STAKK_`-prefixed environment variables, then a repository `stakk.toml`
-(found by walking up to the jj workspace root),
-then the user config (`~/.config/stakk/config.toml` on Linux), then built-in defaults.
-All fields are optional, and unknown fields cause a parse error.
+CLI flags override `STAKK_*` environment variables, which override a repository `stakk.toml`,
+which overrides the user config (`~/.config/stakk/config.toml` on Linux).
 
 ```toml
 # stakk.toml
@@ -147,184 +110,57 @@ stack_placement = "body"
 auto_prefix = "gb-"
 ```
 
-Every config key and environment variable, the `inherit` field, worked examples,
-and what a repo-supplied `stakk.toml` is able to do: [docs/config.md](docs/config.md), or run `stakk docs config`.
+Every key and variable: [docs/config.md](docs/config.md) or `stakk docs config`.
 
 ### GitHub Enterprise Server
 
-github.com works out of the box.
-For a GitHub Enterprise Server host, name the host with `--github-host`, `STAKK_GITHUB_HOST`,
-`github_host` in `stakk.toml`, or `GH_HOST` —
-stakk then accepts remotes on that host and uses its API at `https://<host>/api/v3`.
-Tokens are resolved per host, mirroring the GitHub CLI, so an Enterprise token is never sent to github.com.
+Name the host with `--github-host`, `STAKK_GITHUB_HOST`, `github_host` in `stakk.toml`, or `GH_HOST`;
+stakk then accepts remotes on it and uses `https://<host>/api/v3`.
+Tokens are resolved per host like the GitHub CLI does it, so an Enterprise token is never sent to github.com.
+Setup and troubleshooting: [docs/auth.md](docs/auth.md) or `stakk docs auth`.
 
-Host resolution order and the API base: [docs/config.md](docs/config.md), or run `stakk docs config`.
-The `gh` commands that set the host up, the per-host token order, what to do when it fails, and how to check the setup:
-[docs/auth.md](docs/auth.md), or run `stakk docs auth`.
+## Non-interactive selection
 
-## Usage
+`--keep`, `--new`, `--new-auto` and `--new-command` replace the TUI with an explicit selection:
+every PR boundary is named on the command line, all marks lie on one trunk-to-tip path,
+unmarked commits fold into the PR above them, and anything above the topmost mark is not submitted.
+`rev` is any jj revset naming one commit: `@-`, a bookmark, or a change id from `stakk graph --format=json`.
 
-`stakk --help` and `stakk <subcommand> --help` are the flag reference: every flag, its default,
-and its environment variable.
+Rules and diagnostic codes, written for coding agents: [docs/agents.md](docs/agents.md) or `stakk docs agents`
+(`stakk docs agents >> AGENTS.md` hands it to yours).
+Exit codes and a worked Python example: [docs/scripting.md](docs/scripting.md) or `stakk docs scripting`.
+The JSON schema: [docs/graph.md](docs/graph.md) or `stakk docs graph`.
 
-`submit`, `graph` and `docs` each answer to their initial letter, so `stakk s`, `stakk g` and `stakk d` work too.
-`completions` has no short form.
+## PR titles and bodies
 
-### `stakk`, `stakk submit`
+The title is the first line of the change description, the body is the rest;
+multi-commit segments join their descriptions with `---`.
+Hard-wrapped prose is reflowed into paragraphs; Markdown structure passes through verbatim.
+Both are written only on PR creation, so edits on GitHub survive — `--sync-pr-content`
+(`title`, `body`, `all`) opts into updating them.
+`--trailers strip` drops the trailing `Key: value` block (`Signed-off-by`, `Refs`, …).
 
-Submit a stack of bookmarks as stacked PRs.
-The two spellings are one command: with no selection flags, both launch the interactive flow —
-a TUI graph of all branch stacks where you pick a leaf,
-then a screen for toggling bookmarks onto the commits that need them.
-Repos with no pre-existing bookmarks work too; unmarked commits get `stakk-<change_id>`.
-The selection flags below replace the TUI with an explicit, scriptable selection.
+## Custom bookmark names
 
-#### Non-interactive selection
+`--bookmark-command` runs a program (`sh -c`, or `cmd /C` on Windows) with a JSON description of the segment on stdin
+and takes its stdout as the bookmark name.
+It powers the `[*]` TUI state and `--new-command`; the JSON schema is in `stakk submit --help`.
 
-`--keep`, `--new`, `--new-auto` and `--new-command` replace the TUI with a fully explicit, scriptable selection:
-every PR boundary is named on the command line, all marks must lie on one trunk-to-tip path,
-the topmost mark is the tip, unmarked commits below it fold into the PR above them, and anything above it —
-an unbookmarked work-in-progress head, typically — is not submitted at all.
-`rev` is any jj revset that names one commit — `@-`, a bookmark name, or a change id as printed by `stakk graph`,
-which makes submission a two-command loop:
+## Immutable commits
 
-```console
-stakk graph --format=json
-stakk submit --keep base --new qzvs=my-feature --new-auto wmtk
-```
-
-Every selection rule and the machine-readable `stakk::selection::*` diagnostic codes: [docs/agents.md](docs/agents.md),
-or run `stakk docs agents`.
-Pointing a coding agent at `stakk docs agents` is the fastest way to bring it up to speed.
-For a program rather than an agent, [docs/scripting.md](docs/scripting.md)
-(`stakk docs scripting`) adds exit codes and a worked Python example.
-
-#### PR titles and bodies
-
-PR titles come from the first line of the jj change description and bodies from everything after it;
-segments with multiple commits join their descriptions with `---` separators.
-Both are written only on PR creation, so manually edited PR descriptions are never overwritten — `--sync-pr-content`
-(`title`, `body`, `all`) opts into updating existing PRs, and only changed fields are sent.
-
-Descriptions are reflowed on the way into the PR body: hard-wrapped prose lines are joined into soft-wrapped paragraphs,
-so a commit message wrapped at 72 columns does not render as ragged lines on GitHub.
-Structural Markdown — headers, lists, tables, block quotes, fenced and indented code, thematic breaks —
-is passed through verbatim.
-`--trailers strip` removes the trailing key/value block
-(`Signed-off-by`, `Co-authored-by`, `Refs`, …) from the generated body; the default `keep` passes it through.
-
-#### Custom bookmark names
-
-`--bookmark-command` names bookmarks with an external program.
-The command is run through `sh -c` (Unix) or `cmd /C` (Windows),
-receives a JSON description of one segment of commits on stdin, and must print a single bookmark name on stdout.
-It powers the `[*]` state in the TUI and the `--new-command` selection flag.
-The full JSON schema, with a worked example, is in `stakk submit --help`;
-the surrounding context is in [docs/template.md](docs/template.md), or run `stakk docs template`.
-
-#### Immutable commits
-
-Commits that jj considers immutable cannot get a new bookmark: the default bookmarks revset excludes `immutable()`,
-so stakk would create a PR it could never see again on the next run.
-The TUI locks such rows to `[ ]` and explains why, `--new <rev>` on one fails with `stakk::selection::rev_immutable`,
-and the commits are annotated in `stakk graph`.
-Move the work onto mutable commits — or, if you really need a PR there,
-create the bookmark yourself and drop `~ immutable()` from `--bookmarks-revset`.
-Details, including the non-interactive side: [docs/agents.md](docs/agents.md), or run `stakk docs agents`.
-
-### `stakk graph`
-
-Display repository status and all bookmark stacks without submitting.
-Fully offline: only `jj` is queried, never GitHub — PR state is `stakk submit --dry-run`'s job.
-`stakk show` is an alias for the same command, deprecated and due for removal in a future major release.
-`graph` and `submit` build the graph the same way, so `--bookmarks-revset`/`--heads-revset` apply to both:
-what `graph` prints is what `submit` would work on.
-
-The default `pretty` format renders a jj-log-style graph of all stacks, always fully expanded.
-Every commit row carries its short change id, bookmarks, and description summary;
-immutable commits and bookmarks excluded by the bookmarks revset are annotated:
-
-```text
-Default branch: main
-Remote: origin git@github.com:you/repo.git (you/repo)
-
- ○  wmtk  feat-a  (no description set)
- ○  wmtl  "feat a work"
- │ ○  rlkv  feat-b  "feat b work"  (immutable — bookmark old-mark excluded by --bookmarks-revset)
- ├─╯
- ○  qzvs  base  "extend base"
- ○  qzvt  "add base"
- ◆  trunk
-```
-
-Bookmarks whose history contains a merge commit cannot be stacked and are left out of the graph; when that happens,
-`pretty` names them in a footer, and the JSON reports them in `excluded_bookmarks`.
-
-`--format=json` emits a schema-versioned document for machine consumption
-(scripts, agents); its change ids and bookmark names can be passed directly to `stakk submit`.
-It is a sparse projection — identifiers, commit titles, bookmarks and stack position —
-and `--format=json-full` is a strict superset that adds each commit's `commit_id`, full `description`,
-`author` and `files[]`.
-Bookmarks carry their push state (`unpushed`, `diverged`, `synced`), derived from `jj` alone,
-so a consumer can tell new work from an update without a network round trip.
-Field-by-field schema: [docs/graph.md](docs/graph.md), or run `stakk docs graph`.
-
-### `stakk docs [topic]`
-
-Print the documentation bundled into the binary.
-Because it ships inside the binary, it always describes the version you are actually running.
-Run `stakk docs` with no arguments for the list of topics.
-Each topic is one of the Markdown files in [docs/](docs/), which is also where to read them on GitHub.
-
-At a terminal the prose is re-flowed to your terminal width.
-Redirected, the source is emitted verbatim —
-so `stakk docs agents >> AGENTS.md` writes exactly the Markdown in `docs/agents.md`,
-below the HTML comment that names the topic,
-which makes it a one-line way to give a coding agent the full non-interactive workflow.
-
-### `stakk completions <shell>`
-
-Generate shell completions.
-Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
-
-```text
-# Zsh — add to your fpath
-stakk completions zsh > ~/.zfunc/_stakk
-
-# Bash
-stakk completions bash > ~/.local/share/bash-completion/completions/stakk
-
-# Fish
-stakk completions fish > ~/.config/fish/completions/stakk.fish
-```
-
-## Design
-
-stakk never calls `git` directly.
-All git operations go through `jj` subcommands (`jj git push`, `jj git remote list`, etc.).
-This means stakk works automatically in jj workspaces and non-colocated repositories —
-two cases where calling `git` directly fails.
-
-All forge interaction goes through a `Forge` trait.
-GitHub is the first (and currently only) implementation, but the core submission logic is forge-agnostic.
-This opens the door to Forgejo, GitLab, or other platforms in the future.
-
-Submission runs as analyze → plan → execute, with every repository and GitHub mutation confined to the last phase.
-That is why `--dry-run` can stop after the plan and be guaranteed to have written nothing.
+Commits jj considers immutable cannot get a new bookmark: the default bookmarks revset excludes `immutable()`,
+so stakk would create a PR it could never see again.
+The TUI locks such rows, `--new <rev>` fails with `stakk::selection::rev_immutable`, and `stakk graph` marks them.
+Move the work onto mutable commits, or create the bookmark yourself and drop `~ immutable()` from `--bookmarks-revset`.
 
 ## Stability
 
 stakk follows semantic versioning.
-Stable surface: subcommands, their aliases and their flags, `STAKK_` environment variables,
-config keys and their defaults, the two `schema_version`-ed JSON documents
-(`stakk graph` and `--bookmark-command`'s stdin), and exit codes.
-Free to change in any release: rendered `--help` and `stakk docs` text, error and progress *wording*,
-the set of diagnostic codes (a change is listed in the changelog), the `pretty` output of `stakk graph`,
-the order of `stacks[]` in its JSON, and the TUI layout and keybindings.
-Raising the minimum supported jj version is not a breaking change.
-
-The contract itself — every entry, with the reasoning: [docs/stability.md](docs/stability.md),
-or run `stakk docs stability`.
+Stable: subcommands, aliases and flags, `STAKK_` environment variables, config keys and defaults,
+the two `schema_version`-ed JSON documents (`stakk graph` and `--bookmark-command`'s stdin), and exit codes.
+Free to change: `--help` and `stakk docs` text, error wording, the set of diagnostic codes,
+`stakk graph`'s pretty output, the order of `stacks[]`, the TUI, and the minimum jj version.
+The contract: [docs/stability.md](docs/stability.md) or `stakk docs stability`.
 
 ## License
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,10 +4,8 @@ summary: Submitting without the TUI, written for coding agents.
 
 # Driving stakk from a coding agent
 
-Submitting a stack of pull requests without the TUI.
-
-Two commands do everything: `stakk graph` reports what exists, `stakk submit` acts on it.
-`stakk graph` is offline — it queries `jj` only, never GitHub — so it is cheap to run at any point.
+`stakk graph` reports the state, `stakk submit` with selection flags acts on it.
+`stakk graph` is offline — jj only, never GitHub — so run it freely.
 
 ## Reading the state
 
@@ -15,178 +13,115 @@ Two commands do everything: `stakk graph` reports what exists, `stakk submit` ac
 stakk graph --format=json
 ```
 
-Every segment reports its bookmarks with a `remote_state`,
-so the document already distinguishes new work from an update:
+Each segment lists its bookmarks with a `remote_state`:
 
-| `remote_state` | Meaning | What a submission does |
-|----------------|---------|------------------------|
-| `unpushed` | No remote counterpart on any remote | Pushes it for the first time |
-| `diverged` | A tracked remote sits elsewhere | Moves the remote to your commit |
-| `synced` | Some remote is on the same commit | Nothing to push, given one remote |
+| `remote_state` | Meaning | A submission… |
+|----------------|---------|---------------|
+| `unpushed` | No remote counterpart | pushes it for the first time |
+| `diverged` | A tracked remote sits elsewhere | moves the remote to your commit |
+| `synced` | Some remote is on this commit | pushes nothing, given one remote |
 
-This is derived from `jj` alone, so it describes what a *push* would do.
-It says nothing about whether a pull request exists; stakk learns that during `stakk submit`'s plan phase,
-which does query GitHub.
-
-One caveat: `stakk graph` takes no `--remote`, so `synced` means "on some remote", not "on the one you push to".
-In a repository with several remotes, check `remotes[]` before reading `synced` as "nothing to do" —
-see `stakk docs graph`.
+This comes from jj alone and says nothing about pull requests;
+stakk learns which PRs exist in `stakk submit`'s plan phase.
+`synced` means "on some remote", not "on the one you push to" — with several remotes, check `remotes[]`.
 
 ## Naming boundaries
 
 ```console
 stakk submit --keep base --new qzvs=my-feature --new-auto wmtk --dry-run
-stakk submit --keep base --new qzvs=my-feature --new-auto wmtk
 ```
-
-The selection flags replace the TUI with a fully explicit selection.
-They are deliberately CLI-only — no environment variables, no config keys —
-because a persisted default would silently change what gets submitted.
 
 | Flag | Meaning |
 |------|---------|
-| `--keep <bookmark>` | Keep an existing bookmark as a PR boundary (repeatable) |
-| `--new <rev>[=<name>]` | New bookmark at `rev` — `stakk-<change_id>` by default, or `name` (repeatable) |
-| `--new-auto <rev>` | New TF-IDF-named bookmark at `rev`, honoring `--auto-prefix` (repeatable) |
-| `--new-command <rev>` | New bookmark at `rev` named by `--bookmark-command` (repeatable) |
+| `--keep <bookmark>` | An existing bookmark stays a PR boundary |
+| `--new <rev>[=<name>]` | New bookmark at `rev`, named `name` or `stakk-<change_id>` |
+| `--new-auto <rev>` | New TF-IDF-named bookmark at `rev`, honoring `--auto-prefix` |
+| `--new-command <rev>` | New bookmark at `rev`, named by `--bookmark-command` |
 
-`rev` is a jj revset that resolves to exactly one commit:
-a `change_id` or `short_change_id` as printed by `stakk graph`, `@-`, a bookmark name,
-or any expression `jj log -r` accepts — it is handed to jj verbatim.
-A short id is only unique against the repository as it stands right now,
-so one stored and used later can fail with `stakk::selection::rev_unresolvable`,
-where the full `change_id` still resolves.
-In `--new <rev>=<name>`, the name starts at the first `=` outside parentheses and quotes,
-so a revset may carry keyword arguments (`remote_bookmarks(main, remote=origin)=<name>`).
+All are repeatable and CLI-only: no environment variables, no config keys.
 
-Submit flags belong after the subcommand.
-`stakk submit --dry-run` works; `stakk --dry-run submit` is rejected as an unexpected argument.
-`--config` and `--github-host` are the exceptions, accepted on either side.
+`rev` is a jj revset that resolves to exactly one commit, handed to `jj log -r` verbatim:
+a `change_id` or `short_change_id` from `stakk graph`, `@-`, a bookmark name, any revset expression.
+Use `change_id` for anything stored — a short id is unique only against the repository right now.
+In `--new <rev>=<name>` the name starts at the first `=` outside parentheses and quotes,
+so `remote_bookmarks(main, remote=origin)=<name>` works.
+
+Submit flags go after the subcommand: `stakk submit --dry-run`, not `stakk --dry-run submit`.
+Only `--config` and `--github-host` are accepted on either side.
 
 ## What the marks decide
 
-**The marks fully determine the PR set — nothing is implicit.**
-A commit becomes a PR boundary only if it is marked.
-
-**All marks must lie on one trunk-to-tip path**, and the topmost mark is the tip of the submission.
-Marks on diverging branches are rejected with `stakk::selection::not_colinear`.
-
-**Unmarked commits *below* the topmost mark fold into the PR above them.**
-The minimal selection produces the *fewest* PRs, not the most.
-
-**Commits *above* the topmost mark are not submitted at all.**
-An unbookmarked work-in-progress head is left out silently unless it is marked.
-A last segment with an empty `bookmarks` array is that head; `--new`,
-`--new-auto` or `--new-command` on its tip includes it.
+- **Marks fully determine the PR set.**
+  A commit is a PR boundary only if it is marked.
+- **All marks lie on one trunk-to-tip path**, and the topmost mark is the tip.
+  Anything else is `stakk::selection::not_colinear`.
+- **Unmarked commits below the topmost mark fold into the PR above them.** Fewer marks, fewer PRs.
+- **Commits above the topmost mark are not submitted.**
+  A last segment with an empty `bookmarks[]` is an unbookmarked head; mark its tip with `--new`,
+  `--new-auto` or `--new-command` to include it.
 
 ## Previewing
 
 `--dry-run` prints the planned bookmark creations and PR actions, then stops.
-It creates no bookmark, pushes nothing, and writes nothing to GitHub — though the plan phase does *read* GitHub,
-to find the pull requests that already exist.
-The plan it prints is the one a run without `--dry-run` executes.
-
-Three things it does not cover.
-A configured `--bookmark-command` runs under `--dry-run` too, during selection,
-both for `--new-command` marks and for TUI rows cycled to `[*]custom`.
-`--dry-run` returns before the execute phase,
-so it does not preview the *removal* of stack artifacts that `--stack-placement none` performs.
-For the same reason it does not preview the server-side stack changes of `--native-stacks`:
-the reconciliation under `on`/`auto`, which can dissolve and recreate existing stacks on GitHub,
-and the retirement `none` performs.
+It creates no bookmark, pushes nothing and writes nothing to GitHub, though the plan phase does read GitHub.
+Not covered: a configured `--bookmark-command` still runs during selection,
+and the execute-phase effects of `--stack-placement none` (removing stack artifacts) and `--native-stacks`
+(creating, dissolving or retiring server-side stacks) are not previewed.
 
 ## Diagnostics
 
-Selection failures carry machine-readable codes.
-None of them leaves the repository in a modified state — selection happens before anything is created or pushed.
+Selection failures carry machine-readable codes and leave the repository untouched.
 
 | Code | Meaning |
 |------|---------|
-| `stakk::selection::rev_unresolvable` | jj rejected the revset — unknown symbol, ambiguous id prefix, syntax error; the message carries jj's diagnosis |
-| `stakk::selection::rev_not_found` | The revset is valid but selects no commit |
-| `stakk::selection::rev_not_unique` | The revset selects more than one commit; a PR boundary is one commit |
-| `stakk::selection::rev_not_on_stack` | The commit exists but is on no submittable stack: trunk, immutable, revset-excluded, or an empty `@` (try `@-`) |
-| `stakk::selection::rev_immutable` | The commit is jj-immutable and cannot take a bookmark — see below |
-| `stakk::selection::empty_rev` | A selection flag was given an empty `REV`, e.g. from a shell expansion that produced nothing |
+| `stakk::selection::rev_unresolvable` | jj rejected the revset; the message carries jj's diagnosis |
+| `stakk::selection::rev_not_found` | The revset selects no commit |
+| `stakk::selection::rev_not_unique` | The revset selects more than one commit |
+| `stakk::selection::rev_not_on_stack` | The commit is on no submittable stack: trunk, immutable, revset-excluded, or an empty `@` (try `@-`) |
+| `stakk::selection::rev_immutable` | The commit is jj-immutable — see below |
+| `stakk::selection::empty_rev` | A selection flag got an empty `REV`, e.g. from a shell expansion |
 | `stakk::selection::invalid_new_spec` | A `--new` value is neither `REV` nor `REV=NAME` |
-| `stakk::selection::not_colinear` | The marks do not lie on a single trunk-to-tip path; each entry in `stacks[]` is one such path |
-| `stakk::selection::keep_not_found` | No such bookmark on the selected path; the names are in each segment's `bookmarks[]` |
-| `stakk::selection::no_stacks` | The repository has no bookmark stacks to select from |
+| `stakk::selection::not_colinear` | The marks are not on one trunk-to-tip path; each entry in `stacks[]` is one |
+| `stakk::selection::keep_not_found` | No such bookmark on the selected path |
+| `stakk::selection::no_stacks` | The repository has no stacks to select from |
 | `stakk::selection::duplicate_mark` | The same revision was marked twice; one boundary takes one mark, however many bookmarks it carries |
 | `stakk::selection::duplicate_name` | Two marks would create the same bookmark name |
-| `stakk::selection::name_exists` | The requested name is already taken by a local bookmark |
-| `stakk::selection::bookmark_command_not_configured` | `--new-command` was used without `--bookmark-command` |
+| `stakk::selection::name_exists` | The name is already a local bookmark |
+| `stakk::selection::bookmark_command_not_configured` | `--new-command` without `--bookmark-command` |
 
-An empty selection is not one of these: with no marks at all, `stakk submit` means the TUI,
-which without a terminal fails as `stakk::not_interactive` and exits `1`.
+With no marks at all, `stakk submit` means the TUI; without a terminal that is `stakk::not_interactive`, exit `1`.
 
 ## Immutable commits
 
-Commits jj considers immutable cannot take a new bookmark.
-The default bookmarks revset excludes `immutable()`,
-so a bookmark created there would be filtered out on every subsequent run —
-stakk would create a pull request it could never see or manage again.
-`--new <rev>` on such a commit fails with `stakk::selection::rev_immutable`,
-and `stakk graph` reports them as `is_immutable`.
+jj-immutable commits cannot take a new bookmark: the default bookmarks revset excludes `immutable()`,
+so stakk would create a PR it could never see or manage again.
+`--new <rev>` there fails with `stakk::selection::rev_immutable`, and `stakk graph` reports `is_immutable`.
+Either move the work onto mutable commits,
+or create the bookmark by hand and drop `~ immutable()` from `--bookmarks-revset`.
 
-There are two ways out, and they are repository-owner decisions rather than stakk configuration:
-move the work onto mutable commits, or create the bookmark manually
-and drop the `~ immutable()` term from `--bookmarks-revset`.
+## The `stakk graph` document
 
-## What `stakk graph` reports
-
-Enough here to act on; `stakk docs graph` has the field-by-field reference.
-
-`--format=json` is the **sparse** projection — identifiers, titles and states,
-which is everything the selection flags need.
+`--format=json` is sparse and has everything the selection flags need.
 `--format=json-full` adds `commit_id`, `description`, `author` and `files[]` to every commit,
-which is what reading commit messages or seeing which files changed requires — for a pull request description, say,
-or a bookmark name derived from the work itself.
+for reading commit messages or naming a bookmark from the work itself.
 Sparse is a strict subset of full, so paths never change between them.
-
-The document:
 
 ```text
 schema_version, default_branch, excluded_bookmarks[], excluded_head_count
 remotes[]        name, url, github ("owner/repo" | null)
 stacks[]
   segments[]     bookmarks[] {name, remote_state}
-    commits[]    (oldest first)
+    commits[]    oldest first: change_id, short_change_id, title,
+                 committer_timestamp, is_immutable, local_bookmark_names[],
+                 is_boundary, is_leaf
 ```
 
-Per commit, in both projections: `change_id`, `short_change_id`, `title`, `committer_timestamp`, `is_immutable`,
-`local_bookmark_names[]`, `is_boundary`, `is_leaf`.
+Three traps:
 
-Three properties of the document that are easy to trip on:
+- **`stacks[]` has no stable order**, and a stack has no name.
+  "The most recently modified stack" is the one with the highest `committer_timestamp` over its commits.
+- **`committer_timestamp` is offset-aware** (`2026-02-19T19:47:54+01:00`), so compare instants, not strings.
+- **`title` is empty** for a commit with no description — normal jj state, not an error.
 
-**The order of `stacks[]` is not part of the contract.**
-It tracks commit recency and shifts as soon as anyone commits.
-A stack has no name of its own either, and its tip need not carry a bookmark,
-so `committer_timestamp` is what identifies "the most recently modified stack":
-
-```console
-stakk graph --format=json | jq '
-  [.stacks[] | {
-     stack: .,
-     touched: ([.segments[].commits[].committer_timestamp] | max)
-   }] | max_by(.touched) | .stack'
-```
-
-**`committer_timestamp` is offset-aware** (`2026-02-19T19:47:54+01:00`),
-so comparing instants and comparing strings disagree: as text that value sorts after `2026-02-19T19:00:00Z`,
-while being twelve minutes earlier.
-The `jq` above is string-comparing, which is fine only for a repository whose commits share one offset;
-`stakk docs scripting` has a version that parses.
-
-**`title` is empty when a commit has no description.**
-That is an ordinary jj state rather than an error — `stakk graph`'s pretty format writes `(no description set)`,
-but the document reports the empty string.
-
-## Reading this later
-
-```console
-stakk docs agents >> AGENTS.md
-```
-
-Redirected, `stakk docs` emits the source verbatim, so that reproduces this file byte for byte.
-At a terminal it re-flows the prose to fit instead.
+Field by field: `stakk docs graph`.
+A parsing example: `stakk docs scripting`.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -4,97 +4,52 @@ summary: GitHub authentication: tokens, hosts, and troubleshooting.
 
 # Authentication
 
-stakk talks to the GitHub REST API with a token it resolves itself, per host, every time it runs.
-There is nothing to store and no stakk-specific login:
-if the GitHub CLI is already authenticated for the host your remote points at, stakk is authenticated too.
+stakk resolves a GitHub API token per host on every run; there is no stakk login and nothing stored.
+If the GitHub CLI is authenticated for the host your remote points at, stakk is too.
 
-Pushing is not part of this.
-Branches are pushed by `jj git push`, which uses your normal git credentials (SSH key or credential helper).
-The token below is used only for the API calls that create, update and comment on pull requests.
+Pushing is separate: `jj git push` uses your normal git credentials.
+The token covers only the API calls that create, update and comment on pull requests.
 
 ## Which host
 
-The **remote URL decides the host**, and the token is resolved for that host.
-`github.com` is always accepted; any other host has to be named first, through `--github-host`, `STAKK_GITHUB_HOST`,
-`github_host` in `stakk.toml`, or the GitHub CLI's own `GH_HOST`.
-That setting only says which hosts are *allowed* — it never overrides the URL,
-so a repo with both a github.com remote and an Enterprise remote works, each authenticated against its own host.
-
-The full precedence order for those settings: `stakk docs config`.
+The remote URL decides the host.
+`github.com` is always accepted; any other host must be named first, via `--github-host`, `STAKK_GITHUB_HOST`,
+`github_host` in `stakk.toml`, or the GitHub CLI's `GH_HOST` (precedence: `stakk docs config`).
+The setting only allows a host and never overrides the URL,
+so a repo with both a github.com remote and an Enterprise remote works, each against its own host.
 
 ## How the token is resolved
 
-stakk does not read your `gh` config or keyring itself.
-It **delegates to the GitHub CLI first** and only falls back to reading the environment:
+1. `gh auth token --hostname <host>` — `gh` answers with the environment token for that host if one is set,
+   otherwise with its stored credential.
+2. If `gh` is not installed or has no token for the host, stakk reads the host's variables itself:
 
-1. `gh auth token --hostname <host>`.
-   `gh` answers with a **token from the environment** when one is set for that host,
-   and with its **stored credential** otherwise.
-2. If `gh` is not installed, or has no token for the host, stakk reads the host's environment variables itself.
-
-Either way, the variables that apply depend on the host — a github.com token is never sent to an Enterprise host,
-or the other way around:
-
-| Host | Environment variables |
-|------|-----------------------|
+| Host | Variables, in precedence order |
+|------|--------------------------------|
 | `github.com` | `GH_TOKEN`, `GITHUB_TOKEN` |
 | anything else | `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN` |
 
-Both stakk and `gh` read them in the order listed — it is the precedence `gh help environment` documents.
-So when several are set, the winner is the same whether the token came from `gh` or from stakk's own fallback.
+The order is the one `gh help environment` documents, so both paths agree on which variable wins.
 
-One exception: `gh` treats a subdomain of `ghe.com` as github.com and reads `GH_TOKEN`/`GITHUB_TOKEN` there,
-while stakk treats every host other than github.com as Enterprise.
-On such a host the two disagree about which *variables* apply, not merely their order,
-so set `GH_ENTERPRISE_TOKEN` for stakk.
+- An exported token overrides `gh`'s stored credential immediately; no need to log out.
+- Empty variables are skipped, and a missing or logged-out `gh` is not an error.
+- Nothing is validated at resolution time: an expired token fails at the first API call.
+- `gh` treats subdomains of `ghe.com` as github.com, stakk treats them as Enterprise.
+  Set `GH_ENTERPRISE_TOKEN` there.
 
-Four details worth knowing:
-
-- **An exported token takes effect immediately.**
-  Because `gh auth token` returns the environment token when there is one,
-  setting `GH_TOKEN` overrides the credential `gh` has stored.
-  There is no need to log out of `gh` to make it apply.
-- **`--hostname` is always passed to `gh`.**
-  Without it `gh` would answer for whatever `GH_HOST` names, which need not be the host this repo's remote points at.
-- **Empty variables are skipped**, and a `gh` that is absent or not logged in for the host is not an error —
-  resolution simply falls through to stakk's own environment read.
-- **Nothing is validated at resolution time.**
-  An expired or revoked token resolves perfectly well and then fails at the first API call.
-
-A classic personal access token needs the `repo` scope.
-A fine-grained token needs write access to pull requests on the repositories you submit from.
+A classic personal access token needs the `repo` scope;
+a fine-grained token needs write access to pull requests on the repositories you submit from.
 
 ## Checking the setup
 
-`stakk` has no connectivity probe of its own; two commands cover it.
+`gh auth status --hostname <host>` names the token stakk will get.
 
-**`gh auth status --hostname <host>`** reports the token stakk will actually get: stakk asks `gh` for that host first,
-so whatever `gh` names here — an environment variable or its stored credential — is what stakk uses.
-It is the quickest way to confirm the setup.
-
-```sh
-gh auth status --hostname github.com
-```
-
-**`stakk submit --dry-run`** exercises the chain read-only.
-The remote and the token are resolved before the selection TUI opens, so a *missing* token fails immediately,
-with the diagnostic that names the problem.
-Nothing is validated at that point, though — a resolved-but-rejected token surfaces only once the API is called,
-and the API is not called until the plan phase, after the selection.
-Bare `stakk submit --dry-run` therefore stops at the TUI
-(or at `stakk::not_interactive` on a non-terminal stdin); add selection flags to reach the API:
-
-```sh
-stakk submit --dry-run --keep my-bookmark
-```
-
-`--dry-run` returns after printing the plan, so nothing is pushed, created or commented on.
-
-`stakk graph` is *not* an authentication check: it is offline and reads only jj, never the token.
+`stakk submit --dry-run --keep <bookmark>` exercises the chain read-only:
+a missing token fails before the TUI would open, a rejected one fails in the plan phase when the API is first called.
+Without selection flags the command stops at the TUI (or `stakk::not_interactive` without a terminal).
+`stakk graph` is offline and checks nothing.
 
 ## GitHub Enterprise Server
-
-Name the host, log in to it, and confirm:
 
 ```sh
 export GH_HOST=github.example.com
@@ -102,19 +57,15 @@ gh auth login --hostname github.example.com
 gh auth status --hostname github.example.com
 ```
 
-stakk then accepts remotes on that host and talks to its REST API at `https://<host>/api/v3`.
-The API base is always `https`, even for an `http://` remote:
-an Enterprise Server reachable only over plain HTTP is not supported.
+stakk then accepts remotes on that host and uses `https://<host>/api/v3`.
+The API base is always `https`, even for an `http://` remote; plain-HTTP servers are not supported.
 
 ## When it fails
 
-- **`stakk::auth::no_token`** — no token was found for the host.
-  Run `gh auth login --hostname <host>`, or set the variables listed above *for that host*.
-  The usual cause is a token set for the wrong one — `GITHUB_TOKEN` exported while the remote is an Enterprise host,
-  or vice versa.
-- **`stakk::auth::gh_cli_error`** — `gh` was found but could not be started.
-  A *missing* `gh` is not an error and falls through to the token variables,
-  but a `gh` that fails to launch aborts resolution before they are read — repair the installation.
-- **A 401 or 403 from the API** means a token *was* resolved and GitHub rejected it: expired, revoked,
-  or missing the scope above.
-  `gh auth status --hostname <host>` names the source, which tells you which token to replace.
+- **`stakk::auth::no_token`** — no token for the host.
+  The usual cause is a token set for the *other* kind of host.
+  `gh auth login --hostname <host>`, or set that host's variables.
+- **`stakk::auth::gh_cli_error`** — `gh` was found but could not be started; repair the installation.
+  A missing `gh` is fine, a broken one is not.
+- **401 or 403 from the API** — a token was resolved and GitHub rejected it: expired, revoked, or missing the scope.
+  `gh auth status --hostname <host>` names its source.

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,67 +4,41 @@ summary: Config files, precedence, and environment variables.
 
 # Configuration
 
-stakk loads settings from TOML config files, environment variables, and CLI flags.
+Precedence, highest first:
 
-The full precedence order, highest to lowest:
-
-1. **CLI flags** — `--remote`, `--pr-mode`, etc.
-2. **Environment variables** — `STAKK_REMOTE`, `STAKK_PR_MODE`, etc.
-3. **Repository config** — `stakk.toml`, found by walking up from the current directory
+1. **CLI flags** — `--remote`, `--pr-mode`, …
+2. **Environment variables** — `STAKK_REMOTE`, `STAKK_PR_MODE`, …
+3. **Repository config** — `stakk.toml`, found by walking up from the current directory to the jj workspace root
+   (the directory containing `.jj/`).
+   `--config <path>` or `STAKK_CONFIG` replaces it, which is also how to share one file across repos.
 4. **User config** — `~/.config/stakk/config.toml` (Linux),
    `~/Library/Application Support/stakk/config.toml` (macOS),
    `%APPDATA%\stakk\config\config.toml` (Windows)
 5. **Built-in defaults**
 
-## Config files
-
-stakk discovers config files automatically — no flags needed.
-
-**Repository config** is found by walking from the current directory toward the jj workspace root
-(the directory containing `.jj/`), stopping at the first `stakk.toml` found.
-The search does not continue past the repo root.
-To share config across multiple repos, use `--config` or the `STAKK_CONFIG` environment variable.
-
-**User config** is loaded from your platform's standard config directory.
-On Linux this is typically `~/.config/stakk/config.toml`.
-
-Both files use the same format.
-When both exist, settings from the repo config take precedence —
-the user config fills in any fields the repo config leaves unset.
+Repo and user config are merged field by field, the repo winning, unless the repo config sets `inherit = false`,
+which drops the user config entirely.
+All fields are optional; unknown fields are a parse error.
 
 ## Repo config runs with your privileges
 
-Discovery has no trust step, and a `stakk.toml` is often committed,
-so cloning a repository can hand you its configuration.
-Most keys only set a preference.
-Two do more:
+A `stakk.toml` is usually committed, so cloning a repository hands you its configuration with no trust step.
+Two keys act:
 
-- **`bookmark_command`** is run through `sh -c` (`cmd /C` on Windows) while stakk works out which bookmarks to create.
-  That happens in the first phase, so it runs before any GitHub call, with `--dry-run`, and with no valid token.
-- **`template_path`** reads whatever path it names — not only files inside the repo — and renders the contents into a
-  pull request comment or body, which is outward-facing.
+- **`bookmark_command`** runs through `sh -c` (`cmd /C` on Windows) during selection —
+  before any GitHub call, under `--dry-run`, and with no valid token.
+- **`template_path`** reads any path, inside the repo or not, and renders it into a pull request.
 
-The rest cannot act on their own.
-Revsets reach `jj` as arguments rather than through a shell, `pr_mode`, `stack_placement`, `native_stacks`,
-`sync_pr_content` and `trailers` are closed sets of values, `remote` has to name a remote that already exists,
-and `github_host` does nothing without a remote on that host.
+The rest only set preferences: closed value sets, revsets passed to `jj` as arguments, a remote that has to exist.
+Before running stakk in a repository you have not read, check those two keys.
+`--config <path>` swaps in a file you chose.
+Note that `inherit = false` also stops your user config from overriding the repo's values;
+only a flag or an environment variable can.
 
-So before running stakk in a repository you have not read, check whether it has a `stakk.toml`,
-and read those two keys if it does.
-Note also that `inherit = false` in a repo config suppresses your user config entirely,
-so a repo-supplied value cannot be overridden by yours — only by a flag or an environment variable.
-
-`--config <path>` (or `STAKK_CONFIG`) replaces the repo-level file rather than adding to it,
-which is the way to run in an untrusted repository with configuration you chose.
-
-## Config file format
-
-All fields are optional.
-Absent fields fall back to the next level in the precedence chain.
-Unknown fields cause a parse error, so typos are caught early.
+## All fields
 
 ```toml
-# stakk.toml — example with all available fields
+# stakk.toml — every field, with its default
 
 # Git remote to push to (default: "origin")
 remote = "origin"
@@ -73,36 +47,29 @@ remote = "origin"
 # (default: unset — falls back to GH_HOST; github.com is always accepted)
 github_host = "github.example.com"
 
-# PR creation mode: "regular" or "draft" (default: "regular")
+# "regular" (default) or "draft"
 pr_mode = "draft"
 
-# Path to a custom minijinja template for stack comments
-# (default: none — the built-in template is used)
-# Reads any path and renders it into a PR — see the trust note above.
+# Custom minijinja template for stack comments (default: built-in).
+# Reads any path — see the trust note above.
 template_path = "/path/to/my-template.md.jinja"
 
-# Where to place stack info: "comment", "body", "none", "ignore",
-# "auto-comment", or "auto-body" (default: "auto-comment", which is
-# identical to "comment" as long as native_stacks is "ignore")
-# "none" writes no stack info and removes existing stack comments/body
-# fences on the next submit. "ignore" writes no stack info and leaves
-# existing artifacts untouched. "auto-comment"/"auto-body" behave like
-# "none" on runs where a native server-side stack is in effect (see
-# native_stacks below) and like "comment"/"body" otherwise.
+# Where the stack overview lives: "comment", "body", "none", "ignore",
+# "auto-comment" (default) or "auto-body". "none" writes nothing and
+# removes existing stack comments and body fences; "ignore" writes
+# nothing and touches nothing. The auto modes behave like "none" on
+# runs where a native stack is in effect and like "comment"/"body"
+# otherwise, so the default equals "comment" while native_stacks is
+# "ignore". Details: stakk docs template
 stack_placement = "body"
 
-# Register submitted stacks with GitHub's native stacked pull requests
-# (public preview): "on", "auto", "none", or "ignore" (default:
-# "ignore"; the default may change to "auto" once the feature reaches
-# general availability)
-# "on" fails the submit if the feature is not available on the
-# repository; "auto" registers the stack where it is available and
-# skips silently where it is not. Like the placement modes, "none"
-# also removes — it registers nothing and dissolves the server-side
-# stacks that are standing — while "ignore" never touches the stack
-# API. A submission producing a single PR is not a stack and skips the
-# registration (and the "on" failure) entirely; "none" retires its
-# stacks anyway.
+# Register stacks with GitHub's native stacked pull requests (public
+# preview): "on" (fail where unavailable), "auto" (register where
+# available, skip silently where not), "none" (register nothing and
+# dissolve standing server-side stacks) or "ignore" (default; never
+# touch the stack API — may change to "auto" at general availability).
+# A single-PR submission is not a stack and skips the registration;
+# "none" retires its stacks anyway.
 native_stacks = "auto"
 
 # Prefix for auto-generated bookmark names (default: none)
@@ -110,136 +77,70 @@ auto_prefix = "gb-"
 
 # Revset for discovering bookmarks
 # (default: "mine() ~ trunk() ~ immutable()")
-# Note: the default excludes bookmarks on immutable commits. Stale
-# untracked remote bookmarks can pin commits immutable — clean them up
-# with `jj bookmark forget --include-remotes 'glob:<pattern>'`, or drop
-# the `~ immutable()` term for one run to include them.
+# Stale untracked remote bookmarks can pin commits immutable; clean
+# them up with `jj bookmark forget --include-remotes 'glob:<pattern>'`
+# or drop the `~ immutable()` term for one run.
 bookmarks_revset = "mine() ~ trunk() ~ immutable()"
 
 # Revset for discovering unbookmarked heads
 # (default: "heads((mine() ~ empty() ~ immutable()) & trunk()..)")
 heads_revset = "heads((mine() ~ empty() ~ immutable()) & trunk()..)"
 
-# Sync PR title/body from commits on every submit (default: "none")
-# Options: "none", "title", "body", "all"
+# Update existing PRs from commits: "none" (default), "title", "body"
+# or "all"
 sync_pr_content = "all"
 
-# How to handle git commit trailers in PR bodies (default: "keep")
-# Options: "keep", "strip"
+# Commit trailers in PR bodies: "keep" (default) or "strip"
 trailers = "strip"
 
-# Shell command for generating custom bookmark names
-# Runs via sh -c — see the trust note above.
+# Shell command for custom bookmark names — see the trust note above
 bookmark_command = "my-bookmark-namer"
 
-# Whether to merge with the user config (default: true)
-# Set to false in a repo config to ignore the user config entirely.
+# Merge with the user config (default: true). Only meaningful in a
+# repo config; false makes the repo file standalone, for team-enforced
+# settings.
 inherit = true
-```
-
-## The `inherit` field
-
-By default, repo config and user config are merged: the repo config wins for any field it sets,
-and the user config fills in the rest.
-If a repo needs to ignore the user config entirely
-(e.g. to enforce team-wide settings), set `inherit = false` in the repo-level `stakk.toml`:
-
-```toml
-# stakk.toml — standalone, ignores user config
-inherit = false
-pr_mode = "regular"
-stack_placement = "comment"
-```
-
-`inherit` only has meaning in a repo config.
-It is not merged from the user config.
-
-Enforcing settings this way works because the repo file wins and your own is skipped —
-which is also why a repo you have not read deserves a look first.
-See **Repo config runs with your privileges** above.
-
-## Examples
-
-**User config** — personal defaults across all repos:
-
-```toml
-# ~/.config/stakk/config.toml
-pr_mode = "draft"
-stack_placement = "body"
-```
-
-**Repo config** — override the remote for this repo, inherit everything else:
-
-```toml
-# stakk.toml (in repo root)
-remote = "upstream"
-```
-
-With both files above, `stakk submit` uses `remote = "upstream"` from the repo config and `pr_mode = "draft"`,
-`stack_placement = "body"` from the user config.
-Passing `--pr-mode regular` on the command line overrides all of them.
-
-**Team-enforced config** — no user config inheritance:
-
-```toml
-# stakk.toml (in repo root)
-inherit = false
-remote = "origin"
-pr_mode = "regular"
-stack_placement = "comment"
 ```
 
 ## GitHub Enterprise Server
 
 github.com is always accepted.
-To work against a GitHub Enterprise Server host, name that host — stakk then accepts remotes on it,
-and talks to its REST API at `https://<host>/api/v3`.
+Naming another host makes stakk accept remotes on it and use `https://<host>/api/v3` — always `https`,
+even for an `http://` remote.
+Any host not named is rejected, so an unrelated forge is never mistaken for GitHub.
 
-The host is resolved highest to lowest:
+Resolution, highest first:
 
-1. `--github-host <host>` — a global flag, so it works either side of the subcommand,
-   e.g. `stakk graph --github-host <host>`
+1. `--github-host <host>` — a global flag, accepted either side of the subcommand
 2. `STAKK_GITHUB_HOST`
 3. `github_host` in `stakk.toml`
-4. `GH_HOST` — the GitHub CLI's own setting, so an existing `gh` setup needs no stakk configuration
+4. `GH_HOST` — the GitHub CLI's own setting, so an existing `gh` setup needs nothing further
 
-Any other host is rejected, so an unrelated forge is never mistaken for GitHub.
-
-The token is resolved for the host the remote actually points at,
-so a github.com token is never sent to an Enterprise host, or the other way around.
-The per-host variables, the `gh auth login` commands that set the host up, and how to confirm the setup afterwards:
-`stakk docs auth`.
-
-Note that the API base is always `https`, even for an `http://` remote:
-an Enterprise Server reachable only over plain HTTP is not supported.
+Tokens are resolved for the host the remote points at, never sent across hosts: `stakk docs auth`.
 
 ## Environment variables
 
 | Variable | Description |
 |----------|-------------|
-| `STAKK_CONFIG` | Path to config file, overrides automatic discovery (overridden by `--config`) |
-| `STAKK_REMOTE` | Default git remote to push to (overridden by `--remote`) |
+| `STAKK_CONFIG` | Path to config file, replaces automatic discovery (overridden by `--config`) |
+| `STAKK_REMOTE` | Git remote to push to (overridden by `--remote`) |
 | `STAKK_GITHUB_HOST` | Extra host to treat as GitHub, for GitHub Enterprise Server (overridden by `--github-host`) |
-| `STAKK_PR_MODE` | PR creation mode: `regular` or `draft` (overridden by `--pr-mode`) |
-| `STAKK_TEMPLATE_PATH` | Path to a custom minijinja template for stack comments (overridden by `--template-path`) |
-| `STAKK_STACK_PLACEMENT` | Where to place the stack info: `comment`, `body`, `none`, `ignore`, `auto-comment` (default), or `auto-body` (overridden by `--stack-placement`) |
-| `STAKK_NATIVE_STACKS` | Register stacks with GitHub's native stacked PRs: `on`, `auto`, `none`, or `ignore` (default) (overridden by `--native-stacks`) |
+| `STAKK_PR_MODE` | `regular` or `draft` (overridden by `--pr-mode`) |
+| `STAKK_TEMPLATE_PATH` | Custom minijinja template for stack comments (overridden by `--template-path`) |
+| `STAKK_STACK_PLACEMENT` | `comment`, `body`, `none`, `ignore`, `auto-comment` (default) or `auto-body` (overridden by `--stack-placement`) |
+| `STAKK_NATIVE_STACKS` | `on`, `auto`, `none` or `ignore` (default) (overridden by `--native-stacks`) |
 | `STAKK_AUTO_PREFIX` | Prefix for auto-generated bookmark names (overridden by `--auto-prefix`) |
-| `STAKK_SYNC_PR_CONTENT` | Sync PR title/body from commits: `none` (default), `title`, `body`, or `all` (overridden by `--sync-pr-content`) |
-| `STAKK_TRAILERS` | Whether to keep or strip git commit trailers in PR bodies: `keep` (default) or `strip` (overridden by `--trailers`) |
-| `STAKK_BOOKMARK_COMMAND` | Shell command for generating custom bookmark names (overridden by `--bookmark-command`) |
+| `STAKK_SYNC_PR_CONTENT` | `none` (default), `title`, `body` or `all` (overridden by `--sync-pr-content`) |
+| `STAKK_TRAILERS` | `keep` (default) or `strip` (overridden by `--trailers`) |
+| `STAKK_BOOKMARK_COMMAND` | Shell command for custom bookmark names (overridden by `--bookmark-command`) |
 | `STAKK_BOOKMARKS_REVSET` | Revset for discovering bookmarks (overridden by `--bookmarks-revset`) |
 | `STAKK_HEADS_REVSET` | Revset for discovering unbookmarked heads (overridden by `--heads-revset`) |
-| `GH_HOST` | The GitHub CLI's host setting; used as the `github_host` fallback |
-| `GH_TOKEN` | GitHub personal access token for github.com (see `stakk docs auth`) |
-| `GITHUB_TOKEN` | Alternative to `GH_TOKEN` |
-| `GH_ENTERPRISE_TOKEN` | Access token for a GitHub Enterprise Server host |
-| `GITHUB_ENTERPRISE_TOKEN` | Alternative to `GH_ENTERPRISE_TOKEN` |
+| `GH_HOST` | The GitHub CLI's host setting; the `github_host` fallback |
+| `GH_TOKEN`, `GITHUB_TOKEN` | Token for github.com, in that order (see `stakk docs auth`) |
+| `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN` | Token for any other host, in that order |
 
-`STAKK_DRAFT` and `STAKK_TEMPLATE` are gone: `STAKK_PR_MODE=draft` replaces the first, `STAKK_TEMPLATE_PATH` the second.
-A stale one is not an error — stakk cannot know the variable is still meant for it —
-but `stakk submit` warns on stderr while either is set.
-Unset it to fix the setting, or set it empty to silence the warning.
+`STAKK_DRAFT` and `STAKK_TEMPLATE` are retired in favour of `STAKK_PR_MODE=draft` and `STAKK_TEMPLATE_PATH`;
+`stakk submit` warns while either is set.
 
-`--dry-run` and the selection flags (`--keep`, `--new`, `--new-auto`, `--new-command`) deliberately have no environment
-variables or config keys: they are per-invocation decisions, and a persisted default would be surprising.
+`--dry-run` and the selection flags (`--keep`, `--new`, `--new-auto`, `--new-command`) have no environment variables
+or config keys on purpose: they are per-invocation decisions.

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -4,144 +4,84 @@ summary: The `stakk graph` document, field by field.
 
 # The `stakk graph` document
 
-`stakk graph` renders the change graph.
-`--format=pretty` (the default) draws it for a human;
-`--format=json` and `--format=json-full` emit a schema-versioned document for a machine.
+`stakk graph` renders the change graph: `--format=pretty` (default) for a human,
+`--format=json` and `--format=json-full` as a schema-versioned document for a machine.
+It is offline — jj only — so it needs no network or credentials.
 
-It is offline.
-It queries `jj` and nothing else, so it is cheap, safe to run at any time, and works without network or credentials.
-
-## What is not in it
-
-No pull request state.
-Not whether a PR exists, not its number, title, review status or CI result.
-Nothing here has been near GitHub.
-
-The closest thing is `remote_state`, which says where a *bookmark* stands against its remote — see **Segments** below.
-A pushed bookmark need not have a pull request, and stakk only learns which do during `stakk submit`'s plan phase.
+Nothing in it has been near GitHub: no PR numbers, titles, review or CI state.
+`remote_state` (below) says where a *bookmark* stands against its remote, which is not the same thing;
+stakk learns which PRs exist during `stakk submit`'s plan phase.
 
 ## Two projections, one schema
 
-`--format=json` is **sparse**: enough to pinpoint a segment, drive `stakk submit`, and judge what a submission would do.
-`--format=json-full` is the **full** document.
-
-Sparse is a strict subset of full — every sparse field appears in full under the same name,
-with the same type and the same value — so a consumer can move between them without rewriting its paths.
-Both report the same `schema_version`.
-
-Sparse is the discovery format because commit bodies, author blocks and `files[]` dominate the byte count:
-dropping them shrinks the document by close to an order of magnitude on a repository like this one,
-and the gap widens with commit-message length.
-`json-full` is what carries commit messages and the files a commit touched.
+`--format=json` is **sparse**: identifiers, titles and states — enough to drive `stakk submit`.
+`--format=json-full` adds commit bodies, authors and files, which dominate the byte count.
+Sparse is a strict subset of full (same names, types, values), and both report the same `schema_version`.
 
 ## Top level
 
-Both projections carry:
-
 - `schema_version` — currently `2`; bumped on breaking schema changes
 - `default_branch`
-- `remotes[]` — `name`, `url`, `github` (`owner/repo`, or `null` for
-  non-GitHub remotes)
-- `excluded_bookmarks[]` — names of bookmarks left out of the graph because
-  of merge commits in their history
-- `excluded_head_count` — unbookmarked heads left out for the same reason,
-  counted rather than named because they have no name to report
-- `stacks[]` — one per leaf, trunk-to-leaf
-
-A non-empty `excluded_bookmarks` means stakk cannot manage those bookmarks: their history contains a merge,
-which the stacking model does not represent.
+- `remotes[]` — `name`, `url`, `github` (`owner/repo`, or `null` for a non-GitHub remote)
+- `excluded_bookmarks[]` — bookmarks left out because their history contains a merge, which the stacking model
+  does not represent; stakk cannot manage these
+- `excluded_head_count` — unbookmarked heads left out for the same reason, counted because they have no name
+- `stacks[]` — one per leaf
 
 ## Stacks
 
-One entry per leaf of the graph.
-Shared ancestor segments are repeated in full in every stack that contains them,
-so each entry is self-contained and no joining across entries is needed.
+One entry per leaf, segments trunk-to-leaf.
+Shared ancestor segments are repeated in full in every stack containing them, so each entry is self-contained.
 
 **The order is not part of the contract.**
-Stacks are sorted by commit recency, newest first, compared as instants and tie-broken deterministically —
-but that is an implementation detail, it is not the TUI's leaf numbering,
-and `stacks[0]` moves as soon as anyone commits anywhere in the repository.
-
-What identifies a stack is its content.
-`committer_timestamp` is in the sparse projection precisely so
-that a consumer wanting "the most recently modified stack" can compute it rather than rely on a position.
+It follows commit recency, so `stacks[0]` changes whenever anyone commits, and it is not the TUI's leaf numbering.
+Identify a stack by its content; `committer_timestamp` is in the sparse projection
+so "the most recently modified stack" can be computed rather than assumed.
 
 ## Segments
 
 A segment is a run of commits ending at a PR boundary.
 
-- `bookmarks[]` — `name` and `remote_state` for each bookmark on the boundary commit.
-  Empty for the unbookmarked head segment
-- `commits[]` — oldest first (trunk side first), matching the
-  `--bookmark-command` payload convention
+- `bookmarks[]` — `name` and `remote_state` per bookmark on the boundary commit; empty for an unbookmarked head
+- `commits[]` — oldest first, matching the `--bookmark-command` payload
 
-`remote_state` is one of:
-
-| Value | Meaning |
-|-------|---------|
+| `remote_state` | Meaning |
+|----------------|---------|
 | `unpushed` | No remote bookmark of this name on this commit, on any remote. A push creates it |
-| `diverged` | A tracked remote disagrees with the local bookmark — the usual state after a rebase or an amend. A push moves it |
-| `synced` | A remote bookmark of this name sits on this commit, on *some* remote. See the caveat below |
-
-Two `jj` facts produce this, and neither is sufficient alone.
-`jj`'s own `synced()` is false only when a *tracked* remote disagrees with the local bookmark,
-so a never-pushed bookmark reports `synced = true` exactly like an up-to-date one.
-What separates them is whether a remote bookmark of the same name sits on the boundary commit. jj's internal `name@git`
-remote does not count — it tracks the colocated git repository, not a push target.
+| `diverged` | A tracked remote disagrees with the local bookmark — the usual state after a rebase or amend. A push moves it |
+| `synced` | A remote bookmark of this name sits on this commit, on *some* remote |
 
 **`remote_state` does not know which remote you push to.**
-`stakk graph` takes no `--remote`, so any remote but `name@git` satisfies the match.
-In a repository with more than one remote,
-a bookmark that exists on `mirror` but was never pushed to `origin` reports `synced`,
-and `stakk submit --remote origin` then pushes it for the first time.
-With a single remote — the ordinary case — `synced` does mean a push would be a no-op.
-Read `remotes[]` when the distinction matters.
+`stakk graph` takes no `--remote`, so with several remotes a bookmark on `mirror`
+but never pushed to `origin` reports `synced`.
+With one remote, `synced` does mean a push is a no-op. jj's internal `name@git` never counts.
 
-A commit can carry several bookmarks, so `bookmarks[]` can have more than one entry.
-They are one boundary, not several: two `--keep`s naming two bookmarks on the same commit are two marks on one boundary,
-which fails as `stakk::selection::duplicate_mark`.
+Several bookmarks on one commit are one boundary: two `--keep`s naming them is `stakk::selection::duplicate_mark`.
 
 ## Commits
 
-Sparse carries:
+In both projections:
 
-- `change_id`, `short_change_id` — identifiers; either can be passed to `stakk submit`'s selection flags.
-  `short_change_id` is jj's shortest prefix that is unique *right now*, often only one or two characters,
-  so it can stop being unique as the repository grows.
-  Pass `change_id` when the value is stored rather than used immediately,
-  or the later run may fail with `stakk::selection::rev_unresolvable`
-- `title` — the first line of the commit message.
-  Empty when the commit has no description, which is a normal jj state;
-  the `(no description set)` wording belongs to the pretty renderer, never to the document
-- `committer_timestamp` — offset-aware, e.g. `2026-02-19T19:47:54+01:00`.
-  This is the key stack order is derived from,
-  and it is in the sparse projection so a consumer can reproduce that order or impose its own.
-  Compare instants, not strings: as text that value sorts *after* `2026-02-19T19:00:00Z`
+- `change_id`, `short_change_id` — either works in the selection flags.
+  The short form is jj's shortest prefix unique *right now*, so store `change_id`,
+  or a later run may fail with `stakk::selection::rev_unresolvable`
+- `title` — first line of the commit message; empty when there is no description
+  (`(no description set)` belongs to the pretty renderer, never to the document)
+- `committer_timestamp` — offset-aware, e.g. `2026-02-19T19:47:54+01:00`; the key stack order is derived from.
+  Compare instants, not strings: that value sorts after `2026-02-19T19:00:00Z` as text
   while being twelve minutes earlier
-- `is_immutable` — jj considers the commit immutable, so it cannot take a
-  new bookmark
-- `local_bookmark_names[]` — unfiltered; includes bookmarks the bookmarks
-  revset excluded, unlike the segment's `bookmarks[]`
-- `is_boundary` — the newest commit of its segment.
-  For a bookmarked segment that is the commit the bookmarks point at; an unbookmarked head segment has one too,
-  pointing at nothing
+- `is_immutable` — cannot take a new bookmark
+- `local_bookmark_names[]` — unfiltered; includes bookmarks the bookmarks revset excluded,
+  unlike the segment's `bookmarks[]`
+- `is_boundary` — the newest commit of its segment
 - `is_leaf` — the tip of its stack
 
-`--format=json-full` adds, on every commit:
-
-- `commit_id`
-- `description` — the full commit message, `title` line included
-- `author` — `name`, `email`, `timestamp`
-- `files[]`
-
-Those four are *absent* from sparse, not null.
-A consumer that reads `.description`, `.author`,
-`.files` or `.commit_id` from `--format=json` moves to `--format=json-full`.
-
-Note that `author.timestamp` and `committer_timestamp` are different fields answering different questions.
-Stack order follows the committer timestamp, because that is what a rebase updates.
+`--format=json-full` adds `commit_id`, `description` (the full message, `title` line included), `author`
+(`name`, `email`, `timestamp`) and `files[]`.
+They are *absent* from sparse, not null.
+Stack order follows `committer_timestamp`, not `author.timestamp`, because a rebase updates the former.
 
 ## Stability
 
-Field names, types and the sparse/full subset relationship are covered by the `schema_version`.
-The **order of `stacks[]` is not**, and neither is the pretty format, which is for humans and free to change.
+Field names, types and the sparse/full subset relationship are covered by `schema_version`.
+The order of `stacks[]` and the pretty format are not.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -4,60 +4,37 @@ summary: Driving stakk from a program: exit codes and a worked example.
 
 # Scripting stakk
 
-Driving `stakk` from a program: exit codes, the properties that matter to automation, and a worked example.
+Exit codes and a worked example.
+The submission model and diagnostic codes are in `stakk docs agents`, the JSON schema in `stakk docs graph`,
+and what a program may rely on across releases in `stakk docs stability`.
 
-Three other topics carry the rest.
-`stakk docs agents` has the submission model — the selection flags,
-the rules that decide which commits become pull requests, and the diagnostic codes.
-`stakk docs graph` has the JSON schema field by field.
-`stakk docs stability` has what a program may rely on across releases, and what it may not.
+## Properties that matter to a program
 
-## Properties worth knowing
-
-**`stacks[]` has no stable order.**
-It tracks commit recency and shifts as soon as anyone commits,
-so an index into it means something different on the next run.
-Matching a bookmark name or comparing `committer_timestamp` does not.
-
-**A stack need not carry a bookmark.**
-A branch whose tip was never bookmarked still appears, with an empty `bookmarks[]` on its last segment,
-so a name is not available as an identifier for every stack.
-
-**`committer_timestamp` is offset-aware.**
-`2026-02-19T19:47:54+01:00` sorts after `2026-02-19T19:00:00Z` as a string while being twelve minutes earlier
-as an instant, so the two comparisons disagree across offsets.
-
-**`short_change_id` is unique only right now.**
-It is jj's shortest unique prefix at the moment of the query, often one or two characters.
-A value stored, passed between processes,
-or computed well before use can fail as `stakk::selection::rev_unresolvable` later,
-where the full `change_id` still resolves.
-The selection flags take any jj revset, so `@`, `@-` and bookmark names resolve too;
-the ids from this document are the form that survives being stored.
-
-**stakk's exit code carries the outcome.**
-A wrapper that discards it turns a stopped submission into a silent one.
+- **`stacks[]` has no stable order** and a stack need not carry a bookmark.
+  Select by bookmark name or by `committer_timestamp`, never by index.
+- **`committer_timestamp` is offset-aware.**
+  `2026-02-19T19:47:54+01:00` sorts after `2026-02-19T19:00:00Z` as a string while being earlier as an instant.
+- **`short_change_id` is unique only right now.**
+  Store and pass `change_id`; the short form can later fail as `stakk::selection::rev_unresolvable`.
+- **The exit code carries the outcome.**
+  A wrapper that discards it turns a stopped submission into a silent one.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success. `--help` and `--version` also exit `0` |
-| `1` | stakk failed; the diagnostic, with its `stakk::…` code, is on stderr |
-| `2` | Usage error — unknown flag, unknown subcommand, invalid enum value |
+| `0` | Success (`--help` and `--version` too) |
+| `1` | stakk failed; the diagnostic with its `stakk::…` code is on stderr |
+| `2` | Usage error — unknown flag, subcommand or enum value (clap's convention, not stakk's contract) |
 | `130` | Interrupted (`Ctrl-C` in the TUI) |
 
-`2` comes from clap, stakk's argument parser, rather than from stakk itself,
-so it follows clap's usage-error convention rather than stakk's stability contract.
-
-Note that `stakk submit` with no selection flags means the TUI.
-Without a terminal that is `stakk::not_interactive` and exit `1`,
-which is what an empty selection looks like when a shell substitution expands to nothing.
+`stakk submit` with no selection flags means the TUI; without a terminal that is `stakk::not_interactive`, exit `1`.
+That is what an empty selection looks like when a shell substitution expands to nothing.
 
 ## A worked example
 
-Submits the most recently modified stack, keeping the bookmarks it already has and auto-naming an unbookmarked tip.
-Requires Python 3.11 or newer for `datetime.fromisoformat` to accept jj's offsets and `Z` suffix.
+Submits the most recently modified stack, keeping its bookmarks and auto-naming an unbookmarked tip.
+Python 3.11 or newer, for `datetime.fromisoformat` to accept jj's offsets.
 
 ```python
 #!/usr/bin/env python3
@@ -73,7 +50,7 @@ from datetime import datetime
 
 
 def graph_json() -> dict:
-    """stakk graph is offline: it queries jj only, never GitHub."""
+    """stakk graph is offline: jj only, never GitHub."""
     proc = subprocess.run(
         ["stakk", "graph", "--format=json"],
         capture_output=True,
@@ -86,13 +63,7 @@ def graph_json() -> dict:
 
 
 def last_touched(stack: dict) -> datetime:
-    """When this stack was last modified.
-
-    Parsed rather than string-compared: jj emits offset-aware
-    timestamps, so "2026-02-19T19:47:54+01:00" sorts after
-    "2026-02-19T19:00:00Z" as text while being twelve minutes
-    earlier as an instant.
-    """
+    """Parsed, not string-compared: the timestamps are offset-aware."""
     return max(
         datetime.fromisoformat(commit["committer_timestamp"])
         for segment in stack["segments"]
@@ -101,12 +72,7 @@ def last_touched(stack: dict) -> datetime:
 
 
 def latest_stack(stacks: list) -> dict:
-    """The most recently modified stack.
-
-    Chosen explicitly rather than by taking stacks[0]: the document's
-    order is not part of the contract, and a stack need not carry a
-    bookmark to be identified by name.
-    """
+    """Chosen by content: the order of stacks[] is not a contract."""
     if not stacks:
         sys.exit("no bookmark stacks in this repository")
     return max(stacks, key=last_touched)
@@ -117,12 +83,12 @@ def selection_flags(stack: dict) -> list:
     flags = []
     for segment in stack["segments"]:
         if segment["bookmarks"]:
-            # One mark per segment, not per name. Two marks on one
+            # One mark per segment, not per name: two marks on one
             # commit is stakk::selection::duplicate_mark.
             flags.append(f"--keep={segment['bookmarks'][0]['name']}")
             continue
         # The unbookmarked head, always last when present. Unmarked,
-        # it sits above the topmost boundary and is not submitted.
+        # it is above the topmost boundary and not submitted.
         tip = segment["commits"][-1]
         if tip["is_immutable"]:
             print(
@@ -130,14 +96,14 @@ def selection_flags(stack: dict) -> list:
                 file=sys.stderr,
             )
             continue
-        # change_id, not short_change_id: short prefixes are unique
+        # change_id, not short_change_id: the short form is unique
         # only against the repository as it stands right now.
         flags.append(f"--new-auto={tip['change_id']}")
     return flags
 
 
 def describe(stack: dict) -> None:
-    """Report what a submission would touch, before touching it."""
+    """What a submission would push, known before touching GitHub."""
     for segment in stack["segments"]:
         for bookmark in segment["bookmarks"]:
             print(f"  {bookmark['name']}: {bookmark['remote_state']}")
@@ -148,8 +114,7 @@ def submit(flags: list, dry_run: bool) -> None:
     argv = ["stakk", "submit", *flags]
     if dry_run:
         argv.append("--dry-run")
-    # The child inherits this stdout. Python block-buffers when stdout is
-    # a pipe, so without the flush our own lines land after stakk's.
+    # The child inherits stdout; flush so our lines land before its.
     sys.stdout.flush()
     proc = subprocess.run(argv)
     if proc.returncode != 0:
@@ -176,12 +141,9 @@ if __name__ == "__main__":
     main()
 ```
 
-`describe` is there to show what `remote_state` makes possible: it comes out of `stakk graph` without touching GitHub,
-so a script can report what a submission would do — "two already pushed, one new" — before running it.
-
 ## The same thing in shell
 
-For the common case where every segment is already bookmarked:
+When every segment is already bookmarked and the repository has one stack:
 
 ```console
 stakk submit $(stakk graph --format=json \
@@ -190,6 +152,5 @@ stakk submit $(stakk graph --format=json \
            | "--keep=\(.bookmarks[0].name)"')
 ```
 
-This indexes `.stacks[0]`, so it picks whichever stack is currently newest rather than a chosen one,
-and a segment with no bookmark is filtered out rather than reported — an unbookmarked tip is silently left unsubmitted.
-Both are fine for a one-off in a single-stack repository, and both are why the Python version is longer.
+This takes whichever stack is currently newest and silently leaves an unbookmarked tip unsubmitted —
+the two shortcuts the Python version avoids.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -5,77 +5,64 @@ summary: What semantic versioning covers, and what may change in any release.
 # Stability
 
 stakk follows semantic versioning.
-This document is the contract: the surface a script, an agent, or another tool may rely on,
-and the surface that may move under it without notice.
+This document is the contract: what a script, an agent or another tool may rely on, and what may move under it.
 
 The *wording* of this document is not itself stable — it is a `stakk docs` topic,
-and those are free to be reworded or restructured at any time.
-What it describes is.
-The contract changes when the contract changes, in a release that says so.
+and those may be rewritten at any time.
+What it describes is; the contract changes in a release that says so.
 
 ## Stable
 
 Changing any of these needs a major release.
 
 - **Subcommand names, their aliases, and their flags.**
-  An alias is as binding as the name it stands for: removing one needs a major release, same as removing a flag.
+  Removing an alias is as breaking as removing a flag.
 - **`STAKK_`-prefixed environment variables.**
-- **Config file keys and their defaults.**
-  Precedence and the full key list: `stakk docs config`.
-- **The `stakk graph` JSON document, under its `schema_version`** — field names, types and meanings.
-  It is currently `2`, and both the sparse `json` and the `json-full` projection report it.
-  Sparse stays a strict subset of full.
+- **Config file keys and their defaults.** The list: `stakk docs config`.
+- **The `stakk graph` JSON document under its `schema_version`** — field names, types and meanings.
+  Currently `2`, reported by both the sparse `json` and the `json-full` projection;
+  sparse stays a strict subset of full.
   The *order* of `stacks[]` is not part of this.
   Field by field: `stakk docs graph`.
 - **The JSON handed to `--bookmark-command` on stdin**, under its own `schema_version` (currently `1`).
-  The schema, with a worked example, is in `stakk submit --help`.
+  The schema is in `stakk submit --help`.
 - **Exit codes:** `0` success, `1` failure, `130` interrupted.
   `2` is clap's usage-error convention and follows clap, not this contract.
-  The table, and the rules a program should follow around it: `stakk docs scripting`.
+  Details: `stakk docs scripting`.
 
 ## Deprecated
 
-Still supported, and still covered by the rules above until the major release that removes them.
-Listed here so a script has notice rather than a surprise.
+Still supported and still covered by the rules above until the major release that removes them.
 
-- **`stakk show`** — an alias for `stakk graph`.
-  The command builds and renders the change graph, and `show` says nothing about that;
-  in jj's own vocabulary `show` is a single commit, which is the opposite of what this prints.
-  The alias works exactly as `stakk graph` does and will be removed in the next major release.
-  Migration is the command name and nothing else: flags, output, `--format` values and `schema_version` are unchanged.
+- **`stakk show`** — an alias for `stakk graph`, to be removed in the next major release.
+  The command renders the change graph and `show` says nothing about that
+  (in jj's vocabulary `show` is a single commit).
+  Migration is the command name only; flags, output and `schema_version` are unchanged.
 
 ## Not stable
 
 These may change in any release.
 
 - **The rendered text of `stakk docs` and `--help`.**
-  Topics may be added, reworded, or restructured at any time; only the `stakk docs <topic>` invocation shape is stable.
+  Only the `stakk docs <topic>` invocation shape is stable.
 - **The order of `stacks[]` in the `stakk graph` JSON.**
-  It tracks commit recency, so it moves as you commit anywhere in the repository,
-  and it is computed separately from the TUI's leaf numbering.
-  Choose a stack by its bookmark names or its contents, never by index.
+  Choose a stack by its bookmarks or contents, never by index.
 - **The `pretty` output of `stakk graph`.**
-  It is drawn for a human; `--format=json` is the one for a program.
+  `--format=json` is the one for a program.
 - **The TUI layout and keybindings.**
 - **Spinner and progress text.**
 - **Diagnostic codes (`stakk::…`) and error wording.**
-  A code is still what a program should match on.
-  Prose may be rewritten silently; a code that is added, split, merged or renamed is listed in the changelog.
-  The set of codes itself may change in any release as the error model settles.
-  Treat an unknown code as a plain failure; the exit code is the signal.
-- **Advisory warnings printed to stderr.**
-  They may be added or removed in any release,
-  so a program must not depend on one appearing and must not treat stderr output as failure.
-  The exit code is the signal.
-- **The server-side behavior behind `--native-stacks`.**
-  The flag and its values are stable surface like any other,
-  but GitHub's stacked pull requests are a public preview the vendor declares subject to change,
-  so the reconciliation's observable effect on GitHub — what a registered stack looks like,
-  when GitHub retargets or rebases — can move without a stakk release at all,
-  and stakk may adjust how it converges the stack (create, append, dissolve-and-recreate) in any release.
+  A code is still what a program should match on; prose may change silently, and a code that is added, split,
+  merged or renamed is listed in the changelog.
+  Treat an unknown code as a plain failure — the exit code is the signal.
+- **Advisory warnings on stderr.**
+  They come and go; stderr output is not failure, the exit code is.
+- **The server-side behaviour behind `--native-stacks`.**
+  The flag and its values are stable surface, but GitHub's stacked pull requests are a public preview,
+  so what a registered stack looks like and when GitHub retargets or rebases can move without a stakk release,
+  and stakk may change how it converges the stack (create, append, dissolve-and-recreate) in any release.
 
 ## Not a breaking change
 
 **Raising the minimum supported jj version.**
-The check is warn-only — stakk runs against an older jj and says so — so the floor can move in any release,
-normally the one that actually adopts a newer jj's behaviour.
+The check is warn-only, so the floor can move in any release — normally the one that adopts a newer jj's behaviour.

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,105 +4,85 @@ summary: Stack info placement and stack comment templates.
 
 # Stack info and templates
 
-Where stakk writes the stack overview on each PR, and how to customize what it says.
+Where stakk writes the stack overview on each PR, and how to change what it says.
 
 ## Placement
 
-`--stack-placement` (or `stack_placement` in a config file, or `STAKK_STACK_PLACEMENT`) decides
-where the stack overview lives on each PR:
+`--stack-placement` (`stack_placement`, `STAKK_STACK_PLACEMENT`):
 
 | Mode | Writes | Removes existing stack comments/body fences |
 |------|--------|---------------------------------------------|
-| `comment` | A separate PR comment, updated in place | Yes, when migrating from `body` |
-| `body` | A fenced section in the PR body (`STAKK_BODY_START` … `STAKK_BODY_END`) | Yes, when migrating from `comment` |
-| `none` | Nothing | Yes, on every submit |
-| `ignore` | Nothing | No — existing artifacts are left exactly as they are |
-| `auto-comment` (default) | Like `none` when a native stack is in effect, like `comment` otherwise | Follows the mode it resolves to |
-| `auto-body` | Like `none` when a native stack is in effect, like `body` otherwise | Follows the mode it resolves to |
+| `comment` | A PR comment, updated in place | When migrating from `body` |
+| `body` | A fenced section in the PR body (`STAKK_BODY_START` … `STAKK_BODY_END`) | When migrating from `comment` |
+| `none` | Nothing | On every submit |
+| `ignore` | Nothing | Never |
+| `auto-comment` (default) | Like `none` when a native stack is in effect, like `comment` otherwise | Follows the resolved mode |
+| `auto-body` | Like `none` when a native stack is in effect, like `body` otherwise | Follows the resolved mode |
 
-Switching between `comment` and `body` migrates automatically.
-Content you write outside the body fences is preserved; the fenced section itself is overwritten on every run.
+Content outside the body fences is preserved; the fenced section is overwritten on every run.
 
-`none` and `ignore` both write no stack info — the difference is what happens to whatever is already on the PR.
-Use `none` to retire stakk's stack comments cleanly (for example when moving to GitHub's own stacked-PR UI).
-Use `ignore` to leave the existing comments and fences frozen in place — handy while trying another tool,
-or when another process owns that part of the PR.
-Neither mode reads or compiles a custom `--template-path`,
-so a broken template cannot fail a submission that will not render it.
+`none` retires stakk's stack info cleanly; `ignore` leaves whatever is on the PR frozen,
+for when another tool or process owns it.
+Neither reads or compiles a custom `--template-path`.
 
-`auto-comment` and `auto-body` defer to `--native-stacks`
-(see `stakk submit --help`):
-on a run where the server-side stack was registered, GitHub's own stack rendering replaces stakk's text,
-so they behave like `none` and retire it; on every other run they behave like `comment`/`body`.
-The retirement requires a *definitive* native stack —
-if stack registration failed for a reason that says nothing about availability
-(a transient network error, say),
-the auto modes still write: a redundant overview self-heals on the next successful run,
-while a skipped update would leave a stale one standing.
-While `--native-stacks` is `ignore` (its default) or `none`,
-`auto-comment` and `auto-body` are exactly `comment` and `body` —
-which is why `auto-comment` can be the default placement without changing any behavior:
-the intended zero-config end state once GitHub's feature reaches general availability is a single default flip of
-`native_stacks` to `auto`, giving native rendering where enabled and stack comments everywhere else, never both.
+The auto modes defer to `--native-stacks`: when the server-side stack was registered on this run,
+GitHub's own rendering replaces stakk's text, so they behave like `none`; otherwise like `comment`/`body`.
+Retirement needs a *definitive* native stack.
+If registration failed for a reason that says nothing about availability
+(a network error, say),
+the auto modes still write — a redundant overview self-heals on the next successful run, a skipped one goes stale.
+While `--native-stacks` is `ignore` (its default) or `none`, the auto modes are exactly `comment` and `body`,
+which is why `auto-comment` is the default:
+the intended end state is a single default flip of `native_stacks` to `auto`,
+giving native rendering where enabled and stack comments everywhere else, never both.
 
-A submission that produces a single PR is not a stack: no stack info is written, and stale artifacts from an earlier,
+A submission producing a single PR is not a stack: no stack info is written, and stale artifacts from an earlier,
 larger stack are cleaned up (unless the mode is `ignore`).
 
 ## Templates
 
-Stack comments are rendered with [minijinja](https://github.com/mitsuhiko/minijinja).
-`--template-path <path>` (or `template_path` in a config file, or `STAKK_TEMPLATE_PATH`) replaces the built-in template.
+Stack comments are rendered with [minijinja](https://github.com/mitsuhiko/minijinja); `--template-path <path>`
+(`template_path`, `STAKK_TEMPLATE_PATH`) replaces the built-in template.
 
 The context holds `stack`, `stack_size`, `default_branch`, `current_bookmark` and `stakk_url`.
-The `stack` array is ordered **trunk-first** — `position` is 1 for the entry nearest the trunk.
-The default template reverses it (`stack | reverse`) so the rendered graph reads leaf-at-top,
-matching `stakk graph` and the TUI.
-
+`stack` is ordered **trunk-first** (`position` 1 nearest the trunk); the default template reverses it
+(`stack | reverse`) so the result reads leaf-at-top like `stakk graph` and the TUI.
 Each entry carries `bookmark_name`, `pr_url`, `pr_number`, `title`, `base`, `is_draft`, `position`,
-`is_current` and `is_leaf` — the last is true for the tip of the stack, the entry furthest from the trunk.
-`stakk submit --help` prints the same list with a worked example template.
-Note that `title` is the *commit-derived* title,
-which can differ from the PR's live title on GitHub when `--sync-pr-content` does not include titles.
-The default template deliberately shows the bare `pr_url` and no link text of its own,
-so the comment cannot contradict the PR page:
-GitHub renders the link as a reference carrying the PR's live title and merge state.
-The bookmark name is not written next to it — the reference is the whole label.
+`is_current` and `is_leaf`.
+`stakk submit --help` prints the same list with a worked example.
 
-Two things are added outside the template and cannot be overridden:
+`title` is the *commit-derived* title,
+which can differ from the PR's live title when `--sync-pr-content` excludes titles.
+That is why the default template shows the bare `pr_url` and no text of its own:
+GitHub renders the link as a reference carrying the PR's live title and merge state,
+so the comment cannot contradict the PR page.
 
-- the metadata line (`<!--- STAKK_STACK: ... --->`), which is how stakk finds and updates its own comment
-- the placement preamble — a warning line, and the repo URL
+Added outside the template, not overridable: the metadata line
+(`<!--- STAKK_STACK: ... --->`),
+by which stakk finds its own comment, and the placement preamble (a warning line and the repo URL).
 
 ### Rendering constraints
 
-GitHub renders comments in a proportional font, so a template must not depend on horizontal alignment: no `│` gutter,
-no indentation for structure, and no code fence (links inside a fence are dead).
-Each row of the default template is a **Markdown list item**, and that is functional rather than decorative.
-GitHub expands a bare PR link into a reference showing the PR's live title and merge state only
-when the link sits inside a list item.
-A link in a plain paragraph, a table cell or a blockquote stays a bare `#N`,
-and so does a link alone in its own paragraph.
-A custom template that lays entries out with line breaks instead of a list still works,
-but every entry loses its title and state.
+GitHub renders comments in a proportional font: no `│` gutter, no indentation for structure, and no code fence
+(links inside a fence are dead).
 
-The bullet GitHub draws for each item *is* the node marker,
-which is why the comment carries no `●`/`○`/`◆` glyphs of its own even though `stakk graph` and the TUI do:
-a glyph next to a bullet reads as two markers, and the bullet cannot be turned off
-(GitHub's sanitizer strips inline `style`).
-A glyph *is* allowed before the link inside an item if a custom template wants one.
+**Each row must be a Markdown list item.**
+GitHub expands a bare PR link into a reference with the PR's live title and merge state only inside a list item.
+A link in a paragraph, table cell or blockquote stays a bare `#N` — even alone in its own paragraph.
+A template that uses line breaks instead of a list still works, but every entry loses its title and state.
 
-A template that fails to render fails the submission, and `--dry-run` does not exercise it:
-dry-run returns before the template is read at all.
-What the ordering does guarantee is that a template is read and compiled before the execute phase,
-so a syntax error stops the run before anything is pushed.
-A failure that only appears while rendering surfaces later —
-the branches are pushed and the PRs created or updated first, and the stack comments written after that.
+GitHub's bullet *is* the node marker, which is why the default template has no `●`/`○`/`◆` glyphs:
+the bullet cannot be hidden (inline `style` is stripped), and a glyph next to it reads as two markers.
+A glyph before the link inside the item is fine if you want one.
+
+A template that fails to render fails the submission.
+It is read and compiled before the execute phase, so a syntax error stops the run before anything is pushed;
+a failure that only appears while rendering surfaces after the branches are pushed and the PRs created or updated.
+`--dry-run` does not exercise the template at all.
 
 ## Custom bookmark names
 
-`--bookmark-command` names bookmarks with an external program.
-The command runs through `sh -c` (Unix) or `cmd /C` (Windows),
-receives a JSON description of one segment of commits on stdin, and must print a single bookmark name on stdout.
-
+`--bookmark-command` names bookmarks with an external program: `sh -c` (Unix) or `cmd /C` (Windows),
+a JSON description of one segment on stdin, a single bookmark name on stdout.
 It powers the `[*]` state in the TUI and the `--new-command` selection flag.
-The full JSON schema, with a worked example, is in `stakk submit --help`.
+The JSON schema, with a worked example, is in `stakk submit --help`.


### PR DESCRIPTION
The documentation had grown to explain everything to everyone. Each document is now cut to what its actual reader needs:

- `README.md` (331 → 167 lines): someone deciding whether to use stakk. Leads with what stakk does and that it works with GitHub's native stacked pull requests, which gets its own section. The `Features` list is folded into the intro and *How stacking works*; the `Usage` section (per-subcommand walkthroughs, `stakk completions`, `stakk docs` mechanics) and the `Design` section are gone — `--help` and the docs topics cover them. The sections CLAUDE.md §8 names as touchpoints are kept, shorter.
- `docs/agents.md`: a coding agent. Drops *Reading this later*, the string-comparing `jq` example, and the prose that restated the tables. The `stakk graph` shape is one block instead of a section.
- `docs/auth.md`: someone whose auth failed or who is setting up GHES.
- `docs/config.md`: someone writing a config file. The *Examples* and *The `inherit` field* sections are folded into the precedence list and the annotated TOML block, which stays exhaustive.
- `docs/graph.md`: someone writing a consumer. Reference only.
- `docs/scripting.md`: a programmer. Properties trimmed to what the other topics do not already say; the Python example keeps its logic with shorter docstrings.
- `docs/stability.md`: the contract, with less reasoning around each entry. The note that its own *wording* is unstable while what it describes is not is kept deliberately.
- `docs/template.md`: someone customizing placement or the template.

Doc summaries (the `stakk docs` index) are unchanged. CLAUDE.md's list of README touchpoints gains the new *GitHub native stacks* section.